### PR TITLE
Simplify archive reader progress sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,10 @@ on:
 jobs:
   verify:
     runs-on: macOS-26
-    
+
     strategy:
-        matrix:
-          destination: ['platform=iOS Simulator,OS=26.4,name=iPad Pro 11-inch (M5)']
+      matrix:
+        destination: ['platform=iOS Simulator,OS=26.4,name=iPad Pro 11-inch (M5)']
     steps:
       - uses: actions/checkout@v6
 
@@ -21,9 +21,74 @@ jobs:
         run: swiftlint --strict
 
       - name: Select Xcode version
-        run: sudo xcode-select -switch /Applications/Xcode_26.4.app
-      
+        run: |
+          sudo xcode-select -switch /Applications/Xcode_26.4.app
+          xcodebuild -version
+
+      - name: Install iOS 26.4 platform components
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          sudo xcodebuild -runFirstLaunch
+
+          if xcrun simctl list runtimes | grep -Fq "iOS 26.4"; then
+            echo "iOS 26.4 runtime already installed"
+          else
+            export_path="$RUNNER_TEMP/platforms"
+            mkdir -p "$export_path"
+            if ! xcodebuild -downloadPlatform iOS -buildVersion 26.4 -exportPath "$export_path"; then
+              xcodebuild -downloadPlatform iOS -exportPath "$export_path"
+            fi
+
+            runtime_dmg="$(find "$export_path" -name '*.dmg' -print -quit)"
+            if [[ -z "$runtime_dmg" ]]; then
+              echo "Failed to find downloaded iOS 26.4 runtime DMG"
+              exit 1
+            fi
+
+            sudo xcodebuild -importPlatform "$runtime_dmg"
+          fi
+
+          python3 <<'PY'
+          import json
+          import subprocess
+          import sys
+
+          runtime_name = "iOS 26.4"
+          device_name = "iPad Pro 11-inch (M5)"
+
+          runtimes = json.loads(subprocess.check_output(["xcrun", "simctl", "list", "-j", "runtimes"]))
+          devices = json.loads(subprocess.check_output(["xcrun", "simctl", "list", "-j", "devices", "available"]))
+          device_types = json.loads(subprocess.check_output(["xcrun", "simctl", "list", "-j", "devicetypes"]))
+
+          runtime = next(
+              (runtime for runtime in runtimes["runtimes"] if runtime.get("name") == runtime_name and runtime.get("isAvailable")),
+              None,
+          )
+          if runtime is None:
+              print(f"{runtime_name} runtime is still unavailable after import", file=sys.stderr)
+              sys.exit(1)
+
+          device_type = next(
+              (device_type for device_type in device_types["devicetypes"] if device_type.get("name") == device_name),
+              None,
+          )
+          if device_type is None:
+              print(f"{device_name} device type is unavailable", file=sys.stderr)
+              sys.exit(1)
+
+          existing_devices = devices["devices"].get(runtime["identifier"], [])
+          if any(device.get("name") == device_name for device in existing_devices):
+              print(f"{device_name} already exists for {runtime_name}")
+          else:
+              subprocess.check_call(
+                  ["xcrun", "simctl", "create", device_name, device_type["identifier"], runtime["identifier"]]
+              )
+              print(f"Created {device_name} for {runtime_name}")
+          PY
+
       - name: Build and test
         run: xcodebuild clean test -project LANreader.xcodeproj -scheme LANreader -destination "${destination}" -skipMacroValidation
-        env: 
-         destination: ${{ matrix.destination }}
+        env:
+          destination: ${{ matrix.destination }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     
     strategy:
         matrix:
-          destination: ['platform=iOS Simulator,OS=26.2,name=iPad Pro 11-inch (M5)']
+          destination: ['platform=iOS Simulator,OS=26.4,name=iPad Pro 11-inch (M5)']
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/manual-ipa-release.yml
+++ b/.github/workflows/manual-ipa-release.yml
@@ -19,6 +19,31 @@ jobs:
           sudo xcode-select -s /Applications/Xcode_26.4.app
           xcodebuild -version
 
+      - name: Install iOS 26.4 platform components
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          sudo xcodebuild -runFirstLaunch
+
+          if xcrun simctl list runtimes | grep -Fq "iOS 26.4"; then
+            echo "iOS 26.4 runtime already installed"
+          else
+            export_path="$RUNNER_TEMP/platforms"
+            mkdir -p "$export_path"
+            if ! xcodebuild -downloadPlatform iOS -buildVersion 26.4 -exportPath "$export_path"; then
+              xcodebuild -downloadPlatform iOS -exportPath "$export_path"
+            fi
+
+            runtime_dmg="$(find "$export_path" -name '*.dmg' -print -quit)"
+            if [[ -z "$runtime_dmg" ]]; then
+              echo "Failed to find downloaded iOS 26.4 runtime DMG"
+              exit 1
+            fi
+
+            sudo xcodebuild -importPlatform "$runtime_dmg"
+          fi
+
       - name: Resolve app versions
         id: versions
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Use this file as the source of truth for Codex-style work in this repository.
 - Main app scheme: `LANreader`
 - Secondary scheme: `Action`
 - Test target: `LANreaderTests`
-- CI simulator destination: `platform=iOS Simulator,OS=26.2,name=iPad Pro 11-inch (M5)`
+- CI simulator destination: `platform=iOS Simulator,OS=26.4,name=iPad Pro 11-inch (M5)`
 - CI lint command: `swiftlint --strict`
 - CI test command: `xcodebuild clean test -project LANreader.xcodeproj -scheme LANreader ... -skipMacroValidation`
 - Current active GitHub workflows are `ci.yml` and `manual-ipa-release.yml`.
@@ -60,6 +60,7 @@ Use this file as the source of truth for Codex-style work in this repository.
 - Keep changes aligned with existing TCA and dependency-injection patterns. Do not rewrite features into a different architecture as a drive-by cleanup.
 - Do not replace UIKit-backed collection views with pure SwiftUI `LazyVStack`, `LazyHStack`, or similar containers unless the task explicitly asks for that change and performance has been re-validated.
 - When changing reader, archive grid, or cache-list behavior, inspect the SwiftUI wrapper and the UIKit controller/cell together before deciding where the fix belongs.
+- When implementing or changing `LANreader/Service/LANraragiService.swift`, keep the client behavior and request/response shapes aligned with the upstream LANraragi OpenAPI spec at `https://github.com/Difegue/LANraragi/blob/dev/tools/openapi.yaml`.
 - Prefer narrow fixes. This repo has some legacy naming and release automation debt; do not normalize unrelated names unless the task is explicitly about release tooling or rebranding.
 - If you need a local build, use the scripts in `scripts/`. They use the normal Xcode folders by default and support repo-local cache overrides when needed.
 - Before commit, push, or PR creation, run `./scripts/lint` and verify it passes. Treat lint as a required pre-PR gate.

--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -93,6 +93,8 @@
 		E9E3631F26F471E400C58D01 /* LogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E3631E26F471E400C58D01 /* LogView.swift */; };
 		E9EACA7B2D64517000229508 /* GRDBQuery in Frameworks */ = {isa = PBXBuildFile; productRef = E9EACA7A2D64517000229508 /* GRDBQuery */; };
 		E9F3B0122B01A21C00F60F62 /* CategoryListV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F3B0112B01A21C00F60F62 /* CategoryListV2.swift */; };
+		F1A2B3C42F60000100AAA001 /* ReaderPositioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C72F60000100AAA001 /* ReaderPositioning.swift */; };
+		F1A2B3C52F60000100AAA001 /* ArchiveReaderFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C82F60000100AAA001 /* ArchiveReaderFeatureTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -210,6 +212,8 @@
 		E9DAEC542B07295D00ADC215 /* ArchiveDetailsV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailsV2.swift; sourceTree = "<group>"; };
 		E9E3631E26F471E400C58D01 /* LogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogView.swift; sourceTree = "<group>"; };
 		E9F3B0112B01A21C00F60F62 /* CategoryListV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryListV2.swift; sourceTree = "<group>"; };
+		F1A2B3C72F60000100AAA001 /* ReaderPositioning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPositioning.swift; sourceTree = "<group>"; };
+		F1A2B3C82F60000100AAA001 /* ArchiveReaderFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveReaderFeatureTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -288,6 +292,7 @@
 				E91EE6822CAB78E80046853C /* UIArchiveReader.swift */,
 				E9DAEC542B07295D00ADC215 /* ArchiveDetailsV2.swift */,
 				E9BFA2062AF52C3300DDE107 /* PageImageV2.swift */,
+				F1A2B3C72F60000100AAA001 /* ReaderPositioning.swift */,
 				E90576B529F6BF8700C3CE3F /* WrappingHStack.swift */,
 				E9BFA2042AF51DB500DDE107 /* ArchiveReader.swift */,
 				E9A8612C2BF31534003534FA /* AutomaticPageConfig.swift */,
@@ -412,6 +417,7 @@
 				7DF6FFA8252DC3A4009280A5 /* Test */,
 				7D354CEB24F1FBEE00617F4A /* Resources */,
 				7D354CB624F1316E00617F4A /* LANreaderTests.swift */,
+				F1A2B3C82F60000100AAA001 /* ArchiveReaderFeatureTests.swift */,
 				7D354CB824F1316E00617F4A /* Info.plist */,
 				4BD820A697A4726B7B747BFD /* Service */,
 			);
@@ -725,6 +731,7 @@
 				E9AAC1352CBC8FC600E5E89A /* UIPageCell.swift in Sources */,
 				E9E3631F26F471E400C58D01 /* LogView.swift in Sources */,
 				6DA713301F56AA72BA0B4BE3 /* ServerSettings.swift in Sources */,
+				F1A2B3C42F60000100AAA001 /* ReaderPositioning.swift in Sources */,
 				E9BFA2052AF51DB500DDE107 /* ArchiveReader.swift in Sources */,
 				6DA711FA92BEE61419224BB4 /* LoadingView.swift in Sources */,
 			);
@@ -733,6 +740,7 @@
 			isa = PBXSourcesBuildPhase;
 			files = (
 				7D354CB724F1316E00617F4A /* LANreaderTests.swift in Sources */,
+				F1A2B3C52F60000100AAA001 /* ArchiveReaderFeatureTests.swift in Sources */,
 				4BD82555CE41A0467CCC6411 /* LANraragiServiceTest.swift in Sources */,
 				7DF6FFAA252DC3BB009280A5 /* FileUtils.swift in Sources */,
 			);
@@ -908,7 +916,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreader.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 156;
+				CURRENT_PROJECT_VERSION = 157;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -919,7 +927,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6.3;
+				MARKETING_VERSION = 3.6.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -936,7 +944,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreaderRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 156;
+				CURRENT_PROJECT_VERSION = 157;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -947,7 +955,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6.3;
+				MARKETING_VERSION = 3.6.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1010,7 +1018,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 156;
+				CURRENT_PROJECT_VERSION = 157;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1022,7 +1030,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.6.3;
+				MARKETING_VERSION = 3.6.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1040,7 +1048,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 156;
+				CURRENT_PROJECT_VERSION = 157;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1052,7 +1060,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.6.3;
+				MARKETING_VERSION = 3.6.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/LANreader/Page/ArchiveReader.swift
+++ b/LANreader/Page/ArchiveReader.swift
@@ -583,28 +583,26 @@ struct ArchiveReader: View {
 
     // swiftlint:disable function_body_length
     @MainActor
+    @ViewBuilder
     private func bottomToolbar(
         store: StoreOf<ArchiveReaderFeature>
     ) -> some View {
-        guard !store.pages.isEmpty else {
-            return AnyView(EmptyView())
-        }
+        if !store.pages.isEmpty {
+            let sliderDisplayValue = sliderDraftIndex ?? Double(store.currentPageIndex)
+            let displayIndex = ReaderPositioning.clampedPageIndex(
+                Int(sliderDisplayValue.rounded()),
+                pageCount: store.pages.count
+            )
+            let sliderBinding = Binding(
+                get: {
+                    sliderDisplayValue
+                },
+                set: { newValue in
+                    sliderDraftIndex = newValue
+                }
+            )
 
-        let sliderDisplayValue = sliderDraftIndex ?? Double(store.currentPageIndex)
-        let displayIndex = ReaderPositioning.clampedPageIndex(
-            Int(sliderDisplayValue.rounded()),
-            pageCount: store.pages.count
-        )
-        let sliderBinding = Binding(
-            get: {
-                sliderDisplayValue
-            },
-            set: { newValue in
-                sliderDraftIndex = newValue
-            }
-        )
-
-        return AnyView(VStack {
+            VStack {
             Grid {
                 GridRow {
                     Button(action: {
@@ -666,7 +664,8 @@ struct ArchiveReader: View {
             }
             .padding()
             .background(.thinMaterial)
-        })
+            }
+        }
     }
     // swiftlint:enable function_body_length
 }

--- a/LANreader/Page/ArchiveReader.swift
+++ b/LANreader/Page/ArchiveReader.swift
@@ -101,6 +101,7 @@ import OrderedCollections
     @Dependency(\.lanraragiService) var service
     @Dependency(\.appDatabase) var database
     @Dependency(\.continuousClock) var clock
+    @Dependency(\.uuid) var uuid
 
     public enum CancelId: Sendable {
         case updateProgress
@@ -238,6 +239,7 @@ import OrderedCollections
                 guard !state.pages.isEmpty else { return .none }
                 let clampedIndex = ReaderPositioning.clampedPageIndex(index, pageCount: state.pages.count)
                 state.scrollRequest = ScrollRequest(
+                    id: uuid(),
                     targetPageIndex: clampedIndex,
                     source: source,
                     animated: source != .slider && source != .initialRestore
@@ -254,6 +256,7 @@ import OrderedCollections
                     return .none
                 }
                 state.scrollRequest = ScrollRequest(
+                    id: uuid(),
                     targetPageIndex: targetIndex,
                     source: source,
                     animated: true

--- a/LANreader/Page/ArchiveReader.swift
+++ b/LANreader/Page/ArchiveReader.swift
@@ -21,8 +21,8 @@ import OrderedCollections
         @SharedReader(.appStorage(SettingsKey.doublePageLayout)) var doublePageLayout = false
 
         var currentArchiveId = ""
-        var sliderIndex: Double = 0
-        var jumpIndex: Int? = 0
+        var currentPageIndex = 0
+        var scrollRequest: ScrollRequest?
         var pages: IdentifiedArrayOf<PageFeature.State> = []
         var fromStart = false
         var extracting = false
@@ -32,7 +32,6 @@ import OrderedCollections
         var successMessage = ""
         var showAutoPageConfig = false
         var autoPage = AutomaticPageFeature.State()
-        var autoDate = Date()
         var lastAutoPageIndex: Int?
         var cached = false
         var inCache = false
@@ -51,6 +50,19 @@ import OrderedCollections
             self.fromStart = fromStart
             self.cached = cached
         }
+
+        var resolvedReadDirection: ReadDirection {
+            ReadDirection(rawValue: readDirection) ?? .leftRight
+        }
+
+        var safeCurrentPageIndex: Int {
+            ReaderPositioning.clampedPageIndex(currentPageIndex, pageCount: pages.count)
+        }
+
+        var currentPage: PageFeature.State? {
+            guard !pages.isEmpty else { return nil }
+            return pages[safeCurrentPageIndex]
+        }
     }
 
     public enum Action: Equatable, BindableAction {
@@ -59,18 +71,16 @@ import OrderedCollections
 
         case autoPage(AutomaticPageFeature.Action)
         case showAutoPageConfig
-        case setAutoDate(Date)
         case autoPageTick
         case setLastAutoPageIndex(Int?)
         case page(IdentifiedActionOf<PageFeature>)
         case extractArchive
-        case loadProgress
         case finishExtracting([String])
         case toggleControlUi(Bool?)
-        case setJumpIndex(Int?)
-        case setSliderIndex(Double)
-        case updateProgress(Int)
-        case setIsNew(Bool)
+        case visiblePageChanged(Int)
+        case requestJump(Int, source: ReaderNavigationSource)
+        case navigate(ReaderNavigationDirection, source: ReaderNavigationSource)
+        case scrollRequestHandled(UUID)
         case setThumbnail
         case finishThumbnailLoading
         case setError(String)
@@ -83,14 +93,13 @@ import OrderedCollections
         case loadPreviousArchive
         case loadNextArchive
 
-        public enum Alert: Sendable {
+        public enum Alert: Equatable, Sendable {
             case confirmDelete
         }
     }
 
     @Dependency(\.lanraragiService) var service
     @Dependency(\.appDatabase) var database
-    @Dependency(\.dismiss) var dismiss
     @Dependency(\.continuousClock) var clock
 
     public enum CancelId: Sendable {
@@ -128,10 +137,14 @@ import OrderedCollections
                            $0.pageNumber < $1.pageNumber
                        }
                    state.pages.append(contentsOf: pageState)
-                   state.sliderIndex = 0.0
+                   state.currentPageIndex = ReaderPositioning.defaultStartPageIndex(
+                       pageCount: state.pages.count,
+                       readDirection: state.resolvedReadDirection,
+                       doublePageLayout: state.doublePageLayout
+                   )
                    state.controlUiHidden = true
                    state.extracting = false
-                   return .none
+                   return .send(.requestJump(state.currentPageIndex, source: .initialRestore))
                } else {
                    state.controlUiHidden = true
                    state.extracting = false
@@ -167,22 +180,19 @@ import OrderedCollections
                     }
                     state.pages.append(contentsOf: pageState)
                     guard let currentArchive = state.allArchives[id: state.currentArchiveId] else { return .none }
-                    let progress = currentArchive.wrappedValue.progress > 0 ?
-                    currentArchive.wrappedValue.progress - 1 : 0
-                    let pageIndexToShow = state.fromStart ? 0 : progress
-                    state.sliderIndex = Double(pageIndexToShow)
-                    state.jumpIndex = pageIndexToShow
+                    let pageIndexToShow = ReaderPositioning.initialPageIndex(
+                        progress: currentArchive.wrappedValue.progress,
+                        pageCount: state.pages.count,
+                        fromStart: state.fromStart,
+                        readDirection: state.resolvedReadDirection,
+                        doublePageLayout: state.doublePageLayout
+                    )
+                    state.currentPageIndex = pageIndexToShow
                     state.controlUiHidden = true
                 }
                 state.extracting = false
-                return .none
-            case .loadProgress:
-                guard let currentArchive = state.allArchives[id: state.currentArchiveId] else { return .none }
-                let progress = currentArchive.wrappedValue.progress > 0 ?
-                currentArchive.wrappedValue.progress - 1 : 0
-                state.sliderIndex = Double(progress)
-                state.controlUiHidden = true
-                return .none
+                guard !state.pages.isEmpty else { return .none }
+                return .send(.requestJump(state.currentPageIndex, source: .initialRestore))
             case let .toggleControlUi(show):
                 if let shouldShow = show {
                     state.controlUiHidden = shouldShow
@@ -191,44 +201,75 @@ import OrderedCollections
                 }
                 state.lastAutoPageIndex = nil
                 return .cancel(id: CancelId.autoPage)
-            case let .setJumpIndex(jumpIndex):
-                state.jumpIndex = jumpIndex
-                return .none
-            case let .setSliderIndex(index):
-                state.sliderIndex = index
-                return .none
-            case let .updateProgress(pageNumber):
-                guard let currentArchive = state.allArchives[id: state.currentArchiveId] else { return .none }
+            case let .visiblePageChanged(index):
+                guard !state.pages.isEmpty else { return .none }
+                let clampedIndex = ReaderPositioning.clampedPageIndex(index, pageCount: state.pages.count)
+                guard clampedIndex != state.currentPageIndex else { return .none }
+                state.currentPageIndex = clampedIndex
+                guard let currentArchive = state.allArchives[id: state.currentArchiveId],
+                      let page = state.currentPage else { return .none }
+
+                let pageNumber = page.pageNumber
+                let shouldClearNewFlag = pageNumber > 1 && currentArchive.wrappedValue.isNew
                 currentArchive.withLock {
                     $0.progress = pageNumber
+                    if shouldClearNewFlag {
+                        $0.isNew = false
+                    }
                 }
                 if state.cached {
                     return .none
                 }
-                return .run(priority: .background) { [state] send in
+                return .run(priority: .background) { [state] _ in
                     try await clock.sleep(for: .seconds(0.5))
                     if state.serverProgress {
                         _ = try await service.updateArchiveReadProgress(
                             id: state.currentArchiveId, progress: pageNumber
                         ).value
                     }
-                    if pageNumber > 1 && currentArchive.wrappedValue.isNew {
+                    if shouldClearNewFlag {
                         _ = try await service.clearNewFlag(id: state.currentArchiveId).value
-                        await send(.setIsNew(false))
                     }
                 } catch: { [state] error, _ in
                     logger.error("failed to update archive progress. id=\(state.currentArchiveId) \(error)")
                 }
                 .cancellable(id: CancelId.updateProgress, cancelInFlight: true)
-            case let .setIsNew(isNew):
-                guard let currentArchive = state.allArchives[id: state.currentArchiveId] else { return .none }
-                currentArchive.withLock {
-                    $0.isNew = isNew
+            case let .requestJump(index, source):
+                guard !state.pages.isEmpty else { return .none }
+                let clampedIndex = ReaderPositioning.clampedPageIndex(index, pageCount: state.pages.count)
+                state.scrollRequest = ScrollRequest(
+                    targetPageIndex: clampedIndex,
+                    source: source,
+                    animated: source != .slider && source != .initialRestore
+                )
+                return .none
+            case let .navigate(direction, source):
+                guard let targetIndex = ReaderPositioning.adjacentPageIndex(
+                    from: state.currentPageIndex,
+                    direction: direction,
+                    pageCount: state.pages.count,
+                    readDirection: state.resolvedReadDirection,
+                    doublePageLayout: state.doublePageLayout
+                ) else {
+                    return .none
                 }
+                state.scrollRequest = ScrollRequest(
+                    targetPageIndex: targetIndex,
+                    source: source,
+                    animated: true
+                )
+                return .none
+            case let .scrollRequestHandled(id):
+                guard state.scrollRequest?.id == id else { return .none }
+                state.scrollRequest = nil
                 return .none
             case .setThumbnail:
                 state.settingThumbnail = true
-                let pageNumber = state.pages[state.sliderIndex.int].pageNumber
+                guard let currentPage = state.currentPage else {
+                    state.settingThumbnail = false
+                    return .none
+                }
+                let pageNumber = currentPage.pageNumber
                 return .run { [id = state.currentArchiveId] send in
                     _ = try await service.updateArchiveThumbnail(id: id, page: pageNumber).value
                     guard let thumbnailData = try await service.retrieveArchiveThumbnail(id: id) else {
@@ -286,16 +327,13 @@ import OrderedCollections
                 state.showAutoPageConfig = false
                 state.controlUiHidden = true
                 return .send(.autoPageTick)
-            case let .setAutoDate(date):
-                state.autoDate = date
-                return .none
             case .autoPage(.cancelAutoPage):
                 state.showAutoPageConfig = false
                 return .none
             case .autoPage:
                 return .none
             case .autoPageTick:
-                let idx = state.sliderIndex.int
+                let idx = state.currentPageIndex
                 var canAdvance = true
                 if state.lastAutoPageIndex == idx {
                     canAdvance = false
@@ -323,11 +361,11 @@ import OrderedCollections
 
                 return .run { [idx, canAdvance, interval = state.autoPageInterval] send in
                     if canAdvance {
-                        try? await Task.sleep(for: .seconds(interval))
-                        await send(.setAutoDate(Date()))
+                        try? await clock.sleep(for: .seconds(interval))
+                        await send(.navigate(.next, source: .autoPage))
                         await send(.setLastAutoPageIndex(idx))
                     } else {
-                        try? await Task.sleep(for: .milliseconds(300))
+                        try? await clock.sleep(for: .milliseconds(300))
                     }
                     await send(.autoPageTick)
                 }.cancellable(id: CancelId.autoPage)
@@ -437,8 +475,8 @@ import OrderedCollections
 
     func resetState(state: inout State) {
         state.pages = []
-        state.sliderIndex = 0
-        state.jumpIndex = 0
+        state.currentPageIndex = 0
+        state.scrollRequest = nil
         state.inCache = false
         state.errorMessage = ""
         state.successMessage = ""
@@ -458,6 +496,7 @@ private enum ArchiveReaderError: LocalizedError {
 
 struct ArchiveReader: View {
     @Bindable var store: StoreOf<ArchiveReaderFeature>
+    @State private var sliderDraftIndex: Double?
     let navigationHelper: NavigationHelper?
 
     var body: some View {
@@ -537,6 +576,9 @@ struct ArchiveReader: View {
                 navigationHelper?.pop()
             }
         }
+        .onChange(of: store.currentArchiveId) {
+            sliderDraftIndex = nil
+        }
     }
 
     // swiftlint:disable function_body_length
@@ -544,11 +586,29 @@ struct ArchiveReader: View {
     private func bottomToolbar(
         store: StoreOf<ArchiveReaderFeature>
     ) -> some View {
-        return VStack {
+        guard !store.pages.isEmpty else {
+            return AnyView(EmptyView())
+        }
+
+        let sliderDisplayValue = sliderDraftIndex ?? Double(store.currentPageIndex)
+        let displayIndex = ReaderPositioning.clampedPageIndex(
+            Int(sliderDisplayValue.rounded()),
+            pageCount: store.pages.count
+        )
+        let sliderBinding = Binding(
+            get: {
+                sliderDisplayValue
+            },
+            set: { newValue in
+                sliderDraftIndex = newValue
+            }
+        )
+
+        return AnyView(VStack {
             Grid {
                 GridRow {
                     Button(action: {
-                        let indexString = store.pages[store.sliderIndex.int].id
+                        let indexString = store.pages[store.safeCurrentPageIndex].id
                         store.send(.page(.element(id: indexString, action: .load(true))))
                     }, label: {
                         Image(systemName: "arrow.clockwise")
@@ -561,7 +621,7 @@ struct ArchiveReader: View {
                     }
                     .disabled(store.readDirection == ReadDirection.upDown.rawValue)
                     Text(String(format: "%d/%d",
-                                store.sliderIndex.int + 1,
+                                displayIndex + 1,
                                 store.pages.count))
                     .bold()
                     Button {
@@ -585,12 +645,19 @@ struct ArchiveReader: View {
                 }
                 GridRow {
                     Slider(
-                        value: $store.sliderIndex,
+                        value: sliderBinding,
                         in: 0...Double(store.pages.count <= 1 ? 1 : store.pages.count - 1),
                         step: 1
                     ) { onSlider in
                         if !onSlider {
-                            store.send(.setJumpIndex(store.sliderIndex.int))
+                            let targetIndex = ReaderPositioning.clampedPageIndex(
+                                Int((sliderDraftIndex ?? Double(store.currentPageIndex)).rounded()),
+                                pageCount: store.pages.count
+                            )
+                            store.send(.requestJump(targetIndex, source: .slider))
+                            DispatchQueue.main.async {
+                                sliderDraftIndex = nil
+                            }
                         }
                     }
                     .padding(.horizontal)
@@ -599,7 +666,7 @@ struct ArchiveReader: View {
             }
             .padding()
             .background(.thinMaterial)
-        }
+        })
     }
     // swiftlint:enable function_body_length
 }

--- a/LANreader/Page/ReaderPositioning.swift
+++ b/LANreader/Page/ReaderPositioning.swift
@@ -1,0 +1,187 @@
+import Foundation
+
+public enum ReaderNavigationSource: Equatable, Sendable {
+    case initialRestore
+    case slider
+    case tap
+    case keyboard
+    case autoPage
+}
+
+public enum ReaderNavigationDirection: Equatable, Sendable {
+    case next
+    case previous
+}
+
+public struct ScrollRequest: Equatable, Sendable, Identifiable {
+    public let id: UUID
+    public let targetPageIndex: Int
+    public let source: ReaderNavigationSource
+    public let animated: Bool
+
+    public init(
+        id: UUID = UUID(),
+        targetPageIndex: Int,
+        source: ReaderNavigationSource,
+        animated: Bool
+    ) {
+        self.id = id
+        self.targetPageIndex = targetPageIndex
+        self.source = source
+        self.animated = animated
+    }
+}
+
+enum ReaderPositioning {
+    static func initialPageIndex(
+        progress: Int,
+        pageCount: Int,
+        fromStart: Bool,
+        readDirection: ReadDirection,
+        doublePageLayout: Bool
+    ) -> Int {
+        guard pageCount > 0 else { return 0 }
+        let storedIndex = fromStart ? 0 : max(progress - 1, 0)
+        let clampedIndex = clampedPageIndex(storedIndex, pageCount: pageCount)
+        guard usesTrailingSpreadProgress(
+            readDirection: readDirection,
+            doublePageLayout: doublePageLayout
+        ) else {
+            return clampedIndex
+        }
+        return canonicalPageIndex(
+            forVisibleIndex: clampedIndex,
+            pageCount: pageCount,
+            readDirection: readDirection,
+            doublePageLayout: doublePageLayout
+        )
+    }
+
+    static func defaultStartPageIndex(
+        pageCount: Int,
+        readDirection: ReadDirection,
+        doublePageLayout: Bool
+    ) -> Int {
+        initialPageIndex(
+            progress: 0,
+            pageCount: pageCount,
+            fromStart: true,
+            readDirection: readDirection,
+            doublePageLayout: doublePageLayout
+        )
+    }
+
+    static func clampedPageIndex(_ index: Int, pageCount: Int) -> Int {
+        guard pageCount > 0 else { return 0 }
+        return min(max(index, 0), pageCount - 1)
+    }
+
+    static func canonicalPageIndex(
+        forVisibleIndex visibleIndex: Int,
+        pageCount: Int,
+        readDirection: ReadDirection,
+        doublePageLayout: Bool
+    ) -> Int {
+        let clampedIndex = clampedPageIndex(visibleIndex, pageCount: pageCount)
+        guard usesTrailingSpreadProgress(
+            readDirection: readDirection,
+            doublePageLayout: doublePageLayout
+        ) else {
+            return clampedIndex
+        }
+
+        let spreadStart = clampedIndex.isMultiple(of: 2) ? clampedIndex : clampedIndex - 1
+        return min(pageCount - 1, spreadStart + 1)
+    }
+
+    static func scrollAnchorIndex(
+        forPageIndex pageIndex: Int,
+        pageCount: Int,
+        readDirection: ReadDirection,
+        doublePageLayout: Bool
+    ) -> Int {
+        let clampedIndex = clampedPageIndex(pageIndex, pageCount: pageCount)
+        guard usesTrailingSpreadProgress(
+            readDirection: readDirection,
+            doublePageLayout: doublePageLayout
+        ) else {
+            return clampedIndex
+        }
+
+        let lastIndex = pageCount - 1
+        if clampedIndex == lastIndex, lastIndex.isMultiple(of: 2) {
+            return clampedIndex
+        }
+        return max(0, clampedIndex - 1)
+    }
+
+    static func adjacentPageIndex(
+        from currentPageIndex: Int,
+        direction: ReaderNavigationDirection,
+        pageCount: Int,
+        readDirection: ReadDirection,
+        doublePageLayout: Bool
+    ) -> Int? {
+        guard pageCount > 0 else { return nil }
+        let currentIndex = clampedPageIndex(currentPageIndex, pageCount: pageCount)
+        if usesTrailingSpreadProgress(
+            readDirection: readDirection,
+            doublePageLayout: doublePageLayout
+        ) {
+            let currentAnchor = scrollAnchorIndex(
+                forPageIndex: currentIndex,
+                pageCount: pageCount,
+                readDirection: readDirection,
+                doublePageLayout: doublePageLayout
+            )
+            let targetAnchor: Int
+            switch direction {
+            case .next:
+                targetAnchor = currentAnchor + 2
+            case .previous:
+                targetAnchor = currentAnchor - 2
+            }
+
+            let clampedAnchor = clampedPageIndex(targetAnchor, pageCount: pageCount)
+            guard clampedAnchor != currentAnchor else { return nil }
+            return canonicalPageIndex(
+                forVisibleIndex: clampedAnchor,
+                pageCount: pageCount,
+                readDirection: readDirection,
+                doublePageLayout: doublePageLayout
+            )
+        }
+
+        let targetIndex: Int
+        switch direction {
+        case .next:
+            targetIndex = currentIndex + 1
+        case .previous:
+            targetIndex = currentIndex - 1
+        }
+
+        let clampedTarget = clampedPageIndex(targetIndex, pageCount: pageCount)
+        guard clampedTarget != currentIndex else { return nil }
+        return clampedTarget
+    }
+
+    static func firstVisualPageIndex(
+        pageCount: Int,
+        readDirection: ReadDirection,
+        doublePageLayout: Bool
+    ) -> Int {
+        canonicalPageIndex(
+            forVisibleIndex: 0,
+            pageCount: pageCount,
+            readDirection: readDirection,
+            doublePageLayout: doublePageLayout
+        )
+    }
+
+    private static func usesTrailingSpreadProgress(
+        readDirection: ReadDirection,
+        doublePageLayout: Bool
+    ) -> Bool {
+        readDirection != .upDown && doublePageLayout
+    }
+}

--- a/LANreader/Page/ReaderPositioning.swift
+++ b/LANreader/Page/ReaderPositioning.swift
@@ -76,6 +76,10 @@ enum ReaderPositioning {
         return min(max(index, 0), pageCount - 1)
     }
 
+    /// Returns the canonical page index for a given visible item index.
+    /// In double-page (spread) layout the canonical index is the trailing (right) page of the spread,
+    /// e.g. visible index 0 maps to canonical index 1 for spread [0, 1].
+    /// In single-page or vertical layout the canonical index equals the visible index.
     static func canonicalPageIndex(
         forVisibleIndex visibleIndex: Int,
         pageCount: Int,

--- a/LANreader/Page/UIPageCollection.swift
+++ b/LANreader/Page/UIPageCollection.swift
@@ -1,7 +1,6 @@
 import ComposableArchitecture
 import SwiftUI
 import UIKit
-import Logging
 
 public struct UIPageCollection: UIViewControllerRepresentable {
     let store: StoreOf<ArchiveReaderFeature>
@@ -23,17 +22,10 @@ public struct UIPageCollection: UIViewControllerRepresentable {
 }
 
 class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
-    private let logger = Logger(label: "UIPageCollectionController")
-
     let store: StoreOf<ArchiveReaderFeature>
     var collectionView: UICollectionView!
-    var lastPageIndexPath: IndexPath?
-
     var dataSource: UICollectionViewDiffableDataSource<Section, StoreOf<PageFeature>>!
-    var didInitialJump = false
-
-    private var lastObservedJumpIndex: Int?
-    private var lastObservedAutoDate: Date?
+    private var lastReportedVisiblePageIndex: Int?
 
     // MARK: - Pull Navigation
     private enum PullEdge {
@@ -88,13 +80,9 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
 
         let section = NSCollectionLayoutSection(group: group)
 
-        section.visibleItemsInvalidationHandler = { [weak self] items, _, _ in
+        section.visibleItemsInvalidationHandler = { [weak self] _, _, _ in
             guard let self else { return }
-            if let idx = items.last?.indexPath, self.lastPageIndexPath != idx {
-                self.store.send(.setSliderIndex(Double(idx.row)))
-                store.send(.updateProgress(dataSource.itemIdentifier(for: idx)?.pageNumber ?? 1))
-                self.lastPageIndexPath = items.last?.indexPath
-            }
+            self.reportVisiblePageIfNeeded()
         }
 
         let configuration = UICollectionViewCompositionalLayoutConfiguration()
@@ -154,25 +142,48 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
         }
     }
 
-    private func scrollToPage(at idx: Int) {
+    private var resolvedReadDirection: ReadDirection {
+        ReadDirection(rawValue: store.readDirection) ?? .leftRight
+    }
+
+    private func scrollPosition(for request: ScrollRequest) -> UICollectionView.ScrollPosition {
+        switch request.source {
+        case .initialRestore, .slider:
+            return .centeredHorizontally
+        case .tap, .keyboard, .autoPage:
+            return .left
+        }
+    }
+
+    private func scrollToPage(for request: ScrollRequest) {
         guard collectionView.numberOfSections > 0 else { return }
         let numberOfItems = collectionView.numberOfItems(inSection: 0)
-        guard idx < numberOfItems else { return }
+        guard numberOfItems > 0 else { return }
+
+        let idx = ReaderPositioning.scrollAnchorIndex(
+            forPageIndex: request.targetPageIndex,
+            pageCount: numberOfItems,
+            readDirection: resolvedReadDirection,
+            doublePageLayout: store.doublePageLayout
+        )
 
         let indexPath = IndexPath(row: idx, section: 0)
         if store.readDirection == ReadDirection.upDown.rawValue {
             if let attr = collectionView.layoutAttributesForItem(at: indexPath) {
-                collectionView.scrollRectToVisible(attr.frame, animated: false)
+                collectionView.scrollRectToVisible(attr.frame, animated: request.animated)
             }
         } else {
-            collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: false)
+            collectionView.scrollToItem(at: indexPath, at: scrollPosition(for: request), animated: request.animated)
+        }
+
+        if !request.animated {
+            DispatchQueue.main.async { [weak self] in
+                self?.reportVisiblePageIfNeeded()
+            }
         }
     }
 
     private func setupObserve() {
-        lastObservedJumpIndex = store.jumpIndex
-        lastObservedAutoDate = store.autoDate
-
         observe { [weak self] in
             guard let self else { return }
             guard !store.pages.isEmpty else { return }
@@ -183,30 +194,13 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
             snapshot.appendItems(
                 Array(store.scope(state: \.pages, action: \.page)))
             dataSource.apply(snapshot, animatingDifferences: false)
-            if !didInitialJump, let idx = store.jumpIndex {
-                scrollToPage(at: idx)
-                didInitialJump = true
-                store.send(.setJumpIndex(nil))
-            }
         }
 
         observe { [weak self] in
             guard let self else { return }
-            let jumpIndex = store.jumpIndex
-            defer { lastObservedJumpIndex = jumpIndex }
-
-            guard jumpIndex != lastObservedJumpIndex, let jumpIndex else { return }
-            scrollToPage(at: jumpIndex)
-            store.send(.setJumpIndex(nil))
-        }
-
-        observe { [weak self] in
-            guard let self else { return }
-            let autoDate = self.store.autoDate
-            defer { lastObservedAutoDate = autoDate }
-
-            guard autoDate != lastObservedAutoDate else { return }
-            handleTapAction(action: PageControl.next.rawValue)
+            guard let scrollRequest = store.scrollRequest else { return }
+            scrollToPage(for: scrollRequest)
+            store.send(.scrollRequestHandled(scrollRequest.id))
         }
     }
 
@@ -264,14 +258,53 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
         }
     }
 
+    private func reportVisiblePageIfNeeded() {
+        guard let visibleIndex = currentVisibleItemIndex() else { return }
+        let pageIndex = ReaderPositioning.canonicalPageIndex(
+            forVisibleIndex: visibleIndex,
+            pageCount: store.pages.count,
+            readDirection: resolvedReadDirection,
+            doublePageLayout: store.doublePageLayout
+        )
+
+        guard pageIndex != lastReportedVisiblePageIndex else { return }
+        lastReportedVisiblePageIndex = pageIndex
+        store.send(.visiblePageChanged(pageIndex))
+    }
+
+    private func currentVisibleItemIndex() -> Int? {
+        guard collectionView != nil else { return nil }
+        let visibleRect = CGRect(
+            origin: collectionView.contentOffset,
+            size: collectionView.bounds.size
+        )
+        let visibleAttributes = (
+            collectionView.collectionViewLayout.layoutAttributesForElements(in: visibleRect) ?? []
+        )
+            .filter { $0.representedElementCategory == .cell }
+        guard !visibleAttributes.isEmpty else { return nil }
+
+        if store.readDirection == ReadDirection.upDown.rawValue || store.doublePageLayout {
+            return visibleAttributes.map(\.indexPath.row).max()
+        }
+
+        let viewportCenter = CGPoint(x: visibleRect.midX, y: visibleRect.midY)
+        return visibleAttributes.min { lhs, rhs in
+            distanceSquared(from: lhs.center, to: viewportCenter)
+                < distanceSquared(from: rhs.center, to: viewportCenter)
+        }?.indexPath.row
+    }
+
+    private func distanceSquared(from lhs: CGPoint, to rhs: CGPoint) -> CGFloat {
+        let deltaX = lhs.x - rhs.x
+        let deltaY = lhs.y - rhs.y
+        return (deltaX * deltaX) + (deltaY * deltaY)
+    }
+
     // Returns index path representing the start of the current visual page (accounts for double page layout)
     private func currentVisualPageIndexPath() -> IndexPath? {
-        guard collectionView != nil else { return nil }
-        let visible = collectionView.indexPathsForVisibleItems
-        guard !visible.isEmpty else { return nil }
-        // Use the last (right-most) visible item for consistency with existing slider logic
-        let sorted = visible.sorted()
-        return startOfGroupIndexPath(for: sorted.last!)
+        guard let visibleIndex = currentVisibleItemIndex() else { return nil }
+        return startOfGroupIndexPath(for: IndexPath(row: visibleIndex, section: 0))
     }
 
     // For double page layout treat a pair of items as one visual page; return left item index path
@@ -296,9 +329,9 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
             if let key = press.key {
                 switch key.keyCode {
                 case .keyboardLeftArrow:
-                    handleTapAction(action: store.tapRight)
+                    handleKeyboardAction(action: store.tapRight)
                 case .keyboardRightArrow:
-                    handleTapAction(action: store.tapLeft)
+                    handleKeyboardAction(action: store.tapLeft)
                 default:
                     super.pressesBegan(presses, with: event)
                 }
@@ -335,10 +368,10 @@ extension UIPageCollectionController: UIGestureRecognizerDelegate {
         }
 
         // Handle the tap based on region
-        handleTapInRegion(region, atLocation: locationInView)
+        handleTapInRegion(region)
     }
 
-    private func handleTapInRegion(_ region: TapRegion, atLocation location: CGPoint) {
+    private func handleTapInRegion(_ region: TapRegion) {
         // Handle tap in region but not on any cell
         if store.readDirection != ReadDirection.upDown.rawValue {
             switch region {
@@ -357,19 +390,26 @@ extension UIPageCollectionController: UIGestureRecognizerDelegate {
     private func handleTapAction(action: String) {
         switch action {
         case PageControl.next.rawValue:
-            let row = store.sliderIndex.int + 1
-            guard row < store.pages.count else { break }
-            let indexPath = IndexPath(row: row, section: 0)
-            collectionView.scrollToItem(at: indexPath, at: .left, animated: true)
+            store.send(.navigate(.next, source: .tap))
         case PageControl.previous.rawValue:
-            let row = store.doublePageLayout ? store.sliderIndex.int - 2 : store.sliderIndex.int - 1
-            guard row >= 0 else { break }
-            let indexPath = IndexPath(row: row, section: 0)
-            collectionView.scrollToItem(at: indexPath, at: .left, animated: true)
+            store.send(.navigate(.previous, source: .tap))
         case PageControl.navigation.rawValue:
             store.send(.toggleControlUi(nil))
         default:
             // This should not happen
+            break
+        }
+    }
+
+    private func handleKeyboardAction(action: String) {
+        switch action {
+        case PageControl.next.rawValue:
+            store.send(.navigate(.next, source: .keyboard))
+        case PageControl.previous.rawValue:
+            store.send(.navigate(.previous, source: .keyboard))
+        case PageControl.navigation.rawValue:
+            store.send(.toggleControlUi(nil))
+        default:
             break
         }
     }
@@ -423,16 +463,21 @@ extension UIPageCollectionController {
     }
 
     private func isAtFirstVisualPage() -> Bool {
+        guard !store.pages.isEmpty else { return true }
         if store.readDirection == ReadDirection.upDown.rawValue {
             // For vertical reading rely on scroll position for accuracy; allow small epsilon
             return collectionView.contentOffset.y <= -collectionView.adjustedContentInset.top + 1
-        } else if store.doublePageLayout {
-            return store.sliderIndex.int <= 1
         }
-        return store.sliderIndex.int <= 0
+
+        return store.currentPageIndex <= ReaderPositioning.firstVisualPageIndex(
+            pageCount: store.pages.count,
+            readDirection: resolvedReadDirection,
+            doublePageLayout: store.doublePageLayout
+        )
     }
 
     private func isAtLastVisualPage() -> Bool {
+        guard !store.pages.isEmpty else { return true }
         let lastIndex = store.pages.count - 1
         if store.readDirection == ReadDirection.upDown.rawValue {
             // Check if we've scrolled to (or beyond) bottom
@@ -443,12 +488,9 @@ extension UIPageCollectionController {
                 collectionView.adjustedContentInset.bottom
             )
             return collectionView.contentOffset.y >= maxOffset - 1
-        } else if store.doublePageLayout {
-            // For double page layout treat last pair as last visual page
-            return store.sliderIndex.int >= lastIndex - 1
-        } else {
-            return store.sliderIndex.int >= lastIndex
         }
+
+        return store.currentPageIndex >= lastIndex
     }
 
     private struct ScrollMetrics {
@@ -672,6 +714,9 @@ extension UIPageCollectionController {
         guard scrollView === collectionView else { return }
         guard let metrics = currentScrollMetrics() else { return }
         updatePullState(scroll: metrics)
+        if store.readDirection == ReadDirection.upDown.rawValue {
+            reportVisiblePageIfNeeded()
+        }
     }
 
     func resetCollectionView() {
@@ -680,8 +725,7 @@ extension UIPageCollectionController {
         >()
         dataSource.apply(snapshot, animatingDifferences: false)
         collectionView.setContentOffset(.zero, animated: false)
-        lastPageIndexPath = nil
-        didInitialJump = false
+        lastReportedVisiblePageIndex = nil
     }
 
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
@@ -703,6 +747,19 @@ extension UIPageCollectionController {
         }
 
         endPullInteraction()
+        if !decelerate {
+            reportVisiblePageIfNeeded()
+        }
+    }
+
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        guard scrollView === collectionView else { return }
+        reportVisiblePageIfNeeded()
+    }
+
+    func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+        guard scrollView === collectionView else { return }
+        reportVisiblePageIfNeeded()
     }
 }
 

--- a/LANreader/Page/UIPageCollection.swift
+++ b/LANreader/Page/UIPageCollection.swift
@@ -4,15 +4,12 @@ import UIKit
 
 public struct UIPageCollection: UIViewControllerRepresentable {
     let store: StoreOf<ArchiveReaderFeature>
-
     public init(store: StoreOf<ArchiveReaderFeature>) {
         self.store = store
     }
-
     public func makeUIViewController(context: Context) -> UIViewController {
         return UIPageCollectionController(store: store)
     }
-
     public func updateUIViewController(
         _ uiViewController: UIViewController,
         context: Context
@@ -145,7 +142,6 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
     private var resolvedReadDirection: ReadDirection {
         ReadDirection(rawValue: store.readDirection) ?? .leftRight
     }
-
     private func scrollPosition(for request: ScrollRequest) -> UICollectionView.ScrollPosition {
         switch request.source {
         case .initialRestore, .slider:
@@ -155,34 +151,39 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
         }
     }
 
-    private func scrollToPage(for request: ScrollRequest) {
-        guard collectionView.numberOfSections > 0 else { return }
+    @discardableResult
+    private func scrollToPage(for request: ScrollRequest) -> Bool {
+        guard collectionView.numberOfSections > 0 else { return false }
         let numberOfItems = collectionView.numberOfItems(inSection: 0)
-        guard numberOfItems > 0 else { return }
-
+        guard numberOfItems > 0 else { return false }
         let idx = ReaderPositioning.scrollAnchorIndex(
             forPageIndex: request.targetPageIndex,
             pageCount: numberOfItems,
             readDirection: resolvedReadDirection,
             doublePageLayout: store.doublePageLayout
         )
-
         let indexPath = IndexPath(row: idx, section: 0)
         if store.readDirection == ReadDirection.upDown.rawValue {
-            if let attr = collectionView.layoutAttributesForItem(at: indexPath) {
-                collectionView.scrollRectToVisible(attr.frame, animated: request.animated)
+            collectionView.layoutIfNeeded()
+            guard let attr = collectionView.layoutAttributesForItem(at: indexPath) else {
+                return false
             }
+            collectionView.scrollRectToVisible(attr.frame, animated: request.animated)
         } else {
             collectionView.scrollToItem(at: indexPath, at: scrollPosition(for: request), animated: request.animated)
         }
-
         if !request.animated {
             DispatchQueue.main.async { [weak self] in
                 self?.reportVisiblePageIfNeeded()
             }
         }
+        return true
     }
-
+    private func consumePendingScrollRequestIfPossible() {
+        guard let scrollRequest = store.scrollRequest else { return }
+        guard scrollToPage(for: scrollRequest) else { return }
+        store.send(.scrollRequestHandled(scrollRequest.id))
+    }
     private func setupObserve() {
         observe { [weak self] in
             guard let self else { return }
@@ -193,17 +194,16 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
             snapshot.appendSections([.main])
             snapshot.appendItems(
                 Array(store.scope(state: \.pages, action: \.page)))
-            dataSource.apply(snapshot, animatingDifferences: false)
+            dataSource.apply(snapshot, animatingDifferences: false) { [weak self] in
+                self?.consumePendingScrollRequestIfPossible()
+            }
         }
-
         observe { [weak self] in
             guard let self else { return }
-            guard let scrollRequest = store.scrollRequest else { return }
-            scrollToPage(for: scrollRequest)
-            store.send(.scrollRequestHandled(scrollRequest.id))
+            guard store.scrollRequest != nil else { return }
+            consumePendingScrollRequestIfPossible()
         }
     }
-
     private func setupGesture() {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
         tapGesture.numberOfTapsRequired = 1
@@ -256,6 +256,7 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
             resnap(to: currentVisualPageIndexPath())
             pendingResnap = false
         }
+        consumePendingScrollRequestIfPossible()
     }
 
     private func reportVisiblePageIfNeeded() {

--- a/LANreader/Page/UIPageCollection.swift
+++ b/LANreader/Page/UIPageCollection.swift
@@ -151,7 +151,6 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
         }
     }
 
-    @discardableResult
     private func scrollToPage(for request: ScrollRequest) -> Bool {
         guard collectionView.numberOfSections > 0 else { return false }
         let numberOfItems = collectionView.numberOfItems(inSection: 0)

--- a/LANreaderTests/ArchiveReaderFeatureTests.swift
+++ b/LANreaderTests/ArchiveReaderFeatureTests.swift
@@ -293,9 +293,12 @@ final class ArchiveReaderFeatureTests: XCTestCase {
     @MainActor
     func testVisiblePageChangedUpdatesProgressAndClearsNewFlag() async {
         configureReaderDefaults()
+        let clock = TestClock()
         var initialState = makeState(progress: 0, cached: true, isNew: true)
         initialState.pages = makePageStates(count: 3)
-        let store = makeTestStore(initialState: initialState)
+        let store = makeTestStore(initialState: initialState) {
+            $0.continuousClock = clock
+        }
 
         await store.send(.visiblePageChanged(1)) {
             $0.currentPageIndex = 1
@@ -391,13 +394,12 @@ final class ArchiveReaderFeatureTests: XCTestCase {
         let store = Store(initialState: initialState) {
             ArchiveReaderFeature()
         }
-        let viewStore = ViewStore(store, observe: { $0 })
         let controller = UIPageCollectionController(store: store)
 
         controller.loadViewIfNeeded()
         await Task.yield()
 
-        XCTAssertNotNil(viewStore.scrollRequest)
+        XCTAssertNotNil(store.scrollRequest)
     }
 
     @MainActor
@@ -410,14 +412,13 @@ final class ArchiveReaderFeatureTests: XCTestCase {
         let store = Store(initialState: initialState) {
             ArchiveReaderFeature()
         }
-        let viewStore = ViewStore(store, observe: { $0 })
         let controller = UIPageCollectionController(store: store)
 
         controller.loadViewIfNeeded()
         await Task.yield()
         await Task.yield()
 
-        XCTAssertNil(viewStore.scrollRequest)
+        XCTAssertNil(store.scrollRequest)
     }
 
     @MainActor
@@ -452,7 +453,7 @@ final class ArchiveReaderFeatureTests: XCTestCase {
         }
     }
 
-    func testLoadNextArchiveResetsStateBeforeLoading() {
+    func testResetStateClearsTransientReaderState() {
         configureReaderDefaults()
         var state = makeState(
             archiveId: "one",
@@ -469,9 +470,8 @@ final class ArchiveReaderFeatureTests: XCTestCase {
         state.errorMessage = "error"
         state.successMessage = "success"
 
-        _ = ArchiveReaderFeature().reduce(into: &state, action: .loadNextArchive)
+        ArchiveReaderFeature().resetState(state: &state)
 
-        XCTAssertEqual(state.currentArchiveId, "two")
         XCTAssertTrue(state.pages.isEmpty)
         XCTAssertEqual(state.currentPageIndex, 0)
         XCTAssertNil(state.scrollRequest)
@@ -534,7 +534,7 @@ private func makeState(
     autoPageInterval: Double = 5
 ) -> ArchiveReaderFeature.State {
     let archives = allArchives ?? [makeArchive(id: archiveId, progress: progress, isNew: isNew)]
-    var state = ArchiveReaderFeature.State(
+    let state = ArchiveReaderFeature.State(
         currentArchiveId: archiveId,
         allArchives: archives.map { Shared(value: $0) },
         fromStart: fromStart,

--- a/LANreaderTests/ArchiveReaderFeatureTests.swift
+++ b/LANreaderTests/ArchiveReaderFeatureTests.swift
@@ -208,72 +208,86 @@ final class ArchiveReaderFeatureTests: XCTestCase {
     @MainActor
     func testFinishExtractingVerticalModeIgnoresDoublePageLayout() async {
         configureReaderDefaults(readDirection: .upDown, doublePageLayout: true)
-        let store = TestStore(
+        let store = makeTestStore(
             initialState: makeState(
                 progress: 3,
                 readDirection: .upDown,
                 doublePageLayout: true
             )
-        ) {
-            ArchiveReaderFeature()
+        )
+
+        await store.send(.finishExtracting(makeExtractedPages(count: 5))) {
+            $0.pages = makePageStates(count: 5)
+            $0.currentPageIndex = 2
+            $0.controlUiHidden = true
         }
-        store.exhaustivity = .off
-
-        await store.send(.finishExtracting(makeExtractedPages(count: 5)))
-        // Vertical mode should use simple index (progress 3 → index 2), ignoring double-page
-        XCTAssertEqual(store.state.currentPageIndex, 2)
-
-        await store.receive(.requestJump(2, source: .initialRestore))
-        XCTAssertEqual(store.state.scrollRequest?.targetPageIndex, 2)
+        await store.receive(.requestJump(2, source: .initialRestore)) {
+            $0.scrollRequest = makeScrollRequest(
+                id: 0,
+                targetPageIndex: 2,
+                source: .initialRestore,
+                animated: false
+            )
+        }
     }
 
     @MainActor
     func testFinishExtractingRestoresSavedProgressAndQueuesInitialScroll() async {
         configureReaderDefaults()
-        let store = TestStore(initialState: makeState(progress: 3)) {
-            ArchiveReaderFeature()
+        let store = makeTestStore(initialState: makeState(progress: 3))
+
+        await store.send(.finishExtracting(makeExtractedPages(count: 5))) {
+            $0.pages = makePageStates(count: 5)
+            $0.currentPageIndex = 2
+            $0.controlUiHidden = true
         }
-        store.exhaustivity = .off
-
-        await store.send(.finishExtracting(makeExtractedPages(count: 5)))
-        XCTAssertEqual(store.state.pages.count, 5)
-        XCTAssertEqual(store.state.currentPageIndex, 2)
-        XCTAssertTrue(store.state.controlUiHidden)
-
-        await store.receive(.requestJump(2, source: .initialRestore))
-        XCTAssertEqual(store.state.scrollRequest?.targetPageIndex, 2)
-        XCTAssertEqual(store.state.scrollRequest?.source, .initialRestore)
-        XCTAssertEqual(store.state.scrollRequest?.animated, false)
+        await store.receive(.requestJump(2, source: .initialRestore)) {
+            $0.scrollRequest = makeScrollRequest(
+                id: 0,
+                targetPageIndex: 2,
+                source: .initialRestore,
+                animated: false
+            )
+        }
     }
 
     @MainActor
     func testFinishExtractingFromStartStartsAtFirstPage() async {
         configureReaderDefaults()
-        let store = TestStore(initialState: makeState(progress: 4, fromStart: true)) {
-            ArchiveReaderFeature()
+        let store = makeTestStore(initialState: makeState(progress: 4, fromStart: true))
+
+        await store.send(.finishExtracting(makeExtractedPages(count: 5))) {
+            $0.pages = makePageStates(count: 5)
+            $0.controlUiHidden = true
         }
-        store.exhaustivity = .off
-
-        await store.send(.finishExtracting(makeExtractedPages(count: 5)))
-        XCTAssertEqual(store.state.currentPageIndex, 0)
-
-        await store.receive(.requestJump(0, source: .initialRestore))
-        XCTAssertEqual(store.state.scrollRequest?.targetPageIndex, 0)
+        await store.receive(.requestJump(0, source: .initialRestore)) {
+            $0.scrollRequest = makeScrollRequest(
+                id: 0,
+                targetPageIndex: 0,
+                source: .initialRestore,
+                animated: false
+            )
+        }
     }
 
     @MainActor
     func testFinishExtractingClampsOutOfRangeProgress() async {
         configureReaderDefaults()
-        let store = TestStore(initialState: makeState(progress: 99)) {
-            ArchiveReaderFeature()
+        let store = makeTestStore(initialState: makeState(progress: 99))
+
+        await store.send(.finishExtracting(makeExtractedPages(count: 4))) {
+            $0.pages = makePageStates(count: 4)
+            $0.currentPageIndex = 3
+            $0.controlUiHidden = true
         }
-        store.exhaustivity = .off
-
-        await store.send(.finishExtracting(makeExtractedPages(count: 4)))
-        XCTAssertEqual(store.state.currentPageIndex, 3)
-
-        await store.receive(.requestJump(3, source: .initialRestore))
-        XCTAssertEqual(store.state.scrollRequest?.targetPageIndex, 3)
+        await store.receive(.requestJump(3, source: .initialRestore)) {
+            $0.scrollRequest = makeScrollRequest(
+                id: 0,
+                targetPageIndex: 3,
+                source: .initialRestore,
+                animated: false
+            )
+        }
     }
 
     @MainActor
@@ -281,15 +295,15 @@ final class ArchiveReaderFeatureTests: XCTestCase {
         configureReaderDefaults()
         var initialState = makeState(progress: 0, cached: true, isNew: true)
         initialState.pages = makePageStates(count: 3)
-        let store = TestStore(initialState: initialState) {
-            ArchiveReaderFeature()
-        }
-        store.exhaustivity = .off
+        let store = makeTestStore(initialState: initialState)
 
-        await store.send(.visiblePageChanged(1))
-        XCTAssertEqual(store.state.currentPageIndex, 1)
-        XCTAssertEqual(store.state.allArchives[id: "archive"]?.wrappedValue.progress, 2)
-        XCTAssertEqual(store.state.allArchives[id: "archive"]?.wrappedValue.isNew, false)
+        await store.send(.visiblePageChanged(1)) {
+            $0.currentPageIndex = 1
+            $0.allArchives[id: "archive"]?.withLock {
+                $0.progress = 2
+                $0.isNew = false
+            }
+        }
     }
 
     @MainActor
@@ -302,15 +316,16 @@ final class ArchiveReaderFeatureTests: XCTestCase {
         )
         initialState.pages = makePageStates(count: 5)
         initialState.currentPageIndex = 1
-        let store = TestStore(initialState: initialState) {
-            ArchiveReaderFeature()
-        }
-        store.exhaustivity = .off
+        let store = makeTestStore(initialState: initialState)
 
-        await store.send(.navigate(.next, source: .tap))
-        XCTAssertEqual(store.state.scrollRequest?.targetPageIndex, 3)
-        XCTAssertEqual(store.state.scrollRequest?.source, .tap)
-        XCTAssertEqual(store.state.scrollRequest?.animated, true)
+        await store.send(.navigate(.next, source: .tap)) {
+            $0.scrollRequest = makeScrollRequest(
+                id: 0,
+                targetPageIndex: 3,
+                source: .tap,
+                animated: true
+            )
+        }
     }
 
     @MainActor
@@ -326,38 +341,45 @@ final class ArchiveReaderFeatureTests: XCTestCase {
         )
         initialState.pages = makePageStates(count: 5)
         initialState.currentPageIndex = 4
-        let store = TestStore(initialState: initialState) {
-            ArchiveReaderFeature()
-        }
-        store.exhaustivity = .off
+        let store = makeTestStore(initialState: initialState)
 
-        await store.send(.navigate(.previous, source: .keyboard))
-        XCTAssertEqual(store.state.scrollRequest?.targetPageIndex, 3)
-        XCTAssertEqual(store.state.scrollRequest?.source, .keyboard)
+        await store.send(.navigate(.previous, source: .keyboard)) {
+            $0.scrollRequest = makeScrollRequest(
+                id: 0,
+                targetPageIndex: 3,
+                source: .keyboard,
+                animated: true
+            )
+        }
     }
 
     @MainActor
-    func testRequestJumpToSamePageTwiceCreatesFreshScrollRequest() async throws {
+    func testRequestJumpToSamePageTwiceCreatesFreshScrollRequest() async {
         configureReaderDefaults()
         var initialState = makeState(progress: 2)
         initialState.pages = makePageStates(count: 4)
         initialState.currentPageIndex = 1
-        let store = TestStore(initialState: initialState) {
-            ArchiveReaderFeature()
+        let store = makeTestStore(initialState: initialState)
+
+        await store.send(.requestJump(1, source: .slider)) {
+            $0.scrollRequest = makeScrollRequest(
+                id: 0,
+                targetPageIndex: 1,
+                source: .slider,
+                animated: false
+            )
         }
-        store.exhaustivity = .off
-
-        await store.send(.requestJump(1, source: .slider))
-        let firstRequestId = try XCTUnwrap(store.state.scrollRequest?.id)
-
-        await store.send(.scrollRequestHandled(firstRequestId))
-        XCTAssertNil(store.state.scrollRequest)
-
-        await store.send(.requestJump(1, source: .slider))
-        let secondRequestId = try XCTUnwrap(store.state.scrollRequest?.id)
-
-        XCTAssertNotEqual(firstRequestId, secondRequestId)
-        XCTAssertEqual(store.state.scrollRequest?.targetPageIndex, 1)
+        await store.send(.scrollRequestHandled(incrementingUUID(0))) {
+            $0.scrollRequest = nil
+        }
+        await store.send(.requestJump(1, source: .slider)) {
+            $0.scrollRequest = makeScrollRequest(
+                id: 1,
+                targetPageIndex: 1,
+                source: .slider,
+                animated: false
+            )
+        }
     }
 
     @MainActor
@@ -406,22 +428,28 @@ final class ArchiveReaderFeatureTests: XCTestCase {
         initialState.pages = makePageStates(count: 3)
         initialState.currentPageIndex = 1
         initialState.pages[1].imageLoaded = true
-        let store = TestStore(initialState: initialState) {
-            ArchiveReaderFeature()
-        } withDependencies: {
+        let store = makeTestStore(initialState: initialState) {
             $0.continuousClock = clock
         }
-        store.exhaustivity = .off
 
         await store.send(.autoPageTick)
         await clock.advance(by: .seconds(1))
 
-        await store.receive(.navigate(.next, source: .autoPage))
-        XCTAssertEqual(store.state.scrollRequest?.targetPageIndex, 2)
-
-        await store.receive(.setLastAutoPageIndex(1))
+        await store.receive(.navigate(.next, source: .autoPage)) {
+            $0.scrollRequest = makeScrollRequest(
+                id: 0,
+                targetPageIndex: 2,
+                source: .autoPage,
+                animated: true
+            )
+        }
+        await store.receive(.setLastAutoPageIndex(1)) {
+            $0.lastAutoPageIndex = 1
+        }
         await store.receive(.autoPageTick)
-        await store.send(.toggleControlUi(false))
+        await store.send(.toggleControlUi(false)) {
+            $0.lastAutoPageIndex = nil
+        }
     }
 
     func testLoadNextArchiveResetsStateBeforeLoading() {
@@ -451,75 +479,105 @@ final class ArchiveReaderFeatureTests: XCTestCase {
         XCTAssertEqual(state.errorMessage, "")
         XCTAssertEqual(state.successMessage, "")
     }
+}
 
-    private func configureReaderDefaults(
-        readDirection: ReadDirection = .leftRight,
-        doublePageLayout: Bool = false,
-        autoPageInterval: Double = 5
-    ) {
-        UserDefaults.standard.set(readDirection.rawValue, forKey: SettingsKey.readDirection)
-        UserDefaults.standard.set(doublePageLayout, forKey: SettingsKey.doublePageLayout)
-        UserDefaults.standard.set(autoPageInterval, forKey: SettingsKey.autoPageInterval)
+private func configureReaderDefaults(
+    readDirection: ReadDirection = .leftRight,
+    doublePageLayout: Bool = false,
+    autoPageInterval: Double = 5
+) {
+    UserDefaults.standard.set(readDirection.rawValue, forKey: SettingsKey.readDirection)
+    UserDefaults.standard.set(doublePageLayout, forKey: SettingsKey.doublePageLayout)
+    UserDefaults.standard.set(autoPageInterval, forKey: SettingsKey.autoPageInterval)
+}
+
+@MainActor
+private func makeTestStore(
+    initialState: ArchiveReaderFeature.State,
+    configureDependencies: ((inout DependencyValues) -> Void)? = nil
+) -> TestStoreOf<ArchiveReaderFeature> {
+    TestStore(initialState: initialState) {
+        ArchiveReaderFeature()
+    } withDependencies: {
+        $0.uuid = .incrementing
+        configureDependencies?(&$0)
     }
+}
 
-    private func makeState(
-        archiveId: String = "archive",
-        progress: Int = 0,
-        fromStart: Bool = false,
-        cached: Bool = false,
-        isNew: Bool = false,
-        allArchives: [ArchiveItem]? = nil,
-        readDirection: ReadDirection = .leftRight,
-        doublePageLayout: Bool = false,
-        autoPageInterval: Double = 5
-    ) -> ArchiveReaderFeature.State {
-        let archives = allArchives ?? [makeArchive(id: archiveId, progress: progress, isNew: isNew)]
-        var state = ArchiveReaderFeature.State(
-            currentArchiveId: archiveId,
-            allArchives: archives.map { Shared(value: $0) },
-            fromStart: fromStart,
-            cached: cached
-        )
-        state.$readDirection = SharedReader(value: readDirection.rawValue)
-        state.$doublePageLayout = SharedReader(value: doublePageLayout)
-        state.$autoPageInterval = SharedReader(value: autoPageInterval)
-        return state
-    }
+private func makeScrollRequest(
+    id: Int,
+    targetPageIndex: Int,
+    source: ReaderNavigationSource,
+    animated: Bool
+) -> ScrollRequest {
+    ScrollRequest(
+        id: incrementingUUID(id),
+        targetPageIndex: targetPageIndex,
+        source: source,
+        animated: animated
+    )
+}
 
-    private func makeArchive(
-        id: String = "archive",
-        progress: Int = 0,
-        isNew: Bool = false
-    ) -> ArchiveItem {
-        ArchiveItem(
-            id: id,
-            name: "Archive \(id)",
-            extension: "zip",
-            tags: "",
-            isNew: isNew,
-            progress: progress,
-            pagecount: 10,
-            dateAdded: nil
-        )
-    }
+private func incrementingUUID(_ value: Int) -> UUID {
+    UUID(uuidString: String(format: "00000000-0000-0000-0000-%012d", value))!
+}
 
-    private func makeExtractedPages(count: Int) -> [String] {
-        (1...count).map { "p\($0)" }
-    }
+private func makeState(
+    archiveId: String = "archive",
+    progress: Int = 0,
+    fromStart: Bool = false,
+    cached: Bool = false,
+    isNew: Bool = false,
+    allArchives: [ArchiveItem]? = nil,
+    readDirection: ReadDirection = .leftRight,
+    doublePageLayout: Bool = false,
+    autoPageInterval: Double = 5
+) -> ArchiveReaderFeature.State {
+    let archives = allArchives ?? [makeArchive(id: archiveId, progress: progress, isNew: isNew)]
+    var state = ArchiveReaderFeature.State(
+        currentArchiveId: archiveId,
+        allArchives: archives.map { Shared(value: $0) },
+        fromStart: fromStart,
+        cached: cached
+    )
+    state.$readDirection = SharedReader(value: readDirection.rawValue)
+    state.$doublePageLayout = SharedReader(value: doublePageLayout)
+    state.$autoPageInterval = SharedReader(value: autoPageInterval)
+    return state
+}
 
-    private func makePageStates(
-        count: Int,
-        archiveId: String = "archive"
-    ) -> IdentifiedArrayOf<PageFeature.State> {
-        IdentifiedArray(
-            uniqueElements: (1...count).map {
-                PageFeature.State(
-                    archiveId: archiveId,
-                    pageId: "\($0)",
-                    pageNumber: $0
-                )
-            }
-        )
-    }
+private func makeArchive(
+    id: String = "archive",
+    progress: Int = 0,
+    isNew: Bool = false
+) -> ArchiveItem {
+    ArchiveItem(
+        id: id,
+        name: "Archive \(id)",
+        extension: "zip",
+        tags: "",
+        isNew: isNew,
+        progress: progress,
+        pagecount: 10,
+        dateAdded: nil
+    )
+}
 
+private func makeExtractedPages(count: Int) -> [String] {
+    (1...count).map { "p\($0)" }
+}
+
+private func makePageStates(
+    count: Int,
+    archiveId: String = "archive"
+) -> IdentifiedArrayOf<PageFeature.State> {
+    IdentifiedArray(
+        uniqueElements: (1...count).map {
+            PageFeature.State(
+                archiveId: archiveId,
+                pageId: "\($0)",
+                pageNumber: $0
+            )
+        }
+    )
 }

--- a/LANreaderTests/ArchiveReaderFeatureTests.swift
+++ b/LANreaderTests/ArchiveReaderFeatureTests.swift
@@ -132,6 +132,101 @@ final class ArchiveReaderFeatureTests: XCTestCase {
         )
     }
 
+    func testReaderPositioningVerticalModeMath() {
+        // In vertical (upDown) mode double-page layout has no effect on positioning math
+        XCTAssertEqual(
+            ReaderPositioning.initialPageIndex(
+                progress: 3,
+                pageCount: 5,
+                fromStart: false,
+                readDirection: .upDown,
+                doublePageLayout: false
+            ),
+            2
+        )
+        XCTAssertEqual(
+            ReaderPositioning.canonicalPageIndex(
+                forVisibleIndex: 2,
+                pageCount: 5,
+                readDirection: .upDown,
+                doublePageLayout: true
+            ),
+            2
+        )
+        XCTAssertEqual(
+            ReaderPositioning.scrollAnchorIndex(
+                forPageIndex: 3,
+                pageCount: 5,
+                readDirection: .upDown,
+                doublePageLayout: true
+            ),
+            3
+        )
+    }
+
+    func testReaderPositioningVerticalModeAdjacentMath() {
+        XCTAssertEqual(
+            ReaderPositioning.adjacentPageIndex(
+                from: 2,
+                direction: .next,
+                pageCount: 5,
+                readDirection: .upDown,
+                doublePageLayout: true
+            ),
+            3
+        )
+        XCTAssertEqual(
+            ReaderPositioning.adjacentPageIndex(
+                from: 2,
+                direction: .previous,
+                pageCount: 5,
+                readDirection: .upDown,
+                doublePageLayout: true
+            ),
+            1
+        )
+        XCTAssertNil(
+            ReaderPositioning.adjacentPageIndex(
+                from: 0,
+                direction: .previous,
+                pageCount: 5,
+                readDirection: .upDown,
+                doublePageLayout: false
+            )
+        )
+        XCTAssertNil(
+            ReaderPositioning.adjacentPageIndex(
+                from: 4,
+                direction: .next,
+                pageCount: 5,
+                readDirection: .upDown,
+                doublePageLayout: false
+            )
+        )
+    }
+
+    @MainActor
+    func testFinishExtractingVerticalModeIgnoresDoublePageLayout() async {
+        configureReaderDefaults(readDirection: .upDown, doublePageLayout: true)
+        let store = TestStore(
+            initialState: makeState(
+                progress: 3,
+                readDirection: .upDown,
+                doublePageLayout: true
+            )
+        ) {
+            ArchiveReaderFeature()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.finishExtracting(makeExtractedPages(count: 5)))
+        // Vertical mode should use simple index (progress 3 → index 2), ignoring double-page
+        XCTAssertEqual(store.state.currentPageIndex, 2)
+
+        await store.receive(.requestJump(2, source: .initialRestore))
+        XCTAssertEqual(store.state.scrollRequest?.targetPageIndex, 2)
+    }
+
     @MainActor
     func testFinishExtractingRestoresSavedProgressAndQueuesInitialScroll() async {
         configureReaderDefaults()

--- a/LANreaderTests/ArchiveReaderFeatureTests.swift
+++ b/LANreaderTests/ArchiveReaderFeatureTests.swift
@@ -1,0 +1,392 @@
+import XCTest
+import ComposableArchitecture
+@testable import LANreader
+
+final class ArchiveReaderFeatureTests: XCTestCase {
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: SettingsKey.readDirection)
+        UserDefaults.standard.removeObject(forKey: SettingsKey.doublePageLayout)
+        UserDefaults.standard.removeObject(forKey: SettingsKey.autoPageInterval)
+        super.tearDown()
+    }
+
+    func testReaderPositioningSinglePageMath() {
+        XCTAssertEqual(
+            ReaderPositioning.initialPageIndex(
+                progress: 3,
+                pageCount: 5,
+                fromStart: false,
+                readDirection: .leftRight,
+                doublePageLayout: false
+            ),
+            2
+        )
+        XCTAssertEqual(
+            ReaderPositioning.canonicalPageIndex(
+                forVisibleIndex: 2,
+                pageCount: 5,
+                readDirection: .upDown,
+                doublePageLayout: false
+            ),
+            2
+        )
+        XCTAssertEqual(
+            ReaderPositioning.scrollAnchorIndex(
+                forPageIndex: 2,
+                pageCount: 5,
+                readDirection: .leftRight,
+                doublePageLayout: false
+            ),
+            2
+        )
+        XCTAssertEqual(
+            ReaderPositioning.adjacentPageIndex(
+                from: 2,
+                direction: .next,
+                pageCount: 5,
+                readDirection: .upDown,
+                doublePageLayout: false
+            ),
+            3
+        )
+        XCTAssertEqual(
+            ReaderPositioning.adjacentPageIndex(
+                from: 2,
+                direction: .previous,
+                pageCount: 5,
+                readDirection: .leftRight,
+                doublePageLayout: false
+            ),
+            1
+        )
+    }
+
+    func testReaderPositioningDoublePageCanonicalAndAnchorMath() {
+        XCTAssertEqual(
+            ReaderPositioning.canonicalPageIndex(
+                forVisibleIndex: 0,
+                pageCount: 5,
+                readDirection: .leftRight,
+                doublePageLayout: true
+            ),
+            1
+        )
+        XCTAssertEqual(
+            ReaderPositioning.canonicalPageIndex(
+                forVisibleIndex: 2,
+                pageCount: 5,
+                readDirection: .rightLeft,
+                doublePageLayout: true
+            ),
+            3
+        )
+        XCTAssertEqual(
+            ReaderPositioning.scrollAnchorIndex(
+                forPageIndex: 1,
+                pageCount: 5,
+                readDirection: .leftRight,
+                doublePageLayout: true
+            ),
+            0
+        )
+        XCTAssertEqual(
+            ReaderPositioning.scrollAnchorIndex(
+                forPageIndex: 4,
+                pageCount: 5,
+                readDirection: .rightLeft,
+                doublePageLayout: true
+            ),
+            4
+        )
+    }
+
+    func testReaderPositioningDoublePageAdjacentMath() {
+        XCTAssertEqual(
+            ReaderPositioning.adjacentPageIndex(
+                from: 1,
+                direction: .next,
+                pageCount: 5,
+                readDirection: .leftRight,
+                doublePageLayout: true
+            ),
+            3
+        )
+        XCTAssertEqual(
+            ReaderPositioning.adjacentPageIndex(
+                from: 4,
+                direction: .previous,
+                pageCount: 5,
+                readDirection: .rightLeft,
+                doublePageLayout: true
+            ),
+            3
+        )
+        XCTAssertNil(
+            ReaderPositioning.adjacentPageIndex(
+                from: 1,
+                direction: .previous,
+                pageCount: 5,
+                readDirection: .leftRight,
+                doublePageLayout: true
+            )
+        )
+    }
+
+    @MainActor
+    func testFinishExtractingRestoresSavedProgressAndQueuesInitialScroll() async {
+        configureReaderDefaults()
+        let store = TestStore(initialState: makeState(progress: 3)) {
+            ArchiveReaderFeature()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.finishExtracting(makeExtractedPages(count: 5)))
+        XCTAssertEqual(store.state.pages.count, 5)
+        XCTAssertEqual(store.state.currentPageIndex, 2)
+        XCTAssertTrue(store.state.controlUiHidden)
+
+        await store.receive(.requestJump(2, source: .initialRestore))
+        XCTAssertEqual(store.state.scrollRequest?.targetPageIndex, 2)
+        XCTAssertEqual(store.state.scrollRequest?.source, .initialRestore)
+        XCTAssertEqual(store.state.scrollRequest?.animated, false)
+    }
+
+    @MainActor
+    func testFinishExtractingFromStartStartsAtFirstPage() async {
+        configureReaderDefaults()
+        let store = TestStore(initialState: makeState(progress: 4, fromStart: true)) {
+            ArchiveReaderFeature()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.finishExtracting(makeExtractedPages(count: 5)))
+        XCTAssertEqual(store.state.currentPageIndex, 0)
+
+        await store.receive(.requestJump(0, source: .initialRestore))
+        XCTAssertEqual(store.state.scrollRequest?.targetPageIndex, 0)
+    }
+
+    @MainActor
+    func testFinishExtractingClampsOutOfRangeProgress() async {
+        configureReaderDefaults()
+        let store = TestStore(initialState: makeState(progress: 99)) {
+            ArchiveReaderFeature()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.finishExtracting(makeExtractedPages(count: 4)))
+        XCTAssertEqual(store.state.currentPageIndex, 3)
+
+        await store.receive(.requestJump(3, source: .initialRestore))
+        XCTAssertEqual(store.state.scrollRequest?.targetPageIndex, 3)
+    }
+
+    @MainActor
+    func testVisiblePageChangedUpdatesProgressAndClearsNewFlag() async {
+        configureReaderDefaults()
+        var initialState = makeState(progress: 0, cached: true, isNew: true)
+        initialState.pages = makePageStates(count: 3)
+        let store = TestStore(initialState: initialState) {
+            ArchiveReaderFeature()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.visiblePageChanged(1))
+        XCTAssertEqual(store.state.currentPageIndex, 1)
+        XCTAssertEqual(store.state.allArchives[id: "archive"]?.wrappedValue.progress, 2)
+        XCTAssertEqual(store.state.allArchives[id: "archive"]?.wrappedValue.isNew, false)
+    }
+
+    @MainActor
+    func testNavigateNextUsesCanonicalDoublePageIndex() async {
+        configureReaderDefaults(doublePageLayout: true)
+        var initialState = makeState(
+            progress: 2,
+            readDirection: .leftRight,
+            doublePageLayout: true
+        )
+        initialState.pages = makePageStates(count: 5)
+        initialState.currentPageIndex = 1
+        let store = TestStore(initialState: initialState) {
+            ArchiveReaderFeature()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.navigate(.next, source: .tap))
+        XCTAssertEqual(store.state.scrollRequest?.targetPageIndex, 3)
+        XCTAssertEqual(store.state.scrollRequest?.source, .tap)
+        XCTAssertEqual(store.state.scrollRequest?.animated, true)
+    }
+
+    @MainActor
+    func testNavigatePreviousUsesCanonicalDoublePageIndex() async {
+        configureReaderDefaults(
+            readDirection: .rightLeft,
+            doublePageLayout: true
+        )
+        var initialState = makeState(
+            progress: 4,
+            readDirection: .rightLeft,
+            doublePageLayout: true
+        )
+        initialState.pages = makePageStates(count: 5)
+        initialState.currentPageIndex = 4
+        let store = TestStore(initialState: initialState) {
+            ArchiveReaderFeature()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.navigate(.previous, source: .keyboard))
+        XCTAssertEqual(store.state.scrollRequest?.targetPageIndex, 3)
+        XCTAssertEqual(store.state.scrollRequest?.source, .keyboard)
+    }
+
+    @MainActor
+    func testRequestJumpToSamePageTwiceCreatesFreshScrollRequest() async throws {
+        configureReaderDefaults()
+        var initialState = makeState(progress: 2)
+        initialState.pages = makePageStates(count: 4)
+        initialState.currentPageIndex = 1
+        let store = TestStore(initialState: initialState) {
+            ArchiveReaderFeature()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.requestJump(1, source: .slider))
+        let firstRequestId = try XCTUnwrap(store.state.scrollRequest?.id)
+
+        await store.send(.scrollRequestHandled(firstRequestId))
+        XCTAssertNil(store.state.scrollRequest)
+
+        await store.send(.requestJump(1, source: .slider))
+        let secondRequestId = try XCTUnwrap(store.state.scrollRequest?.id)
+
+        XCTAssertNotEqual(firstRequestId, secondRequestId)
+        XCTAssertEqual(store.state.scrollRequest?.targetPageIndex, 1)
+    }
+
+    @MainActor
+    func testAutoPageTickRequestsNextPage() async {
+        configureReaderDefaults(autoPageInterval: 1)
+        let clock = TestClock()
+        var initialState = makeState(progress: 2, autoPageInterval: 1)
+        initialState.pages = makePageStates(count: 3)
+        initialState.currentPageIndex = 1
+        initialState.pages[1].imageLoaded = true
+        let store = TestStore(initialState: initialState) {
+            ArchiveReaderFeature()
+        } withDependencies: {
+            $0.continuousClock = clock
+        }
+        store.exhaustivity = .off
+
+        await store.send(.autoPageTick)
+        await clock.advance(by: .seconds(1))
+
+        await store.receive(.navigate(.next, source: .autoPage))
+        XCTAssertEqual(store.state.scrollRequest?.targetPageIndex, 2)
+
+        await store.receive(.setLastAutoPageIndex(1))
+        await store.receive(.autoPageTick)
+        await store.send(.toggleControlUi(false))
+    }
+
+    func testLoadNextArchiveResetsStateBeforeLoading() {
+        configureReaderDefaults()
+        var state = makeState(
+            archiveId: "one",
+            progress: 2,
+            allArchives: [
+                makeArchive(id: "one", progress: 2),
+                makeArchive(id: "two", progress: 4)
+            ]
+        )
+        state.pages = makePageStates(count: 3, archiveId: "one")
+        state.currentPageIndex = 2
+        state.scrollRequest = ScrollRequest(targetPageIndex: 2, source: .slider, animated: false)
+        state.inCache = true
+        state.errorMessage = "error"
+        state.successMessage = "success"
+
+        _ = ArchiveReaderFeature().reduce(into: &state, action: .loadNextArchive)
+
+        XCTAssertEqual(state.currentArchiveId, "two")
+        XCTAssertTrue(state.pages.isEmpty)
+        XCTAssertEqual(state.currentPageIndex, 0)
+        XCTAssertNil(state.scrollRequest)
+        XCTAssertFalse(state.inCache)
+        XCTAssertEqual(state.errorMessage, "")
+        XCTAssertEqual(state.successMessage, "")
+    }
+
+    private func configureReaderDefaults(
+        readDirection: ReadDirection = .leftRight,
+        doublePageLayout: Bool = false,
+        autoPageInterval: Double = 5
+    ) {
+        UserDefaults.standard.set(readDirection.rawValue, forKey: SettingsKey.readDirection)
+        UserDefaults.standard.set(doublePageLayout, forKey: SettingsKey.doublePageLayout)
+        UserDefaults.standard.set(autoPageInterval, forKey: SettingsKey.autoPageInterval)
+    }
+
+    private func makeState(
+        archiveId: String = "archive",
+        progress: Int = 0,
+        fromStart: Bool = false,
+        cached: Bool = false,
+        isNew: Bool = false,
+        allArchives: [ArchiveItem]? = nil,
+        readDirection: ReadDirection = .leftRight,
+        doublePageLayout: Bool = false,
+        autoPageInterval: Double = 5
+    ) -> ArchiveReaderFeature.State {
+        let archives = allArchives ?? [makeArchive(id: archiveId, progress: progress, isNew: isNew)]
+        var state = ArchiveReaderFeature.State(
+            currentArchiveId: archiveId,
+            allArchives: archives.map { Shared(value: $0) },
+            fromStart: fromStart,
+            cached: cached
+        )
+        state.$readDirection = SharedReader(value: readDirection.rawValue)
+        state.$doublePageLayout = SharedReader(value: doublePageLayout)
+        state.$autoPageInterval = SharedReader(value: autoPageInterval)
+        return state
+    }
+
+    private func makeArchive(
+        id: String = "archive",
+        progress: Int = 0,
+        isNew: Bool = false
+    ) -> ArchiveItem {
+        ArchiveItem(
+            id: id,
+            name: "Archive \(id)",
+            extension: "zip",
+            tags: "",
+            isNew: isNew,
+            progress: progress,
+            pagecount: 10,
+            dateAdded: nil
+        )
+    }
+
+    private func makeExtractedPages(count: Int) -> [String] {
+        (1...count).map { "p\($0)" }
+    }
+
+    private func makePageStates(
+        count: Int,
+        archiveId: String = "archive"
+    ) -> IdentifiedArrayOf<PageFeature.State> {
+        IdentifiedArray(
+            uniqueElements: (1...count).map {
+                PageFeature.State(
+                    archiveId: archiveId,
+                    pageId: "\($0)",
+                    pageNumber: $0
+                )
+            }
+        )
+    }
+
+}

--- a/LANreaderTests/ArchiveReaderFeatureTests.swift
+++ b/LANreaderTests/ArchiveReaderFeatureTests.swift
@@ -361,6 +361,44 @@ final class ArchiveReaderFeatureTests: XCTestCase {
     }
 
     @MainActor
+    func testUIPageCollectionKeepsPendingScrollRequestWhenPagesAreNotLoaded() async {
+        configureReaderDefaults()
+        var initialState = makeState(progress: 2)
+        initialState.scrollRequest = ScrollRequest(targetPageIndex: 1, source: .slider, animated: false)
+
+        let store = Store(initialState: initialState) {
+            ArchiveReaderFeature()
+        }
+        let viewStore = ViewStore(store, observe: { $0 })
+        let controller = UIPageCollectionController(store: store)
+
+        controller.loadViewIfNeeded()
+        await Task.yield()
+
+        XCTAssertNotNil(viewStore.scrollRequest)
+    }
+
+    @MainActor
+    func testUIPageCollectionConsumesPendingScrollRequestAfterPagesLoad() async {
+        configureReaderDefaults()
+        var initialState = makeState(progress: 2)
+        initialState.pages = makePageStates(count: 4)
+        initialState.scrollRequest = ScrollRequest(targetPageIndex: 1, source: .slider, animated: false)
+
+        let store = Store(initialState: initialState) {
+            ArchiveReaderFeature()
+        }
+        let viewStore = ViewStore(store, observe: { $0 })
+        let controller = UIPageCollectionController(store: store)
+
+        controller.loadViewIfNeeded()
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertNil(viewStore.scrollRequest)
+    }
+
+    @MainActor
     func testAutoPageTickRequestsNextPage() async {
         configureReaderDefaults(autoPageInterval: 1)
         let clock = TestClock()

--- a/scripts/test-ios
+++ b/scripts/test-ios
@@ -9,7 +9,7 @@ source "$SCRIPT_DIR/_xcode_env.sh"
 prepare_xcode_environment
 trust_swift_macros
 
-DESTINATION="${LANREADER_DESTINATION:-platform=iOS Simulator,OS=26.2,name=iPad Pro 11-inch (M5)}"
+DESTINATION="${LANREADER_DESTINATION:-platform=iOS Simulator,OS=26.4,name=iPad Pro 11-inch (M5)}"
 RESULT_BUNDLE_PATH="$LANREADER_RESULTS_DIR/LANreader-tests.xcresult"
 
 rm -rf "$RESULT_BUNDLE_PATH"


### PR DESCRIPTION
## What changed
- refactored reader progress and jump coordination around a single canonical page index plus explicit scroll requests
- moved page index and spread math into `ReaderPositioning`
- kept slider drag state local to the SwiftUI toolbar instead of reducer state
- fixed a `UIPageCollection` race so pending scroll requests are not dropped before pages load
- added regression coverage for reader positioning, jump requests, and pending scroll handling

## Why
- reduce the maintenance cost of keeping slider state, visible page state, and page jumps in sync
- avoid timing-dependent failures when restoring progress or jumping before collection data is ready

## Verification
- `./scripts/lint`
- `xcodebuild -project LANreader.xcodeproj -scheme LANreader -destination 'platform=iOS Simulator,OS=26.4,name=iPad Pro 11-inch (M5)' -resultBundlePath /Users/yijin/Documents/dev/LANreader/build/results/LANreader-tests-scroll-request-race.xcresult -skipMacroValidation -only-testing:LANreaderTests/ArchiveReaderFeatureTests test`