### PR TITLE
Add reader slider preview

### DIFF
--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -916,7 +916,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreader.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 157;
+				CURRENT_PROJECT_VERSION = 158;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -927,7 +927,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6.4;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -944,7 +944,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreaderRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 157;
+				CURRENT_PROJECT_VERSION = 158;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -955,7 +955,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6.4;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1018,7 +1018,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 157;
+				CURRENT_PROJECT_VERSION = 158;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1030,7 +1030,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.6.4;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1048,7 +1048,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 157;
+				CURRENT_PROJECT_VERSION = 158;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1060,7 +1060,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.6.4;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/LANreader/Models/LANraragiResponse.swift
+++ b/LANreader/Models/LANraragiResponse.swift
@@ -110,6 +110,61 @@ struct QueueUrlDownloadResponse: Decodable {
     let url: String
 }
 
+public struct PageThumbnailQueueResponse: Decodable, Equatable, Sendable {
+    let job: Int?
+    let message: String?
+    let operation: String
+    let success: Int
+}
+
+public enum MinionNoteValue: Decodable, Equatable, Sendable {
+    case string(String)
+    case int(Int)
+    case double(Double)
+    case bool(Bool)
+    case null
+
+    public init(from decoder: Decoder) throws {
+        let singleValueContainer = try decoder.singleValueContainer()
+        if singleValueContainer.decodeNil() {
+            self = .null
+        } else if let intValue = try? singleValueContainer.decode(Int.self) {
+            self = .int(intValue)
+        } else if let doubleValue = try? singleValueContainer.decode(Double.self) {
+            self = .double(doubleValue)
+        } else if let boolValue = try? singleValueContainer.decode(Bool.self) {
+            self = .bool(boolValue)
+        } else {
+            self = .string(try singleValueContainer.decode(String.self))
+        }
+    }
+
+    var stringValue: String? {
+        if case let .string(value) = self {
+            return value
+        }
+        return nil
+    }
+}
+
+public struct BasicJobStatus: Decodable, Equatable, Sendable {
+    let task: String?
+    let state: String
+    let notes: [String: MinionNoteValue]?
+    let error: String?
+
+    var processedPages: Set<Int> {
+        Set(
+            (notes ?? [:]).compactMap { key, value in
+                guard value.stringValue == "processed", let pageNumber = Int(key) else {
+                    return nil
+                }
+                return pageNumber
+            }
+        )
+    }
+}
+
 struct JobStatus: Decodable {
     let id: String
     let state: String

--- a/LANreader/Page/ArchiveReader.swift
+++ b/LANreader/Page/ArchiveReader.swift
@@ -39,13 +39,12 @@ import UIKit
         var cached = false
         var inCache = false
         var removeCacheSuccess = false
-        var sliderDraftIndex: Double?
+        var sliderDraftIndex: Int?
         var sliderDragging = false
         var sliderPreviewVisible = false
         var sliderPreviewPageIndex: Int?
         var sliderPreviewImageURL: URL?
         var sliderPreviewLoading = false
-        var sliderThumbnailQueueing = false
         var sliderThumbnailJobId: Int?
         var sliderReadyThumbnailPages: Set<Int> = []
 
@@ -103,12 +102,11 @@ import UIKit
         case scrollRequestHandled(UUID)
         case prepareSliderPreviewThumbnails
         case sliderPreviewThumbnailsQueued(PageThumbnailQueueResponse)
-        case sliderPreviewThumbnailQueueFailed
         case pollSliderPreviewThumbnailJob(Int)
         case sliderPreviewThumbnailJobStatus(BasicJobStatus)
         case sliderPreviewThumbnailPollingFailed
         case sliderDragStarted
-        case sliderDragChanged(Double)
+        case sliderDragChanged(Int)
         case sliderDragEnded
         case loadSliderPreview(Int)
         case sliderPreviewLoaded(Int, URL)
@@ -293,22 +291,18 @@ import UIKit
                 return .none
             case .prepareSliderPreviewThumbnails:
                 guard !state.cached, !state.pages.isEmpty else { return .none }
-                guard !state.sliderThumbnailQueueing,
-                      state.sliderThumbnailJobId == nil,
+                guard state.sliderThumbnailJobId == nil,
                       state.sliderReadyThumbnailPages.count < state.archivePageCount else {
                     return .none
                 }
-                state.sliderThumbnailQueueing = true
                 return .run { [archiveId = state.currentArchiveId] send in
                     let response = try await service.queuePageThumbnails(id: archiveId).value
                     await send(.sliderPreviewThumbnailsQueued(response))
-                } catch: { [archiveId = state.currentArchiveId] error, send in
+                } catch: { [archiveId = state.currentArchiveId] error, _ in
                     logger.warning("failed to queue slider preview thumbnails. id=\(archiveId) \(error)")
-                    await send(.sliderPreviewThumbnailQueueFailed)
                 }
                 .cancellable(id: CancelId.sliderPreviewThumbnailQueue, cancelInFlight: true)
             case let .sliderPreviewThumbnailsQueued(response):
-                state.sliderThumbnailQueueing = false
                 if let jobId = response.job {
                     state.sliderThumbnailJobId = jobId
                     return .send(.pollSliderPreviewThumbnailJob(jobId))
@@ -319,23 +313,12 @@ import UIKit
                     return .send(.loadSliderPreview(previewPageIndex))
                 }
                 return .none
-            case .sliderPreviewThumbnailQueueFailed:
-                state.sliderThumbnailQueueing = false
-                if let previewPageIndex = state.sliderPreviewPageIndex,
-                   let existingPreviewURL = self.previewFileURL(state: state, pageIndex: previewPageIndex),
-                   FileManager.default.fileExists(atPath: existingPreviewURL.path(percentEncoded: false)) {
-                    state.sliderPreviewImageURL = existingPreviewURL
-                } else {
-                    state.sliderPreviewImageURL = nil
-                }
-                state.sliderPreviewLoading = false
-                return .none
             case let .pollSliderPreviewThumbnailJob(jobId):
                 return .run { send in
                     while true {
                         let status = try await service.checkBasicJobStatus(id: jobId).value
                         await send(.sliderPreviewThumbnailJobStatus(status))
-                        if status.state != "active" {
+                        if status.state == "finished" || status.state == "failed" {
                             return
                         }
                         try await clock.sleep(for: .seconds(1))
@@ -350,10 +333,8 @@ import UIKit
                 if status.state == "finished" {
                     state.sliderReadyThumbnailPages.formUnion(state.archivePageNumbers)
                     state.sliderThumbnailJobId = nil
-                } else if status.state != "active" {
+                } else if status.state == "failed" {
                     state.sliderThumbnailJobId = nil
-                    state.sliderPreviewLoading = false
-                    return .none
                 }
                 if let previewPageIndex = state.sliderPreviewPageIndex {
                     return .send(.loadSliderPreview(previewPageIndex))
@@ -361,19 +342,14 @@ import UIKit
                 return .none
             case .sliderPreviewThumbnailPollingFailed:
                 state.sliderThumbnailJobId = nil
-                if let previewPageIndex = state.sliderPreviewPageIndex,
-                   let existingPreviewURL = self.previewFileURL(state: state, pageIndex: previewPageIndex),
-                   FileManager.default.fileExists(atPath: existingPreviewURL.path(percentEncoded: false)) {
-                    state.sliderPreviewImageURL = existingPreviewURL
-                } else if state.sliderPreviewPageIndex != nil {
-                    state.sliderPreviewImageURL = nil
+                if let previewPageIndex = state.sliderPreviewPageIndex {
+                    return .send(.loadSliderPreview(previewPageIndex))
                 }
-                state.sliderPreviewLoading = false
                 return .none
             case .sliderDragStarted:
                 state.sliderDragging = true
                 let previewIndex = ReaderPositioning.clampedPageIndex(
-                    Int((state.sliderDraftIndex ?? Double(state.currentPageIndex)).rounded()),
+                    state.sliderDraftIndex ?? state.currentPageIndex,
                     pageCount: state.pages.count
                 )
                 state.sliderPreviewVisible = !state.pages.isEmpty
@@ -383,7 +359,7 @@ import UIKit
                 guard state.sliderDragging else { return .none }
                 guard !state.pages.isEmpty else { return .none }
                 let targetIndex = ReaderPositioning.clampedPageIndex(
-                    Int(newValue.rounded()),
+                    newValue,
                     pageCount: state.pages.count
                 )
                 return self.updateSliderPreview(state: &state, pageIndex: targetIndex)
@@ -394,7 +370,7 @@ import UIKit
                     return .cancel(id: CancelId.sliderPreviewLoad)
                 }
                 let targetIndex = ReaderPositioning.clampedPageIndex(
-                    Int((state.sliderDraftIndex ?? Double(state.currentPageIndex)).rounded()),
+                    state.sliderDraftIndex ?? state.currentPageIndex,
                     pageCount: state.pages.count
                 )
                 self.resetSliderPreviewDisplayState(state: &state)
@@ -408,30 +384,13 @@ import UIKit
                 guard state.sliderPreviewVisible, state.sliderPreviewPageIndex == clampedIndex else { return .none }
 
                 let page = state.pages[clampedIndex]
-                let previewFileURL = Self.sliderPreviewFileURL(
-                    archiveId: state.currentArchiveId,
-                    pageNumber: page.pageNumber
-                )
-                let hasExistingPreviewFile = FileManager.default.fileExists(
-                    atPath: previewFileURL.path(percentEncoded: false)
-                )
-                if hasExistingPreviewFile {
-                    state.sliderPreviewImageURL = previewFileURL
-                    state.sliderPreviewLoading = false
+                if self.restoreExistingSliderPreviewIfAvailable(state: &state, pageIndex: clampedIndex) {
                     return .none
                 }
 
                 guard state.cached || state.sliderReadyThumbnailPages.contains(page.pageNumber) else {
-                    let shouldRetryThumbnailPreparation = !state.cached
-                        && state.sliderThumbnailJobId == nil
-                        && !state.sliderThumbnailQueueing
                     state.sliderPreviewImageURL = nil
-                    state.sliderPreviewLoading = shouldRetryThumbnailPreparation
-                        || state.sliderThumbnailQueueing
-                        || state.sliderThumbnailJobId != nil
-                    if shouldRetryThumbnailPreparation {
-                        return .send(.prepareSliderPreviewThumbnails)
-                    }
+                    state.sliderPreviewLoading = state.sliderThumbnailJobId != nil
                     return .none
                 }
 
@@ -501,21 +460,14 @@ import UIKit
                 return .none
             case let .sliderPreviewUnavailable(pageIndex):
                 guard state.sliderPreviewPageIndex == pageIndex else { return .none }
-                if let existingPreviewURL = self.previewFileURL(state: state, pageIndex: pageIndex),
-                   FileManager.default.fileExists(atPath: existingPreviewURL.path(percentEncoded: false)) {
-                    state.sliderPreviewImageURL = existingPreviewURL
-                    state.sliderPreviewLoading = false
-                } else {
+                if !self.restoreExistingSliderPreviewIfAvailable(state: &state, pageIndex: pageIndex) {
                     state.sliderPreviewLoading = state.sliderThumbnailJobId != nil
                     state.sliderPreviewImageURL = nil
                 }
                 return .none
             case let .sliderPreviewFailed(pageIndex):
                 guard state.sliderPreviewPageIndex == pageIndex else { return .none }
-                if let existingPreviewURL = self.previewFileURL(state: state, pageIndex: pageIndex),
-                   FileManager.default.fileExists(atPath: existingPreviewURL.path(percentEncoded: false)) {
-                    state.sliderPreviewImageURL = existingPreviewURL
-                } else {
+                if !self.restoreExistingSliderPreviewIfAvailable(state: &state, pageIndex: pageIndex) {
                     state.sliderPreviewImageURL = nil
                 }
                 state.sliderPreviewLoading = false
@@ -769,18 +721,10 @@ import UIKit
             return .none
         }
 
-        let previewFileURL = Self.sliderPreviewFileURL(
-            archiveId: state.currentArchiveId,
-            pageNumber: state.pages[clampedIndex].pageNumber
-        )
-        let hasPreviewFile = FileManager.default.fileExists(atPath: previewFileURL.path(percentEncoded: false))
-
-        state.sliderDraftIndex = Double(clampedIndex)
+        state.sliderDraftIndex = clampedIndex
         state.sliderPreviewVisible = true
         state.sliderPreviewPageIndex = clampedIndex
-        if hasPreviewFile {
-            state.sliderPreviewImageURL = previewFileURL
-            state.sliderPreviewLoading = false
+        if self.restoreExistingSliderPreviewIfAvailable(state: &state, pageIndex: clampedIndex) {
             return .none
         }
         return .send(.loadSliderPreview(clampedIndex))
@@ -797,7 +741,6 @@ import UIKit
 
     private func resetSliderPreviewArchiveState(state: inout State) {
         resetSliderPreviewDisplayState(state: &state)
-        state.sliderThumbnailQueueing = false
         state.sliderThumbnailJobId = nil
         state.sliderReadyThumbnailPages = []
     }
@@ -810,6 +753,19 @@ import UIKit
             archiveId: state.currentArchiveId,
             pageNumber: state.pages[pageIndex].pageNumber
         )
+    }
+
+    private func restoreExistingSliderPreviewIfAvailable(
+        state: inout State,
+        pageIndex: Int
+    ) -> Bool {
+        guard let existingPreviewURL = self.previewFileURL(state: state, pageIndex: pageIndex),
+              FileManager.default.fileExists(atPath: existingPreviewURL.path(percentEncoded: false)) else {
+            return false
+        }
+        state.sliderPreviewImageURL = existingPreviewURL
+        state.sliderPreviewLoading = false
+        return true
     }
 
     private static func sliderPreviewRootDirectory() -> URL {
@@ -953,39 +909,31 @@ struct ArchiveReader: View {
         readerSize: CGSize
     ) -> some View {
         if !store.pages.isEmpty {
+            let isRightToLeft = store.resolvedReadDirection == .rightLeft
             let bubbleLayout = sliderPreviewBubbleLayout(readerSize: readerSize)
             let sliderHorizontalPadding: CGFloat = 16
             let bubbleVerticalSpacing: CGFloat = 14
-            let isRightToLeft = store.resolvedReadDirection == .rightLeft
-            let sliderDisplayValue = store.sliderDraftIndex ?? Double(store.currentPageIndex)
+            let sliderDisplayIndex = store.sliderDraftIndex ?? store.currentPageIndex
+            let sliderDisplayValue = Double(sliderDisplayIndex)
             let displayIndex = ReaderPositioning.clampedPageIndex(
-                Int(sliderDisplayValue.rounded()),
+                sliderDisplayIndex,
                 pageCount: store.pages.count
             )
             let displayPageNumber = store.pages[displayIndex].pageNumber
-            let sliderBinding = Binding(
-                get: {
-                    sliderDisplayValue
-                },
-                set: { _ in }
-            )
             let sliderMaxIndex = max(store.pages.count - 1, 1)
 
             VStack(spacing: 0) {
                 if store.sliderPreviewVisible {
                     GeometryReader { geometry in
-                        let logicalNormalized = store.pages.count <= 1
-                            ? 0.0
-                            : CGFloat(displayIndex) / CGFloat(store.pages.count - 1)
-                        let visualNormalized = isRightToLeft ? (1 - logicalNormalized) : logicalNormalized
-                        let sliderWidth = max(geometry.size.width - sliderHorizontalPadding * 2, 1)
-                        let thumbCenterX = sliderHorizontalPadding + (sliderWidth * visualNormalized)
-                        let bubbleLeadingX = max(
-                            0,
-                            min(
-                                thumbCenterX - (bubbleLayout.width / 2),
-                                geometry.size.width - bubbleLayout.width
-                            )
+                        let bubbleLeadingX = SliderPreviewPositioning.bubbleLeadingX(
+                            pageIndex: displayIndex,
+                            pageCount: store.pages.count,
+                            track: SliderPreviewTrackGeometry(
+                                rowWidth: geometry.size.width,
+                                sliderHorizontalPadding: sliderHorizontalPadding,
+                                bubbleWidth: bubbleLayout.width
+                            ),
+                            isRightToLeft: isRightToLeft
                         )
 
                         SliderPreviewBubble(
@@ -997,10 +945,10 @@ struct ArchiveReader: View {
                         .offset(x: bubbleLeadingX)
                         .allowsHitTesting(false)
                     }
-                    .environment(\.layoutDirection, .leftToRight)
                     .frame(height: bubbleLayout.rowHeight)
                     .padding(.horizontal, 16)
                     .padding(.bottom, bubbleVerticalSpacing)
+                    .environment(\.layoutDirection, .leftToRight)
                     .transition(.opacity)
                 }
 
@@ -1048,14 +996,11 @@ struct ArchiveReader: View {
 
                             ZStack {
                                 Slider(
-                                    value: sliderBinding,
+                                    value: .constant(sliderDisplayValue),
                                     in: 0...Double(sliderMaxIndex),
                                     step: 1
                                 )
                                 .padding(.horizontal, sliderHorizontalPadding)
-                                // Keep the decorative slider in a stable coordinate system.
-                                // The transparent drag layer handles RTL/LTR value mapping.
-                                .environment(\.layoutDirection, .leftToRight)
                                 .scaleEffect(x: isRightToLeft ? -1 : 1, y: 1)
                                 .allowsHitTesting(false)
 
@@ -1070,7 +1015,7 @@ struct ArchiveReader: View {
                                                 }
                                                 store.send(
                                                     .sliderDragChanged(
-                                                        sliderValue(
+                                                        SliderPreviewPositioning.pageIndex(
                                                             at: value.location.x,
                                                             sliderWidth: sliderWidth,
                                                             horizontalPadding: sliderHorizontalPadding,
@@ -1083,7 +1028,7 @@ struct ArchiveReader: View {
                                             .onEnded { value in
                                                 store.send(
                                                     .sliderDragChanged(
-                                                        sliderValue(
+                                                        SliderPreviewPositioning.pageIndex(
                                                             at: value.location.x,
                                                             sliderWidth: sliderWidth,
                                                             horizontalPadding: sliderHorizontalPadding,
@@ -1097,9 +1042,9 @@ struct ArchiveReader: View {
                                     )
                             }
                         }
-                        .environment(\.layoutDirection, .leftToRight)
                         .frame(height: 44)
                         .gridCellColumns(5)
+                        .environment(\.layoutDirection, .leftToRight)
                     }
                 }
                 .padding()
@@ -1127,22 +1072,59 @@ struct ArchiveReader: View {
             rowHeight: imageHeight + 52
         )
     }
+}
 
-    private func sliderValue(
+enum SliderPreviewPositioning {
+    static func visualNormalized(
+        pageIndex: Int,
+        pageCount: Int,
+        isRightToLeft: Bool
+    ) -> CGFloat {
+        guard pageCount > 1 else { return 0 }
+        let clampedIndex = ReaderPositioning.clampedPageIndex(pageIndex, pageCount: pageCount)
+        let logicalNormalized = CGFloat(clampedIndex) / CGFloat(pageCount - 1)
+        return isRightToLeft ? (1 - logicalNormalized) : logicalNormalized
+    }
+
+    static func bubbleLeadingX(
+        pageIndex: Int,
+        pageCount: Int,
+        track: SliderPreviewTrackGeometry,
+        isRightToLeft: Bool
+    ) -> CGFloat {
+        let sliderWidth = max(track.rowWidth - track.sliderHorizontalPadding * 2, 1)
+        let thumbCenterX = track.sliderHorizontalPadding + (
+            sliderWidth * visualNormalized(
+                pageIndex: pageIndex,
+                pageCount: pageCount,
+                isRightToLeft: isRightToLeft
+            )
+        )
+        let maxLeading = max(track.rowWidth - track.bubbleWidth, 0)
+        return max(0, min(thumbCenterX - (track.bubbleWidth / 2), maxLeading))
+    }
+
+    static func pageIndex(
         at locationX: CGFloat,
         sliderWidth: CGFloat,
         horizontalPadding: CGFloat,
         sliderMaxIndex: Int,
         isRightToLeft: Bool
-    ) -> Double {
+    ) -> Int {
         let adjustedX = min(
             max(locationX - horizontalPadding, 0),
             sliderWidth
         )
         let visualNormalized = sliderWidth == 0 ? 0 : adjustedX / sliderWidth
         let logicalNormalized = isRightToLeft ? (1 - visualNormalized) : visualNormalized
-        return Double(logicalNormalized) * Double(sliderMaxIndex)
+        return Int((logicalNormalized * CGFloat(sliderMaxIndex)).rounded())
     }
+}
+
+struct SliderPreviewTrackGeometry {
+    let rowWidth: CGFloat
+    let sliderHorizontalPadding: CGFloat
+    let bubbleWidth: CGFloat
 }
 
 private struct SliderPreviewBubble: View {
@@ -1150,21 +1132,15 @@ private struct SliderPreviewBubble: View {
     let loading: Bool
     let imageHeight: CGFloat
 
-    @State private var previewImage: UIImage?
-
-    private var imageLoadId: String {
-        if let imageURL {
-            return imageURL.path(percentEncoded: false)
-        }
-        return "none"
-    }
-
-    private func makePreviewImage() -> UIImage? {
+    private var previewImage: UIImage? {
         guard let imageURL,
               let image = UIImage(contentsOfFile: imageURL.path(percentEncoded: false)) else {
             return nil
         }
-        return image.preparingForDisplay() ?? image
+        if let preparedImage = image.preparingForDisplay() {
+            return preparedImage
+        }
+        return image
     }
 
     var body: some View {
@@ -1188,10 +1164,6 @@ private struct SliderPreviewBubble: View {
             }
         }
         .frame(height: imageHeight)
-        .task(id: imageLoadId) {
-            previewImage = nil
-            previewImage = makePreviewImage()
-        }
         .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
         .padding(12)
         .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))

--- a/LANreader/Page/ArchiveReader.swift
+++ b/LANreader/Page/ArchiveReader.swift
@@ -3,6 +3,9 @@ import SwiftUI
 import Logging
 import NotificationBannerSwift
 import OrderedCollections
+import UIKit
+
+// swiftlint:disable type_body_length file_length
 
 @Reducer public struct ArchiveReaderFeature: Sendable {
     private let logger = Logger(label: "ArchiveReaderFeature")
@@ -36,6 +39,15 @@ import OrderedCollections
         var cached = false
         var inCache = false
         var removeCacheSuccess = false
+        var sliderDraftIndex: Double?
+        var sliderDragging = false
+        var sliderPreviewVisible = false
+        var sliderPreviewPageIndex: Int?
+        var sliderPreviewImageURL: URL?
+        var sliderPreviewLoading = false
+        var sliderThumbnailQueueing = false
+        var sliderThumbnailJobId: Int?
+        var sliderReadyThumbnailPages: Set<Int> = []
 
         var allArchives: IdentifiedArrayOf<Shared<ArchiveItem>> = []
 
@@ -63,6 +75,14 @@ import OrderedCollections
             guard !pages.isEmpty else { return nil }
             return pages[safeCurrentPageIndex]
         }
+
+        var archivePageNumbers: Set<Int> {
+            Set(pages.map(\.pageNumber))
+        }
+
+        var archivePageCount: Int {
+            archivePageNumbers.count
+        }
     }
 
     public enum Action: Equatable, BindableAction {
@@ -81,6 +101,20 @@ import OrderedCollections
         case requestJump(Int, source: ReaderNavigationSource)
         case navigate(ReaderNavigationDirection, source: ReaderNavigationSource)
         case scrollRequestHandled(UUID)
+        case prepareSliderPreviewThumbnails
+        case sliderPreviewThumbnailsQueued(PageThumbnailQueueResponse)
+        case sliderPreviewThumbnailQueueFailed
+        case pollSliderPreviewThumbnailJob(Int)
+        case sliderPreviewThumbnailJobStatus(BasicJobStatus)
+        case sliderPreviewThumbnailPollingFailed
+        case sliderDragStarted
+        case sliderDragChanged(Double)
+        case sliderDragEnded
+        case loadSliderPreview(Int)
+        case sliderPreviewLoaded(Int, URL)
+        case sliderPreviewUnavailable(Int)
+        case sliderPreviewFailed(Int)
+        case cleanupSliderPreviewResources
         case setThumbnail
         case finishThumbnailLoading
         case setError(String)
@@ -100,12 +134,16 @@ import OrderedCollections
 
     @Dependency(\.lanraragiService) var service
     @Dependency(\.appDatabase) var database
+    @Dependency(\.imageService) var imageService
     @Dependency(\.continuousClock) var clock
     @Dependency(\.uuid) var uuid
 
     public enum CancelId: Sendable {
         case updateProgress
         case autoPage
+        case sliderPreviewThumbnailQueue
+        case sliderPreviewThumbnailPolling
+        case sliderPreviewLoad
     }
 
     public var body: some ReducerOf<Self> {
@@ -147,6 +185,7 @@ import OrderedCollections
                    state.extracting = false
                    return .send(.requestJump(state.currentPageIndex, source: .initialRestore))
                } else {
+                   self.resetSliderPreviewArchiveState(state: &state)
                    state.controlUiHidden = true
                    state.extracting = false
                    return .send(.setError(String(localized: "archive.cache.load.failed")))
@@ -193,7 +232,10 @@ import OrderedCollections
                 }
                 state.extracting = false
                 guard !state.pages.isEmpty else { return .none }
-                return .send(.requestJump(state.currentPageIndex, source: .initialRestore))
+                return .merge(
+                    .send(.requestJump(state.currentPageIndex, source: .initialRestore)),
+                    .send(.prepareSliderPreviewThumbnails)
+                )
             case let .toggleControlUi(show):
                 if let shouldShow = show {
                     state.controlUiHidden = shouldShow
@@ -201,7 +243,11 @@ import OrderedCollections
                     state.controlUiHidden.toggle()
                 }
                 state.lastAutoPageIndex = nil
-                return .cancel(id: CancelId.autoPage)
+                self.resetSliderPreviewDisplayState(state: &state)
+                return .merge(
+                    .cancel(id: CancelId.autoPage),
+                    .cancel(id: CancelId.sliderPreviewLoad)
+                )
             case let .visiblePageChanged(index):
                 guard !state.pages.isEmpty else { return .none }
                 let clampedIndex = ReaderPositioning.clampedPageIndex(index, pageCount: state.pages.count)
@@ -245,6 +291,242 @@ import OrderedCollections
                     animated: source != .slider && source != .initialRestore
                 )
                 return .none
+            case .prepareSliderPreviewThumbnails:
+                guard !state.cached, !state.pages.isEmpty else { return .none }
+                guard !state.sliderThumbnailQueueing,
+                      state.sliderThumbnailJobId == nil,
+                      state.sliderReadyThumbnailPages.count < state.archivePageCount else {
+                    return .none
+                }
+                state.sliderThumbnailQueueing = true
+                return .run { [archiveId = state.currentArchiveId] send in
+                    let response = try await service.queuePageThumbnails(id: archiveId).value
+                    await send(.sliderPreviewThumbnailsQueued(response))
+                } catch: { [archiveId = state.currentArchiveId] error, send in
+                    logger.warning("failed to queue slider preview thumbnails. id=\(archiveId) \(error)")
+                    await send(.sliderPreviewThumbnailQueueFailed)
+                }
+                .cancellable(id: CancelId.sliderPreviewThumbnailQueue, cancelInFlight: true)
+            case let .sliderPreviewThumbnailsQueued(response):
+                state.sliderThumbnailQueueing = false
+                if let jobId = response.job {
+                    state.sliderThumbnailJobId = jobId
+                    return .send(.pollSliderPreviewThumbnailJob(jobId))
+                }
+                state.sliderThumbnailJobId = nil
+                state.sliderReadyThumbnailPages = state.archivePageNumbers
+                if let previewPageIndex = state.sliderPreviewPageIndex {
+                    return .send(.loadSliderPreview(previewPageIndex))
+                }
+                return .none
+            case .sliderPreviewThumbnailQueueFailed:
+                state.sliderThumbnailQueueing = false
+                if let previewPageIndex = state.sliderPreviewPageIndex,
+                   let existingPreviewURL = self.previewFileURL(state: state, pageIndex: previewPageIndex),
+                   FileManager.default.fileExists(atPath: existingPreviewURL.path(percentEncoded: false)) {
+                    state.sliderPreviewImageURL = existingPreviewURL
+                } else {
+                    state.sliderPreviewImageURL = nil
+                }
+                state.sliderPreviewLoading = false
+                return .none
+            case let .pollSliderPreviewThumbnailJob(jobId):
+                return .run { send in
+                    while true {
+                        let status = try await service.checkBasicJobStatus(id: jobId).value
+                        await send(.sliderPreviewThumbnailJobStatus(status))
+                        if status.state != "active" {
+                            return
+                        }
+                        try await clock.sleep(for: .seconds(1))
+                    }
+                } catch: { [archiveId = state.currentArchiveId] error, send in
+                    logger.warning("failed to poll slider preview thumbnail job. id=\(archiveId) \(error)")
+                    await send(.sliderPreviewThumbnailPollingFailed)
+                }
+                .cancellable(id: CancelId.sliderPreviewThumbnailPolling, cancelInFlight: true)
+            case let .sliderPreviewThumbnailJobStatus(status):
+                state.sliderReadyThumbnailPages.formUnion(status.processedPages)
+                if status.state == "finished" {
+                    state.sliderReadyThumbnailPages.formUnion(state.archivePageNumbers)
+                    state.sliderThumbnailJobId = nil
+                } else if status.state != "active" {
+                    state.sliderThumbnailJobId = nil
+                    state.sliderPreviewLoading = false
+                    return .none
+                }
+                if let previewPageIndex = state.sliderPreviewPageIndex {
+                    return .send(.loadSliderPreview(previewPageIndex))
+                }
+                return .none
+            case .sliderPreviewThumbnailPollingFailed:
+                state.sliderThumbnailJobId = nil
+                if let previewPageIndex = state.sliderPreviewPageIndex,
+                   let existingPreviewURL = self.previewFileURL(state: state, pageIndex: previewPageIndex),
+                   FileManager.default.fileExists(atPath: existingPreviewURL.path(percentEncoded: false)) {
+                    state.sliderPreviewImageURL = existingPreviewURL
+                } else if state.sliderPreviewPageIndex != nil {
+                    state.sliderPreviewImageURL = nil
+                }
+                state.sliderPreviewLoading = false
+                return .none
+            case .sliderDragStarted:
+                state.sliderDragging = true
+                let previewIndex = ReaderPositioning.clampedPageIndex(
+                    Int((state.sliderDraftIndex ?? Double(state.currentPageIndex)).rounded()),
+                    pageCount: state.pages.count
+                )
+                state.sliderPreviewVisible = !state.pages.isEmpty
+                guard !state.pages.isEmpty else { return .none }
+                return self.updateSliderPreview(state: &state, pageIndex: previewIndex)
+            case let .sliderDragChanged(newValue):
+                guard state.sliderDragging else { return .none }
+                guard !state.pages.isEmpty else { return .none }
+                let targetIndex = ReaderPositioning.clampedPageIndex(
+                    Int(newValue.rounded()),
+                    pageCount: state.pages.count
+                )
+                return self.updateSliderPreview(state: &state, pageIndex: targetIndex)
+            case .sliderDragEnded:
+                state.sliderDragging = false
+                guard !state.pages.isEmpty else {
+                    self.resetSliderPreviewDisplayState(state: &state)
+                    return .cancel(id: CancelId.sliderPreviewLoad)
+                }
+                let targetIndex = ReaderPositioning.clampedPageIndex(
+                    Int((state.sliderDraftIndex ?? Double(state.currentPageIndex)).rounded()),
+                    pageCount: state.pages.count
+                )
+                self.resetSliderPreviewDisplayState(state: &state)
+                return .merge(
+                    .cancel(id: CancelId.sliderPreviewLoad),
+                    .send(.requestJump(targetIndex, source: .slider))
+                )
+            case let .loadSliderPreview(pageIndex):
+                guard !state.pages.isEmpty else { return .none }
+                let clampedIndex = ReaderPositioning.clampedPageIndex(pageIndex, pageCount: state.pages.count)
+                guard state.sliderPreviewVisible, state.sliderPreviewPageIndex == clampedIndex else { return .none }
+
+                let page = state.pages[clampedIndex]
+                let previewFileURL = Self.sliderPreviewFileURL(
+                    archiveId: state.currentArchiveId,
+                    pageNumber: page.pageNumber
+                )
+                let hasExistingPreviewFile = FileManager.default.fileExists(
+                    atPath: previewFileURL.path(percentEncoded: false)
+                )
+                if hasExistingPreviewFile {
+                    state.sliderPreviewImageURL = previewFileURL
+                    state.sliderPreviewLoading = false
+                    return .none
+                }
+
+                guard state.cached || state.sliderReadyThumbnailPages.contains(page.pageNumber) else {
+                    let shouldRetryThumbnailPreparation = !state.cached
+                        && state.sliderThumbnailJobId == nil
+                        && !state.sliderThumbnailQueueing
+                    state.sliderPreviewImageURL = nil
+                    state.sliderPreviewLoading = shouldRetryThumbnailPreparation
+                        || state.sliderThumbnailQueueing
+                        || state.sliderThumbnailJobId != nil
+                    if shouldRetryThumbnailPreparation {
+                        return .send(.prepareSliderPreviewThumbnails)
+                    }
+                    return .none
+                }
+
+                state.sliderPreviewImageURL = nil
+                state.sliderPreviewLoading = true
+
+                if state.cached {
+                    return .run { [archiveId = state.currentArchiveId, pageNumber = page.pageNumber] send in
+                        guard let cacheFolder = LANraragiService.cachePath?.appendingPathComponent(archiveId),
+                              let sourceURL = imageService.storedImagePath(
+                                  folderUrl: cacheFolder,
+                                  pageNumber: "\(pageNumber)"
+                              ) else {
+                            throw ArchiveReaderError.previewSourceUnavailable
+                        }
+
+                        let previewFileURL = Self.sliderPreviewFileURL(
+                            archiveId: archiveId,
+                            pageNumber: pageNumber
+                        )
+                        guard imageService.generatePreviewImage(
+                            sourceUrl: sourceURL,
+                            destinationUrl: previewFileURL
+                        ) else {
+                            throw ArchiveReaderError.previewGenerationFailed
+                        }
+                        await send(.sliderPreviewLoaded(clampedIndex, previewFileURL))
+                    } catch: { [archiveId = state.currentArchiveId] error, send in
+                        logger.warning("failed to generate cached slider preview. id=\(archiveId) \(error)")
+                        await send(.sliderPreviewFailed(clampedIndex))
+                    }
+                    .cancellable(id: CancelId.sliderPreviewLoad, cancelInFlight: true)
+                }
+
+                return .run { [archiveId = state.currentArchiveId, pageNumber = page.pageNumber] send in
+                    for attempt in 0..<6 {
+                        let thumbnailData = try await service.retrieveGeneratedArchiveThumbnail(
+                            id: archiveId,
+                            page: pageNumber,
+                            cacheBust: Self.sliderPreviewCacheBust(pageNumber: pageNumber, attempt: attempt)
+                        )
+                        if let thumbnailData {
+                            let previewFileURL = Self.sliderPreviewFileURL(
+                                archiveId: archiveId,
+                                pageNumber: pageNumber
+                            )
+                            if imageService.storePreviewImage(
+                                imageData: thumbnailData,
+                                destinationUrl: previewFileURL
+                            ) {
+                                await send(.sliderPreviewLoaded(clampedIndex, previewFileURL))
+                                return
+                            }
+                        }
+                        try await clock.sleep(for: .milliseconds(300))
+                    }
+                    await send(.sliderPreviewUnavailable(clampedIndex))
+                } catch: { [archiveId = state.currentArchiveId] error, send in
+                    logger.warning("failed to fetch slider preview thumbnail. id=\(archiveId) \(error)")
+                    await send(.sliderPreviewFailed(clampedIndex))
+                }
+                .cancellable(id: CancelId.sliderPreviewLoad, cancelInFlight: true)
+            case let .sliderPreviewLoaded(pageIndex, url):
+                guard state.sliderPreviewPageIndex == pageIndex else { return .none }
+                state.sliderPreviewImageURL = url
+                state.sliderPreviewLoading = false
+                return .none
+            case let .sliderPreviewUnavailable(pageIndex):
+                guard state.sliderPreviewPageIndex == pageIndex else { return .none }
+                if let existingPreviewURL = self.previewFileURL(state: state, pageIndex: pageIndex),
+                   FileManager.default.fileExists(atPath: existingPreviewURL.path(percentEncoded: false)) {
+                    state.sliderPreviewImageURL = existingPreviewURL
+                    state.sliderPreviewLoading = false
+                } else {
+                    state.sliderPreviewLoading = state.sliderThumbnailJobId != nil
+                    state.sliderPreviewImageURL = nil
+                }
+                return .none
+            case let .sliderPreviewFailed(pageIndex):
+                guard state.sliderPreviewPageIndex == pageIndex else { return .none }
+                if let existingPreviewURL = self.previewFileURL(state: state, pageIndex: pageIndex),
+                   FileManager.default.fileExists(atPath: existingPreviewURL.path(percentEncoded: false)) {
+                    state.sliderPreviewImageURL = existingPreviewURL
+                } else {
+                    state.sliderPreviewImageURL = nil
+                }
+                state.sliderPreviewLoading = false
+                return .none
+            case .cleanupSliderPreviewResources:
+                self.resetSliderPreviewArchiveState(state: &state)
+                return .merge(
+                    .cancel(id: CancelId.sliderPreviewThumbnailQueue),
+                    .cancel(id: CancelId.sliderPreviewThumbnailPolling),
+                    .cancel(id: CancelId.sliderPreviewLoad)
+                )
             case let .navigate(direction, source):
                 guard let targetIndex = ReaderPositioning.adjacentPageIndex(
                     from: state.currentPageIndex,
@@ -450,11 +732,12 @@ import OrderedCollections
                 let newShared = state.allArchives[currentIndex - 1]
                 state.currentArchiveId = newShared.wrappedValue.id
                 self.resetState(state: &state)
-                if state.cached {
-                    return .send(.loadCached)
-                } else {
-                    return .send(.extractArchive)
-                }
+                return .merge(
+                    .cancel(id: CancelId.sliderPreviewThumbnailQueue),
+                    .cancel(id: CancelId.sliderPreviewThumbnailPolling),
+                    .cancel(id: CancelId.sliderPreviewLoad),
+                    state.cached ? .send(.loadCached) : .send(.extractArchive)
+                )
             case .loadNextArchive:
                 guard let currentIndex = state.allArchives.firstIndex(where: { $0.id == state.currentArchiveId }) else {
                     return .none
@@ -463,17 +746,89 @@ import OrderedCollections
                 let newShared = state.allArchives[currentIndex + 1]
                 state.currentArchiveId = newShared.wrappedValue.id
                 self.resetState(state: &state)
-                if state.cached {
-                    return .send(.loadCached)
-                } else {
-                    return .send(.extractArchive)
-                }
+                return .merge(
+                    .cancel(id: CancelId.sliderPreviewThumbnailQueue),
+                    .cancel(id: CancelId.sliderPreviewThumbnailPolling),
+                    .cancel(id: CancelId.sliderPreviewLoad),
+                    state.cached ? .send(.loadCached) : .send(.extractArchive)
+                )
             }
         }
         .forEach(\.pages, action: \.page) {
             PageFeature()
         }
         .ifLet(\.$alert, action: \.alert)
+    }
+
+    private func updateSliderPreview(
+        state: inout State,
+        pageIndex: Int
+    ) -> Effect<Action> {
+        let clampedIndex = ReaderPositioning.clampedPageIndex(pageIndex, pageCount: state.pages.count)
+        guard clampedIndex < state.pages.count else {
+            return .none
+        }
+
+        let previewFileURL = Self.sliderPreviewFileURL(
+            archiveId: state.currentArchiveId,
+            pageNumber: state.pages[clampedIndex].pageNumber
+        )
+        let hasPreviewFile = FileManager.default.fileExists(atPath: previewFileURL.path(percentEncoded: false))
+
+        state.sliderDraftIndex = Double(clampedIndex)
+        state.sliderPreviewVisible = true
+        state.sliderPreviewPageIndex = clampedIndex
+        if hasPreviewFile {
+            state.sliderPreviewImageURL = previewFileURL
+            state.sliderPreviewLoading = false
+            return .none
+        }
+        return .send(.loadSliderPreview(clampedIndex))
+    }
+
+    private func resetSliderPreviewDisplayState(state: inout State) {
+        state.sliderDraftIndex = nil
+        state.sliderDragging = false
+        state.sliderPreviewVisible = false
+        state.sliderPreviewPageIndex = nil
+        state.sliderPreviewImageURL = nil
+        state.sliderPreviewLoading = false
+    }
+
+    private func resetSliderPreviewArchiveState(state: inout State) {
+        resetSliderPreviewDisplayState(state: &state)
+        state.sliderThumbnailQueueing = false
+        state.sliderThumbnailJobId = nil
+        state.sliderReadyThumbnailPages = []
+    }
+
+    private func previewFileURL(state: State, pageIndex: Int) -> URL? {
+        guard pageIndex >= 0, pageIndex < state.pages.count else {
+            return nil
+        }
+        return Self.sliderPreviewFileURL(
+            archiveId: state.currentArchiveId,
+            pageNumber: state.pages[pageIndex].pageNumber
+        )
+    }
+
+    private static func sliderPreviewRootDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("LANreader", isDirectory: true)
+            .appendingPathComponent("reader-preview", isDirectory: true)
+    }
+
+    private static func sliderPreviewDirectory(archiveId: String) -> URL {
+        sliderPreviewRootDirectory().appendingPathComponent(archiveId, isDirectory: true)
+    }
+
+    private static func sliderPreviewFileURL(archiveId: String, pageNumber: Int) -> URL {
+        sliderPreviewDirectory(archiveId: archiveId)
+            .appendingPathComponent("\(pageNumber).jpg", isDirectory: false)
+    }
+
+    private static func sliderPreviewCacheBust(pageNumber: Int, attempt: Int) -> Int {
+        Int(Date().timeIntervalSince1970 * 1000) + pageNumber + attempt
     }
 
     func resetState(state: inout State) {
@@ -483,23 +838,29 @@ import OrderedCollections
         state.inCache = false
         state.errorMessage = ""
         state.successMessage = ""
+        resetSliderPreviewArchiveState(state: &state)
     }
 }
 
 private enum ArchiveReaderError: LocalizedError {
     case thumbnailUnavailableAfterUpdate
+    case previewSourceUnavailable
+    case previewGenerationFailed
 
     var errorDescription: String? {
         switch self {
         case .thumbnailUnavailableAfterUpdate:
             return "Thumbnail is not ready yet. Please try again in a moment."
+        case .previewSourceUnavailable:
+            return "Preview source image is unavailable."
+        case .previewGenerationFailed:
+            return "Preview image generation failed."
         }
     }
 }
 
 struct ArchiveReader: View {
     @Bindable var store: StoreOf<ArchiveReaderFeature>
-    @State private var sliderDraftIndex: Double?
     let navigationHelper: NavigationHelper?
 
     var body: some View {
@@ -515,7 +876,7 @@ struct ArchiveReader: View {
             }
             .overlay(alignment: .bottom) {
                 if !store.controlUiHidden {
-                    bottomToolbar(store: store)
+                    bottomToolbar(store: store, readerSize: geometry.size)
                         .environment(\.layoutDirection, flip ? .rightToLeft : .leftToRight)
                 }
             }
@@ -579,8 +940,8 @@ struct ArchiveReader: View {
                 navigationHelper?.pop()
             }
         }
-        .onChange(of: store.currentArchiveId) {
-            sliderDraftIndex = nil
+        .onDisappear {
+            store.send(.cleanupSliderPreviewResources)
         }
     }
 
@@ -588,87 +949,259 @@ struct ArchiveReader: View {
     @MainActor
     @ViewBuilder
     private func bottomToolbar(
-        store: StoreOf<ArchiveReaderFeature>
+        store: StoreOf<ArchiveReaderFeature>,
+        readerSize: CGSize
     ) -> some View {
         if !store.pages.isEmpty {
-            let sliderDisplayValue = sliderDraftIndex ?? Double(store.currentPageIndex)
+            let bubbleLayout = sliderPreviewBubbleLayout(readerSize: readerSize)
+            let sliderHorizontalPadding: CGFloat = 16
+            let bubbleVerticalSpacing: CGFloat = 14
+            let isRightToLeft = store.resolvedReadDirection == .rightLeft
+            let sliderDisplayValue = store.sliderDraftIndex ?? Double(store.currentPageIndex)
             let displayIndex = ReaderPositioning.clampedPageIndex(
                 Int(sliderDisplayValue.rounded()),
                 pageCount: store.pages.count
             )
+            let displayPageNumber = store.pages[displayIndex].pageNumber
             let sliderBinding = Binding(
                 get: {
                     sliderDisplayValue
                 },
-                set: { newValue in
-                    sliderDraftIndex = newValue
-                }
+                set: { _ in }
             )
+            let sliderMaxIndex = max(store.pages.count - 1, 1)
 
-            VStack {
-            Grid {
-                GridRow {
-                    Button(action: {
-                        let indexString = store.pages[store.safeCurrentPageIndex].id
-                        store.send(.page(.element(id: indexString, action: .load(true))))
-                    }, label: {
-                        Image(systemName: "arrow.clockwise")
-                    })
-                    .disabled(store.cached)
-                    Button {
-                        store.send(.showAutoPageConfig)
-                    } label: {
-                        Image(systemName: "play")
-                    }
-                    .disabled(store.readDirection == ReadDirection.upDown.rawValue)
-                    Text(String(format: "%d/%d",
-                                displayIndex + 1,
-                                store.pages.count))
-                    .bold()
-                    Button {
-                        if store.cached || store.inCache {
-                            store.send(.removeCache)
-                        } else {
-                            store.send(.downloadPages)
-                        }
-                    } label: {
-                        store.cached || store.inCache ?
-                        Image(systemName: "trash") : Image(systemName: "arrowshape.down")
-                    }
-                    Button(action: {
-                        Task {
-                            store.send(.setThumbnail)
-                        }
-                    }, label: {
-                        Image(systemName: "photo.artframe")
-                    })
-                    .disabled(store.settingThumbnail || store.cached)
-                }
-                GridRow {
-                    Slider(
-                        value: sliderBinding,
-                        in: 0...Double(store.pages.count <= 1 ? 1 : store.pages.count - 1),
-                        step: 1
-                    ) { onSlider in
-                        if !onSlider {
-                            let targetIndex = ReaderPositioning.clampedPageIndex(
-                                Int((sliderDraftIndex ?? Double(store.currentPageIndex)).rounded()),
-                                pageCount: store.pages.count
+            VStack(spacing: 0) {
+                if store.sliderPreviewVisible {
+                    GeometryReader { geometry in
+                        let logicalNormalized = store.pages.count <= 1
+                            ? 0.0
+                            : CGFloat(displayIndex) / CGFloat(store.pages.count - 1)
+                        let visualNormalized = isRightToLeft ? (1 - logicalNormalized) : logicalNormalized
+                        let sliderWidth = max(geometry.size.width - sliderHorizontalPadding * 2, 1)
+                        let thumbCenterX = sliderHorizontalPadding + (sliderWidth * visualNormalized)
+                        let bubbleLeadingX = max(
+                            0,
+                            min(
+                                thumbCenterX - (bubbleLayout.width / 2),
+                                geometry.size.width - bubbleLayout.width
                             )
-                            store.send(.requestJump(targetIndex, source: .slider))
-                            DispatchQueue.main.async {
-                                sliderDraftIndex = nil
+                        )
+
+                        SliderPreviewBubble(
+                            imageURL: store.sliderPreviewImageURL,
+                            loading: store.sliderPreviewLoading,
+                            imageHeight: bubbleLayout.imageHeight
+                        )
+                        .frame(width: bubbleLayout.width)
+                        .offset(x: bubbleLeadingX)
+                        .allowsHitTesting(false)
+                    }
+                    .environment(\.layoutDirection, .leftToRight)
+                    .frame(height: bubbleLayout.rowHeight)
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, bubbleVerticalSpacing)
+                    .transition(.opacity)
+                }
+
+                Grid {
+                    GridRow {
+                        Button(action: {
+                            let indexString = store.pages[store.safeCurrentPageIndex].id
+                            store.send(.page(.element(id: indexString, action: .load(true))))
+                        }, label: {
+                            Image(systemName: "arrow.clockwise")
+                        })
+                        .disabled(store.cached)
+                        Button {
+                            store.send(.showAutoPageConfig)
+                        } label: {
+                            Image(systemName: "play")
+                        }
+                        .disabled(store.readDirection == ReadDirection.upDown.rawValue)
+                        Text(String(format: "%d/%d",
+                                    displayPageNumber,
+                                    store.archivePageCount))
+                        .bold()
+                        Button {
+                            if store.cached || store.inCache {
+                                store.send(.removeCache)
+                            } else {
+                                store.send(.downloadPages)
+                            }
+                        } label: {
+                            store.cached || store.inCache ?
+                            Image(systemName: "trash") : Image(systemName: "arrowshape.down")
+                        }
+                        Button(action: {
+                            Task {
+                                store.send(.setThumbnail)
+                            }
+                        }, label: {
+                            Image(systemName: "photo.artframe")
+                        })
+                        .disabled(store.settingThumbnail || store.cached)
+                    }
+                    GridRow {
+                        GeometryReader { geometry in
+                            let sliderWidth = max(geometry.size.width - sliderHorizontalPadding * 2, 1)
+
+                            ZStack {
+                                Slider(
+                                    value: sliderBinding,
+                                    in: 0...Double(sliderMaxIndex),
+                                    step: 1
+                                )
+                                .padding(.horizontal, sliderHorizontalPadding)
+                                // Keep the decorative slider in a stable coordinate system.
+                                // The transparent drag layer handles RTL/LTR value mapping.
+                                .environment(\.layoutDirection, .leftToRight)
+                                .scaleEffect(x: isRightToLeft ? -1 : 1, y: 1)
+                                .allowsHitTesting(false)
+
+                                Rectangle()
+                                    .fill(Color.clear)
+                                    .contentShape(Rectangle())
+                                    .gesture(
+                                        DragGesture(minimumDistance: 0)
+                                            .onChanged { value in
+                                                if !store.sliderDragging {
+                                                    store.send(.sliderDragStarted)
+                                                }
+                                                store.send(
+                                                    .sliderDragChanged(
+                                                        sliderValue(
+                                                            at: value.location.x,
+                                                            sliderWidth: sliderWidth,
+                                                            horizontalPadding: sliderHorizontalPadding,
+                                                            sliderMaxIndex: sliderMaxIndex,
+                                                            isRightToLeft: isRightToLeft
+                                                        )
+                                                    )
+                                                )
+                                            }
+                                            .onEnded { value in
+                                                store.send(
+                                                    .sliderDragChanged(
+                                                        sliderValue(
+                                                            at: value.location.x,
+                                                            sliderWidth: sliderWidth,
+                                                            horizontalPadding: sliderHorizontalPadding,
+                                                            sliderMaxIndex: sliderMaxIndex,
+                                                            isRightToLeft: isRightToLeft
+                                                        )
+                                                    )
+                                                )
+                                                store.send(.sliderDragEnded)
+                                            }
+                                    )
                             }
                         }
+                        .environment(\.layoutDirection, .leftToRight)
+                        .frame(height: 44)
+                        .gridCellColumns(5)
                     }
-                    .padding(.horizontal)
-                    .gridCellColumns(5)
                 }
-            }
-            .padding()
-            .background(.thinMaterial)
+                .padding()
+                .background(.thinMaterial)
             }
         }
     }
     // swiftlint:enable function_body_length
+
+    private func sliderPreviewBubbleLayout(readerSize: CGSize) -> SliderPreviewBubbleLayout {
+        let aspectRatio: CGFloat = 248 / 176
+        let isPad = UIDevice.current.userInterfaceIdiom == .pad
+        let minWidth: CGFloat = isPad ? 260 : 176
+        let maxWidth: CGFloat = isPad ? 360 : 220
+        let widthScale: CGFloat = isPad ? 0.34 : 0.44
+        let availableWidth = max(readerSize.width - 48, minWidth)
+        let targetWidth = min(max(availableWidth * widthScale, minWidth), maxWidth)
+        let maxImageHeight = max(min(readerSize.height * (isPad ? 0.52 : 0.45), isPad ? 520 : 420), 248)
+        let width = min(targetWidth, maxImageHeight / aspectRatio)
+        let imageHeight = max((width * aspectRatio).rounded(.toNearestOrAwayFromZero), 248)
+
+        return SliderPreviewBubbleLayout(
+            width: width.rounded(.toNearestOrAwayFromZero),
+            imageHeight: imageHeight,
+            rowHeight: imageHeight + 52
+        )
+    }
+
+    private func sliderValue(
+        at locationX: CGFloat,
+        sliderWidth: CGFloat,
+        horizontalPadding: CGFloat,
+        sliderMaxIndex: Int,
+        isRightToLeft: Bool
+    ) -> Double {
+        let adjustedX = min(
+            max(locationX - horizontalPadding, 0),
+            sliderWidth
+        )
+        let visualNormalized = sliderWidth == 0 ? 0 : adjustedX / sliderWidth
+        let logicalNormalized = isRightToLeft ? (1 - visualNormalized) : visualNormalized
+        return Double(logicalNormalized) * Double(sliderMaxIndex)
+    }
 }
+
+private struct SliderPreviewBubble: View {
+    let imageURL: URL?
+    let loading: Bool
+    let imageHeight: CGFloat
+
+    @State private var previewImage: UIImage?
+
+    private var imageLoadId: String {
+        if let imageURL {
+            return imageURL.path(percentEncoded: false)
+        }
+        return "none"
+    }
+
+    private func makePreviewImage() -> UIImage? {
+        guard let imageURL,
+              let image = UIImage(contentsOfFile: imageURL.path(percentEncoded: false)) else {
+            return nil
+        }
+        return image.preparingForDisplay() ?? image
+    }
+
+    var body: some View {
+        Group {
+            if let previewImage {
+                Image(uiImage: previewImage)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Color(.secondarySystemBackground))
+            } else if loading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Color(.secondarySystemBackground))
+            } else {
+                Image(systemName: "photo")
+                    .font(.title2)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Color(.secondarySystemBackground))
+            }
+        }
+        .frame(height: imageHeight)
+        .task(id: imageLoadId) {
+            previewImage = nil
+            previewImage = makePreviewImage()
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .padding(12)
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .shadow(color: .black.opacity(0.18), radius: 16, y: 6)
+    }
+}
+
+private struct SliderPreviewBubbleLayout {
+    let width: CGFloat
+    let imageHeight: CGFloat
+    let rowHeight: CGFloat
+}
+// swiftlint:enable type_body_length file_length

--- a/LANreader/Service/ImageService.swift
+++ b/LANreader/Service/ImageService.swift
@@ -43,7 +43,11 @@ final class ImageService: Sendable {
         pageNumber: String,
         split: Bool
     ) -> Bool {
-        try? FileManager.default.createDirectory(at: destinationUrl, withIntermediateDirectories: true)
+        try? FileManager.default.createDirectory(
+            at: destinationUrl,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
 
         if isAnimatedImage(imageUrl: imageUrl, imageData: imageData) {
             guard let originalData = imageData ?? (try? Data(contentsOf: imageUrl)) else { return false }
@@ -87,6 +91,201 @@ final class ImageService: Sendable {
             splitted = true
         }
         return splitted
+    }
+
+    func generatePreviewImage(
+        sourceUrl: URL,
+        destinationUrl: URL,
+        maxPixelSize: CGFloat = 1024
+    ) -> Bool {
+        guard let imageSource = CGImageSourceCreateWithURL(sourceUrl as CFURL, nil) else {
+            return false
+        }
+        return writePreviewImage(
+            from: imageSource,
+            destinationUrl: destinationUrl,
+            maxPixelSize: maxPixelSize
+        )
+    }
+
+    func storePreviewImage(
+        imageData: Data,
+        destinationUrl: URL,
+    ) -> Bool {
+        guard hasCompleteEncodedPayload(imageData) else {
+            return false
+        }
+
+        try? FileManager.default.createDirectory(
+            at: destinationUrl.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+
+        do {
+            try imageData.write(to: destinationUrl, options: .atomic)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private func writePreviewImage(
+        from imageSource: CGImageSource,
+        destinationUrl: URL,
+        maxPixelSize: CGFloat
+    ) -> Bool {
+        guard CGImageSourceGetCount(imageSource) > 0,
+              CGImageSourceGetStatus(imageSource) == .statusComplete,
+              CGImageSourceGetStatusAtIndex(imageSource, 0) == .statusComplete else {
+            return false
+        }
+
+        let options = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize
+        ] as CFDictionary
+        let previewImage = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, options)
+
+        guard let previewImage else {
+            return false
+        }
+
+        let outputImage = if cgImageHasAlpha(previewImage) {
+            flattenedImageForJPEG(previewImage)
+        } else {
+            previewImage
+        }
+
+        guard let outputImage else {
+            return false
+        }
+
+        return writeJPEGImage(outputImage, destinationUrl: destinationUrl)
+    }
+
+    private func hasCompleteEncodedPayload(_ imageData: Data) -> Bool {
+        guard imageData.count > 4 else {
+            return false
+        }
+
+        if imageData.starts(with: [0xFF, 0xD8]) {
+            return hasJPEGEndMarker(imageData)
+        }
+
+        let pngSignature = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+        if imageData.starts(with: pngSignature) {
+            let pngTrailer = Data([0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82])
+            return imageData.suffix(12) == pngTrailer
+        }
+
+        return true
+    }
+
+    private func hasJPEGEndMarker(_ imageData: Data) -> Bool {
+        let trailingSkippableBytes = Set([UInt8(0x00), 0x09, 0x0A, 0x0D, 0x20])
+        var endIndex = imageData.endIndex
+
+        while endIndex > imageData.startIndex {
+            let indexBeforeEnd = imageData.index(before: endIndex)
+            if trailingSkippableBytes.contains(imageData[indexBeforeEnd]) {
+                endIndex = indexBeforeEnd
+            } else {
+                break
+            }
+        }
+
+        guard endIndex >= imageData.index(imageData.startIndex, offsetBy: 2) else {
+            return false
+        }
+
+        let markerEnd = imageData.index(before: endIndex)
+        let markerStart = imageData.index(before: markerEnd)
+        return imageData[markerStart] == 0xFF && imageData[markerEnd] == 0xD9
+    }
+
+    private func cgImageHasAlpha(_ image: CGImage) -> Bool {
+        switch image.alphaInfo {
+        case .alphaOnly, .first, .last, .premultipliedFirst, .premultipliedLast:
+            return true
+        case .none, .noneSkipFirst, .noneSkipLast:
+            return false
+        @unknown default:
+            return true
+        }
+    }
+
+    private func flattenedImageForJPEG(_ image: CGImage) -> CGImage? {
+        guard image.width > 0, image.height > 0 else {
+            return nil
+        }
+
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.noneSkipLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
+
+        guard let context = CGContext(
+            data: nil,
+            width: image.width,
+            height: image.height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo
+        ) else {
+            return nil
+        }
+
+        context.setFillColor(UIColor.systemBackground.cgColor)
+        context.fill(CGRect(x: 0, y: 0, width: image.width, height: image.height))
+        context.draw(image, in: CGRect(x: 0, y: 0, width: image.width, height: image.height))
+        return context.makeImage()
+    }
+
+    private func writeJPEGImage(_ image: CGImage, destinationUrl: URL) -> Bool {
+        let destinationDirectory = destinationUrl.deletingLastPathComponent()
+        let tempURL = destinationDirectory.appendingPathComponent(
+            "\(UUID().uuidString).jpg",
+            isDirectory: false
+        )
+
+        try? FileManager.default.createDirectory(
+            at: destinationDirectory,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+
+        guard let destination = CGImageDestinationCreateWithURL(
+            tempURL as CFURL,
+            UTType.jpeg.identifier as CFString,
+            1,
+            nil
+        ) else {
+            return false
+        }
+
+        let options = [
+            kCGImageDestinationLossyCompressionQuality: 0.9
+        ] as CFDictionary
+        CGImageDestinationAddImage(destination, image, options)
+
+        guard CGImageDestinationFinalize(destination) else {
+            try? FileManager.default.removeItem(at: tempURL)
+            return false
+        }
+
+        do {
+            if FileManager.default.fileExists(atPath: destinationUrl.path(percentEncoded: false)) {
+                _ = try FileManager.default.replaceItemAt(destinationUrl, withItemAt: tempURL)
+            } else {
+                try FileManager.default.moveItem(at: tempURL, to: destinationUrl)
+            }
+            return true
+        } catch {
+            try? FileManager.default.removeItem(at: tempURL)
+            return false
+        }
     }
 
     private func makeImageSource(imageUrl: URL, imageData: Data? = nil) -> CGImageSource? {

--- a/LANreader/Service/ImageService.swift
+++ b/LANreader/Service/ImageService.swift
@@ -237,7 +237,7 @@ final class ImageService: Sendable {
             return nil
         }
 
-        context.setFillColor(UIColor.systemBackground.cgColor)
+        context.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
         context.fill(CGRect(x: 0, y: 0, width: image.width, height: image.height))
         context.draw(image, in: CGRect(x: 0, y: 0, width: image.width, height: image.height))
         return context.makeImage()

--- a/LANreader/Service/LANraragiService.swift
+++ b/LANreader/Service/LANraragiService.swift
@@ -134,15 +134,41 @@ actor LANraragiService {
     }
 
     func retrieveArchiveThumbnail(id: String, page: Int = 0) async throws -> Data? {
+        try await fetchArchiveThumbnail(id: id, page: page)
+    }
+
+    func retrieveGeneratedArchiveThumbnail(
+        id: String,
+        page: Int,
+        cacheBust: Int
+    ) async throws -> Data? {
+        try await fetchArchiveThumbnail(id: id, page: page, cacheBust: cacheBust, disableResponseCache: true)
+    }
+
+    private func fetchArchiveThumbnail(
+        id: String,
+        page: Int,
+        cacheBust: Int? = nil,
+        disableResponseCache: Bool = false
+    ) async throws -> Data? {
         let query = [
             "no_fallback": "true",
             "page": String(page)
         ]
+        .merging(cacheBust.map { ["cachebust": String($0)] } ?? [:]) { _, new in new }
 
         var components = URLComponents(string: "\(url)/api/archives/\(id)/thumbnail")!
         components.queryItems = query.map { URLQueryItem(name: $0.key, value: $0.value) }
 
-        let response = await session.request(components.url!).serializingData().response
+        let request = session.request(components.url!)
+        let response: DataResponse<Data, AFError>
+
+        if disableResponseCache {
+            let cacher = ResponseCacher(behavior: .doNotCache)
+            response = await request.cacheResponse(using: cacher).serializingData().response
+        } else {
+            response = await request.serializingData().response
+        }
 
         guard let statusCode = response.response?.statusCode else {
             throw response.error ?? URLError(.badServerResponse)
@@ -162,10 +188,10 @@ actor LANraragiService {
         }
     }
 
-    func queuePageThumbnails(id: String) async -> DataTask<String> {
+    func queuePageThumbnails(id: String) async -> DataTask<PageThumbnailQueueResponse> {
         return session.request("\(url)/api/archives/\(id)/files/thumbnails", method: .post)
             .validate(statusCode: [200, 202])
-            .serializingString()
+            .serializingDecodable(PageThumbnailQueueResponse.self)
     }
 
     func updateArchiveThumbnail(id: String, page: Int) -> DataTask<String> {
@@ -345,6 +371,12 @@ actor LANraragiService {
         session.request("\(url)/api/minion/\(id)/detail", method: .get)
                 .validate(statusCode: 200...200)
                 .serializingDecodable(JobStatus.self)
+    }
+
+    func checkBasicJobStatus(id: Int) async -> DataTask<BasicJobStatus> {
+        session.request("\(url)/api/minion/\(id)", method: .get)
+            .validate(statusCode: 200...200)
+            .serializingDecodable(BasicJobStatus.self)
     }
 
     func databaseBackup() async -> DataTask<DatabaseBackup> {

--- a/LANreaderTests/ArchiveReaderFeatureTests.swift
+++ b/LANreaderTests/ArchiveReaderFeatureTests.swift
@@ -1,12 +1,19 @@
 import XCTest
 import ComposableArchitecture
+import OHHTTPStubs
+import OHHTTPStubsSwift
 @testable import LANreader
+
+// swiftlint:disable type_body_length file_length
 
 final class ArchiveReaderFeatureTests: XCTestCase {
     override func tearDown() {
         UserDefaults.standard.removeObject(forKey: SettingsKey.readDirection)
         UserDefaults.standard.removeObject(forKey: SettingsKey.doublePageLayout)
         UserDefaults.standard.removeObject(forKey: SettingsKey.autoPageInterval)
+        UserDefaults.standard.removeObject(forKey: SettingsKey.lanraragiUrl)
+        UserDefaults.standard.removeObject(forKey: SettingsKey.lanraragiApiKey)
+        HTTPStubs.removeAllStubs()
         super.tearDown()
     }
 
@@ -208,6 +215,8 @@ final class ArchiveReaderFeatureTests: XCTestCase {
     @MainActor
     func testFinishExtractingVerticalModeIgnoresDoublePageLayout() async {
         configureReaderDefaults(readDirection: .upDown, doublePageLayout: true)
+        try? await configureVerifiedClient()
+        stubPageThumbnailQueueAlreadyGenerated()
         let store = makeTestStore(
             initialState: makeState(
                 progress: 3,
@@ -229,11 +238,20 @@ final class ArchiveReaderFeatureTests: XCTestCase {
                 animated: false
             )
         }
+        await store.receive(.prepareSliderPreviewThumbnails) {
+            $0.sliderThumbnailQueueing = true
+        }
+        await store.receive(.sliderPreviewThumbnailsQueued(makeAlreadyGeneratedThumbnailQueueResponse())) {
+            $0.sliderThumbnailQueueing = false
+            $0.sliderReadyThumbnailPages = Set([1, 2, 3, 4, 5])
+        }
     }
 
     @MainActor
     func testFinishExtractingRestoresSavedProgressAndQueuesInitialScroll() async {
         configureReaderDefaults()
+        try? await configureVerifiedClient()
+        stubPageThumbnailQueueAlreadyGenerated()
         let store = makeTestStore(initialState: makeState(progress: 3))
 
         await store.send(.finishExtracting(makeExtractedPages(count: 5))) {
@@ -249,11 +267,20 @@ final class ArchiveReaderFeatureTests: XCTestCase {
                 animated: false
             )
         }
+        await store.receive(.prepareSliderPreviewThumbnails) {
+            $0.sliderThumbnailQueueing = true
+        }
+        await store.receive(.sliderPreviewThumbnailsQueued(makeAlreadyGeneratedThumbnailQueueResponse())) {
+            $0.sliderThumbnailQueueing = false
+            $0.sliderReadyThumbnailPages = Set([1, 2, 3, 4, 5])
+        }
     }
 
     @MainActor
     func testFinishExtractingFromStartStartsAtFirstPage() async {
         configureReaderDefaults()
+        try? await configureVerifiedClient()
+        stubPageThumbnailQueueAlreadyGenerated()
         let store = makeTestStore(initialState: makeState(progress: 4, fromStart: true))
 
         await store.send(.finishExtracting(makeExtractedPages(count: 5))) {
@@ -268,11 +295,20 @@ final class ArchiveReaderFeatureTests: XCTestCase {
                 animated: false
             )
         }
+        await store.receive(.prepareSliderPreviewThumbnails) {
+            $0.sliderThumbnailQueueing = true
+        }
+        await store.receive(.sliderPreviewThumbnailsQueued(makeAlreadyGeneratedThumbnailQueueResponse())) {
+            $0.sliderThumbnailQueueing = false
+            $0.sliderReadyThumbnailPages = Set([1, 2, 3, 4, 5])
+        }
     }
 
     @MainActor
     func testFinishExtractingClampsOutOfRangeProgress() async {
         configureReaderDefaults()
+        try? await configureVerifiedClient()
+        stubPageThumbnailQueueAlreadyGenerated()
         let store = makeTestStore(initialState: makeState(progress: 99))
 
         await store.send(.finishExtracting(makeExtractedPages(count: 4))) {
@@ -287,6 +323,13 @@ final class ArchiveReaderFeatureTests: XCTestCase {
                 source: .initialRestore,
                 animated: false
             )
+        }
+        await store.receive(.prepareSliderPreviewThumbnails) {
+            $0.sliderThumbnailQueueing = true
+        }
+        await store.receive(.sliderPreviewThumbnailsQueued(makeAlreadyGeneratedThumbnailQueueResponse())) {
+            $0.sliderThumbnailQueueing = false
+            $0.sliderReadyThumbnailPages = Set([1, 2, 3, 4])
         }
     }
 
@@ -393,6 +436,8 @@ final class ArchiveReaderFeatureTests: XCTestCase {
 
         let store = Store(initialState: initialState) {
             ArchiveReaderFeature()
+        } withDependencies: {
+            $0.continuousClock = ImmediateClock()
         }
         let controller = UIPageCollectionController(store: store)
 
@@ -411,6 +456,8 @@ final class ArchiveReaderFeatureTests: XCTestCase {
 
         let store = Store(initialState: initialState) {
             ArchiveReaderFeature()
+        } withDependencies: {
+            $0.continuousClock = ImmediateClock()
         }
         let controller = UIPageCollectionController(store: store)
 
@@ -453,6 +500,341 @@ final class ArchiveReaderFeatureTests: XCTestCase {
         }
     }
 
+    @MainActor
+    func testSliderPreviewQueuedResponseStoresJobId() async {
+        configureReaderDefaults()
+        var initialState = makeState(progress: 2)
+        initialState.pages = makePageStates(count: 4)
+        let store = makeTestStore(initialState: initialState)
+
+        await store.send(
+            .sliderPreviewThumbnailsQueued(
+                PageThumbnailQueueResponse(
+                    job: 42,
+                    message: nil,
+                    operation: "generate_page_thumbnails",
+                    success: 1
+                )
+            )
+        ) {
+            $0.sliderThumbnailJobId = 42
+        }
+        await store.receive(.pollSliderPreviewThumbnailJob(42))
+        await store.receive(.sliderPreviewThumbnailPollingFailed) {
+            $0.sliderThumbnailJobId = nil
+        }
+    }
+
+    @MainActor
+    func testPrepareSliderPreviewThumbnailsUsesUniqueArchivePageCountWhenPagesAreSplit() async {
+        configureReaderDefaults()
+        var initialState = makeState(progress: 2)
+        initialState.pages = makeSplitPageStates()
+        initialState.sliderReadyThumbnailPages = Set([1, 2, 3])
+        let store = makeTestStore(initialState: initialState)
+
+        await store.send(.prepareSliderPreviewThumbnails)
+    }
+
+    @MainActor
+    func testSliderPreviewQueuedResponseUsesUniqueArchivePageCountWhenPagesAreSplit() async {
+        configureReaderDefaults()
+        var initialState = makeState(progress: 2)
+        initialState.pages = makeSplitPageStates()
+        let store = makeTestStore(initialState: initialState)
+
+        await store.send(
+            .sliderPreviewThumbnailsQueued(
+                PageThumbnailQueueResponse(
+                    job: 42,
+                    message: nil,
+                    operation: "generate_page_thumbnails",
+                    success: 1
+                )
+            )
+        ) {
+            $0.sliderThumbnailJobId = 42
+        }
+        await store.receive(.pollSliderPreviewThumbnailJob(42))
+        await store.receive(.sliderPreviewThumbnailPollingFailed) {
+            $0.sliderThumbnailJobId = nil
+        }
+    }
+
+    @MainActor
+    func testSliderPreviewFinishedJobStatusMarksReadyPages() async {
+        configureReaderDefaults()
+        var initialState = makeState(progress: 2)
+        initialState.pages = makePageStates(count: 4)
+        initialState.sliderThumbnailJobId = 42
+        let store = makeTestStore(initialState: initialState)
+
+        await store.send(
+            .sliderPreviewThumbnailJobStatus(
+                BasicJobStatus(
+                    task: "generate_page_thumbnails",
+                    state: "finished",
+                    notes: [
+                        "1": .string("processed"),
+                        "2": .string("processed"),
+                        "3": .string("processed"),
+                        "4": .string("processed"),
+                        "total_pages": .int(4)
+                    ],
+                    error: ""
+                )
+            )
+        ) {
+            $0.sliderThumbnailJobId = nil
+            $0.sliderReadyThumbnailPages = Set([1, 2, 3, 4])
+        }
+    }
+
+    @MainActor
+    func testSliderPreviewFinishedJobStatusUsesUniqueArchivePageCountWhenPagesAreSplit() async {
+        configureReaderDefaults()
+        var initialState = makeState(progress: 2)
+        initialState.pages = makeSplitPageStates()
+        initialState.sliderThumbnailJobId = 42
+        let store = makeTestStore(initialState: initialState)
+
+        await store.send(
+            .sliderPreviewThumbnailJobStatus(
+                BasicJobStatus(
+                    task: "generate_page_thumbnails",
+                    state: "finished",
+                    notes: [
+                        "1": .string("processed"),
+                        "2": .string("processed")
+                    ],
+                    error: ""
+                )
+            )
+        ) {
+            $0.sliderThumbnailJobId = nil
+            $0.sliderReadyThumbnailPages = Set([1, 2, 3])
+        }
+    }
+
+    @MainActor
+    func testSliderPreviewInactiveJobStatusStopsPollingAndClearsJobId() async {
+        configureReaderDefaults()
+        var initialState = makeState(progress: 2)
+        initialState.pages = makePageStates(count: 4)
+        initialState.sliderThumbnailJobId = 42
+        initialState.sliderPreviewLoading = true
+        let store = makeTestStore(initialState: initialState)
+
+        await store.send(
+            .sliderPreviewThumbnailJobStatus(
+                BasicJobStatus(
+                    task: "generate_page_thumbnails",
+                    state: "inactive",
+                    notes: [
+                        "1": .string("processed")
+                    ],
+                    error: ""
+                )
+            )
+        ) {
+            $0.sliderThumbnailJobId = nil
+            $0.sliderReadyThumbnailPages = Set([1])
+            $0.sliderPreviewLoading = false
+        }
+    }
+
+    @MainActor
+    func testSliderPreviewAlreadyGeneratedMarksAllPagesReady() async {
+        configureReaderDefaults()
+        var initialState = makeState(progress: 2)
+        initialState.pages = makePageStates(count: 4)
+        let store = makeTestStore(initialState: initialState)
+
+        await store.send(
+            .sliderPreviewThumbnailsQueued(
+                PageThumbnailQueueResponse(
+                    job: nil,
+                    message: "No job queued, all thumbnails already exist.",
+                    operation: "generate_page_thumbnails",
+                    success: 1
+                )
+            )
+        ) {
+            $0.sliderReadyThumbnailPages = Set([1, 2, 3, 4])
+        }
+    }
+
+    @MainActor
+    func testSliderPreviewQueueFailureAllowsLaterRetry() async throws {
+        configureReaderDefaults()
+        try await configureVerifiedClient()
+        stubPageThumbnailQueueFailure()
+
+        var initialState = makeState(progress: 2)
+        initialState.pages = makePageStates(count: 4)
+        initialState.sliderPreviewVisible = true
+        initialState.sliderPreviewPageIndex = 1
+        let store = makeTestStore(initialState: initialState)
+
+        await store.send(.loadSliderPreview(1)) {
+            $0.sliderPreviewImageURL = nil
+            $0.sliderPreviewLoading = true
+        }
+        await store.receive(.prepareSliderPreviewThumbnails) {
+            $0.sliderThumbnailQueueing = true
+        }
+        await store.receive(.sliderPreviewThumbnailQueueFailed) {
+            $0.sliderThumbnailQueueing = false
+            $0.sliderPreviewLoading = false
+        }
+
+        await store.send(.loadSliderPreview(1)) {
+            $0.sliderPreviewImageURL = nil
+            $0.sliderPreviewLoading = true
+        }
+        await store.receive(.prepareSliderPreviewThumbnails) {
+            $0.sliderThumbnailQueueing = true
+        }
+        await store.receive(.sliderPreviewThumbnailQueueFailed) {
+            $0.sliderThumbnailQueueing = false
+            $0.sliderPreviewLoading = false
+        }
+    }
+
+    @MainActor
+    func testSliderDragChangedUpdatesPreviewStateWithoutJump() async {
+        configureReaderDefaults()
+        var initialState = makeState(progress: 2)
+        initialState.pages = makePageStates(count: 4)
+        initialState.currentPageIndex = 1
+        let store = makeTestStore(initialState: initialState)
+
+        await store.send(.sliderDragStarted) {
+            $0.sliderDragging = true
+            $0.sliderDraftIndex = 1
+            $0.sliderPreviewVisible = true
+            $0.sliderPreviewPageIndex = 1
+        }
+        await store.receive(.loadSliderPreview(1)) {
+            $0.sliderPreviewLoading = true
+        }
+        await store.receive(.prepareSliderPreviewThumbnails) {
+            $0.sliderThumbnailQueueing = true
+        }
+        await store.receive(.sliderPreviewThumbnailQueueFailed) {
+            $0.sliderThumbnailQueueing = false
+            $0.sliderPreviewLoading = false
+        }
+
+        await store.send(.sliderDragChanged(3)) {
+            $0.sliderDraftIndex = 3
+            $0.sliderPreviewPageIndex = 3
+        }
+        await store.receive(.loadSliderPreview(3)) {
+            $0.sliderPreviewLoading = true
+        }
+        await store.receive(.prepareSliderPreviewThumbnails) {
+            $0.sliderThumbnailQueueing = true
+        }
+        await store.receive(.sliderPreviewThumbnailQueueFailed) {
+            $0.sliderThumbnailQueueing = false
+            $0.sliderPreviewLoading = false
+        }
+    }
+
+    @MainActor
+    func testSliderDragEndedQueuesSliderJumpAndClearsPreviewState() async {
+        configureReaderDefaults()
+        var initialState = makeState(progress: 2)
+        initialState.pages = makePageStates(count: 4)
+        initialState.sliderDraftIndex = 3
+        initialState.sliderDragging = true
+        initialState.sliderPreviewVisible = true
+        initialState.sliderPreviewPageIndex = 3
+        initialState.sliderPreviewLoading = true
+        let store = makeTestStore(initialState: initialState)
+
+        await store.send(.sliderDragEnded) {
+            $0.sliderDraftIndex = nil
+            $0.sliderDragging = false
+            $0.sliderPreviewVisible = false
+            $0.sliderPreviewPageIndex = nil
+            $0.sliderPreviewImageURL = nil
+            $0.sliderPreviewLoading = false
+        }
+        await store.receive(.requestJump(3, source: .slider)) {
+            $0.scrollRequest = makeScrollRequest(
+                id: 0,
+                targetPageIndex: 3,
+                source: .slider,
+                animated: false
+            )
+        }
+    }
+
+    @MainActor
+    func testSliderDragChangeAfterEndDoesNotReopenPreview() async {
+        configureReaderDefaults()
+        var initialState = makeState(progress: 2)
+        initialState.pages = makePageStates(count: 4)
+        initialState.sliderDraftIndex = 3
+        initialState.sliderDragging = true
+        initialState.sliderPreviewVisible = true
+        initialState.sliderPreviewPageIndex = 3
+        let store = makeTestStore(initialState: initialState)
+
+        await store.send(.sliderDragEnded) {
+            $0.sliderDraftIndex = nil
+            $0.sliderDragging = false
+            $0.sliderPreviewVisible = false
+            $0.sliderPreviewPageIndex = nil
+            $0.sliderPreviewImageURL = nil
+            $0.sliderPreviewLoading = false
+        }
+        await store.receive(.requestJump(3, source: .slider)) {
+            $0.scrollRequest = makeScrollRequest(
+                id: 0,
+                targetPageIndex: 3,
+                source: .slider,
+                animated: false
+            )
+        }
+
+        await store.send(.sliderDragChanged(3))
+    }
+
+    @MainActor
+    func testSliderPreviewFailedKeepsExistingPreviewFile() async throws {
+        configureReaderDefaults()
+        let archiveId = UUID().uuidString
+        var initialState = makeState(archiveId: archiveId, progress: 2)
+        initialState.pages = makePageStates(count: 4, archiveId: archiveId)
+        initialState.sliderPreviewVisible = true
+        initialState.sliderPreviewPageIndex = 1
+
+        let previewDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LANreader", isDirectory: true)
+            .appendingPathComponent("reader-preview", isDirectory: true)
+            .appendingPathComponent(archiveId, isDirectory: true)
+        let previewURL = previewDirectory.appendingPathComponent("2.jpg", isDirectory: false)
+        try FileManager.default.createDirectory(
+            at: previewDirectory,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+        try Data([0xFF, 0xD8, 0xFF, 0xD9]).write(to: previewURL, options: .atomic)
+        defer {
+            try? FileManager.default.removeItem(at: previewDirectory)
+        }
+
+        let store = makeTestStore(initialState: initialState)
+
+        await store.send(.sliderPreviewFailed(1)) {
+            $0.sliderPreviewImageURL = previewURL
+            $0.sliderPreviewLoading = false
+        }
+    }
+
     func testResetStateClearsTransientReaderState() {
         configureReaderDefaults()
         var state = makeState(
@@ -469,6 +851,15 @@ final class ArchiveReaderFeatureTests: XCTestCase {
         state.inCache = true
         state.errorMessage = "error"
         state.successMessage = "success"
+        state.sliderDraftIndex = 1
+        state.sliderDragging = true
+        state.sliderPreviewVisible = true
+        state.sliderPreviewPageIndex = 1
+        state.sliderPreviewImageURL = URL(fileURLWithPath: "/tmp/preview.jpg")
+        state.sliderPreviewLoading = true
+        state.sliderThumbnailQueueing = true
+        state.sliderThumbnailJobId = 42
+        state.sliderReadyThumbnailPages = Set([1, 2])
 
         ArchiveReaderFeature().resetState(state: &state)
 
@@ -478,6 +869,15 @@ final class ArchiveReaderFeatureTests: XCTestCase {
         XCTAssertFalse(state.inCache)
         XCTAssertEqual(state.errorMessage, "")
         XCTAssertEqual(state.successMessage, "")
+        XCTAssertNil(state.sliderDraftIndex)
+        XCTAssertFalse(state.sliderDragging)
+        XCTAssertFalse(state.sliderPreviewVisible)
+        XCTAssertNil(state.sliderPreviewPageIndex)
+        XCTAssertNil(state.sliderPreviewImageURL)
+        XCTAssertFalse(state.sliderPreviewLoading)
+        XCTAssertFalse(state.sliderThumbnailQueueing)
+        XCTAssertNil(state.sliderThumbnailJobId)
+        XCTAssertTrue(state.sliderReadyThumbnailPages.isEmpty)
     }
 }
 
@@ -489,6 +889,79 @@ private func configureReaderDefaults(
     UserDefaults.standard.set(readDirection.rawValue, forKey: SettingsKey.readDirection)
     UserDefaults.standard.set(doublePageLayout, forKey: SettingsKey.doublePageLayout)
     UserDefaults.standard.set(autoPageInterval, forKey: SettingsKey.autoPageInterval)
+}
+
+private func configureVerifiedClient() async throws {
+    let url = "https://localhost"
+    let apiKey = "apiKey"
+    UserDefaults.standard.set(url, forKey: SettingsKey.lanraragiUrl)
+    UserDefaults.standard.set(apiKey, forKey: SettingsKey.lanraragiApiKey)
+
+    stub(condition: isHost("localhost")
+            && isPath("/api/info")
+            && isMethodGET()
+            && hasHeaderNamed("Authorization", value: "Bearer YXBpS2V5")) { _ in
+        HTTPStubsResponse(
+            data: Data("""
+            {
+              "archives_per_page": 100,
+              "debug_mode": false,
+              "has_password": true,
+              "motd": "",
+              "name": "LANraragi",
+              "nofun_mode": false,
+              "server_tracks_progress": true,
+              "version": "0.9.30",
+              "version_name": "Law (Earthlings On Fire)"
+            }
+            """.utf8),
+            statusCode: 200,
+            headers: ["Content-Type": "application/json"]
+        )
+    }
+
+    _ = try await LANraragiService.shared.verifyClient(url: url, apiKey: apiKey)
+}
+
+private func stubPageThumbnailQueueAlreadyGenerated(archiveId: String = "archive") {
+    stub(condition: isHost("localhost")
+            && isPath("/api/archives/\(archiveId)/files/thumbnails")
+            && isMethodPOST()
+            && hasHeaderNamed("Authorization", value: "Bearer YXBpS2V5")) { _ in
+        HTTPStubsResponse(
+            data: Data("""
+            {
+              "message": "No job queued, all thumbnails already exist.",
+              "operation": "generate_page_thumbnails",
+              "success": 1
+            }
+            """.utf8),
+            statusCode: 200,
+            headers: ["Content-Type": "application/json"]
+        )
+    }
+}
+
+private func stubPageThumbnailQueueFailure(archiveId: String = "archive") {
+    stub(condition: isHost("localhost")
+            && isPath("/api/archives/\(archiveId)/files/thumbnails")
+            && isMethodPOST()
+            && hasHeaderNamed("Authorization", value: "Bearer YXBpS2V5")) { _ in
+        HTTPStubsResponse(
+            data: Data(),
+            statusCode: 500,
+            headers: ["Content-Type": "application/json"]
+        )
+    }
+}
+
+private func makeAlreadyGeneratedThumbnailQueueResponse() -> PageThumbnailQueueResponse {
+    PageThumbnailQueueResponse(
+        job: nil,
+        message: "No job queued, all thumbnails already exist.",
+        operation: "generate_page_thumbnails",
+        success: 1
+    )
 }
 
 @MainActor
@@ -581,3 +1054,37 @@ private func makePageStates(
         }
     )
 }
+
+private func makeSplitPageStates(
+    archiveId: String = "archive"
+) -> IdentifiedArrayOf<PageFeature.State> {
+    IdentifiedArray(
+        uniqueElements: [
+            PageFeature.State(
+                archiveId: archiveId,
+                pageId: "1",
+                pageNumber: 1,
+                pageMode: .normal
+            ),
+            PageFeature.State(
+                archiveId: archiveId,
+                pageId: "2",
+                pageNumber: 2,
+                pageMode: .left
+            ),
+            PageFeature.State(
+                archiveId: archiveId,
+                pageId: "2",
+                pageNumber: 2,
+                pageMode: .right
+            ),
+            PageFeature.State(
+                archiveId: archiveId,
+                pageId: "3",
+                pageNumber: 3,
+                pageMode: .normal
+            )
+        ]
+    )
+}
+// swiftlint:enable type_body_length file_length

--- a/LANreaderTests/ArchiveReaderFeatureTests.swift
+++ b/LANreaderTests/ArchiveReaderFeatureTests.swift
@@ -212,11 +212,94 @@ final class ArchiveReaderFeatureTests: XCTestCase {
         )
     }
 
+    func testSliderPreviewPositioningMirrorsVisualNormalizedInRTL() {
+        XCTAssertEqual(
+            SliderPreviewPositioning.visualNormalized(
+                pageIndex: 0,
+                pageCount: 5,
+                isRightToLeft: false
+            ),
+            0,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            SliderPreviewPositioning.visualNormalized(
+                pageIndex: 0,
+                pageCount: 5,
+                isRightToLeft: true
+            ),
+            1,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            SliderPreviewPositioning.visualNormalized(
+                pageIndex: 4,
+                pageCount: 5,
+                isRightToLeft: true
+            ),
+            0,
+            accuracy: 0.001
+        )
+    }
+
+    func testSliderPreviewPositioningClampsBubbleToRightEdgeInRTL() {
+        XCTAssertEqual(
+            SliderPreviewPositioning.bubbleLeadingX(
+                pageIndex: 0,
+                pageCount: 5,
+                track: SliderPreviewTrackGeometry(
+                    rowWidth: 320,
+                    sliderHorizontalPadding: 16,
+                    bubbleWidth: 100
+                ),
+                isRightToLeft: true
+            ),
+            220,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            SliderPreviewPositioning.bubbleLeadingX(
+                pageIndex: 0,
+                pageCount: 5,
+                track: SliderPreviewTrackGeometry(
+                    rowWidth: 320,
+                    sliderHorizontalPadding: 16,
+                    bubbleWidth: 100
+                ),
+                isRightToLeft: false
+            ),
+            0,
+            accuracy: 0.001
+        )
+    }
+
+    func testSliderPreviewPositioningMapsRightEdgeToFirstPageInRTL() {
+        XCTAssertEqual(
+            SliderPreviewPositioning.pageIndex(
+                at: 304,
+                sliderWidth: 288,
+                horizontalPadding: 16,
+                sliderMaxIndex: 4,
+                isRightToLeft: true
+            ),
+            0
+        )
+        XCTAssertEqual(
+            SliderPreviewPositioning.pageIndex(
+                at: 16,
+                sliderWidth: 288,
+                horizontalPadding: 16,
+                sliderMaxIndex: 4,
+                isRightToLeft: true
+            ),
+            4
+        )
+    }
+
     @MainActor
-    func testFinishExtractingVerticalModeIgnoresDoublePageLayout() async {
+    func testFinishExtractingVerticalModeIgnoresDoublePageLayout() async throws {
         configureReaderDefaults(readDirection: .upDown, doublePageLayout: true)
-        try? await configureVerifiedClient()
-        stubPageThumbnailQueueAlreadyGenerated()
+        try await configureReadyThumbnailQueue()
         let store = makeTestStore(
             initialState: makeState(
                 progress: 3,
@@ -238,20 +321,25 @@ final class ArchiveReaderFeatureTests: XCTestCase {
                 animated: false
             )
         }
-        await store.receive(.prepareSliderPreviewThumbnails) {
-            $0.sliderThumbnailQueueing = true
-        }
-        await store.receive(.sliderPreviewThumbnailsQueued(makeAlreadyGeneratedThumbnailQueueResponse())) {
-            $0.sliderThumbnailQueueing = false
+        await store.receive(.prepareSliderPreviewThumbnails)
+        await store.receive(
+            .sliderPreviewThumbnailsQueued(
+                PageThumbnailQueueResponse(
+                    job: nil,
+                    message: "No job queued, all thumbnails already exist.",
+                    operation: "generate_page_thumbnails",
+                    success: 1
+                )
+            )
+        ) {
             $0.sliderReadyThumbnailPages = Set([1, 2, 3, 4, 5])
         }
     }
 
     @MainActor
-    func testFinishExtractingRestoresSavedProgressAndQueuesInitialScroll() async {
+    func testFinishExtractingRestoresSavedProgressAndQueuesInitialScroll() async throws {
         configureReaderDefaults()
-        try? await configureVerifiedClient()
-        stubPageThumbnailQueueAlreadyGenerated()
+        try await configureReadyThumbnailQueue()
         let store = makeTestStore(initialState: makeState(progress: 3))
 
         await store.send(.finishExtracting(makeExtractedPages(count: 5))) {
@@ -267,20 +355,25 @@ final class ArchiveReaderFeatureTests: XCTestCase {
                 animated: false
             )
         }
-        await store.receive(.prepareSliderPreviewThumbnails) {
-            $0.sliderThumbnailQueueing = true
-        }
-        await store.receive(.sliderPreviewThumbnailsQueued(makeAlreadyGeneratedThumbnailQueueResponse())) {
-            $0.sliderThumbnailQueueing = false
+        await store.receive(.prepareSliderPreviewThumbnails)
+        await store.receive(
+            .sliderPreviewThumbnailsQueued(
+                PageThumbnailQueueResponse(
+                    job: nil,
+                    message: "No job queued, all thumbnails already exist.",
+                    operation: "generate_page_thumbnails",
+                    success: 1
+                )
+            )
+        ) {
             $0.sliderReadyThumbnailPages = Set([1, 2, 3, 4, 5])
         }
     }
 
     @MainActor
-    func testFinishExtractingFromStartStartsAtFirstPage() async {
+    func testFinishExtractingFromStartStartsAtFirstPage() async throws {
         configureReaderDefaults()
-        try? await configureVerifiedClient()
-        stubPageThumbnailQueueAlreadyGenerated()
+        try await configureReadyThumbnailQueue()
         let store = makeTestStore(initialState: makeState(progress: 4, fromStart: true))
 
         await store.send(.finishExtracting(makeExtractedPages(count: 5))) {
@@ -295,20 +388,25 @@ final class ArchiveReaderFeatureTests: XCTestCase {
                 animated: false
             )
         }
-        await store.receive(.prepareSliderPreviewThumbnails) {
-            $0.sliderThumbnailQueueing = true
-        }
-        await store.receive(.sliderPreviewThumbnailsQueued(makeAlreadyGeneratedThumbnailQueueResponse())) {
-            $0.sliderThumbnailQueueing = false
+        await store.receive(.prepareSliderPreviewThumbnails)
+        await store.receive(
+            .sliderPreviewThumbnailsQueued(
+                PageThumbnailQueueResponse(
+                    job: nil,
+                    message: "No job queued, all thumbnails already exist.",
+                    operation: "generate_page_thumbnails",
+                    success: 1
+                )
+            )
+        ) {
             $0.sliderReadyThumbnailPages = Set([1, 2, 3, 4, 5])
         }
     }
 
     @MainActor
-    func testFinishExtractingClampsOutOfRangeProgress() async {
+    func testFinishExtractingClampsOutOfRangeProgress() async throws {
         configureReaderDefaults()
-        try? await configureVerifiedClient()
-        stubPageThumbnailQueueAlreadyGenerated()
+        try await configureReadyThumbnailQueue()
         let store = makeTestStore(initialState: makeState(progress: 99))
 
         await store.send(.finishExtracting(makeExtractedPages(count: 4))) {
@@ -324,11 +422,17 @@ final class ArchiveReaderFeatureTests: XCTestCase {
                 animated: false
             )
         }
-        await store.receive(.prepareSliderPreviewThumbnails) {
-            $0.sliderThumbnailQueueing = true
-        }
-        await store.receive(.sliderPreviewThumbnailsQueued(makeAlreadyGeneratedThumbnailQueueResponse())) {
-            $0.sliderThumbnailQueueing = false
+        await store.receive(.prepareSliderPreviewThumbnails)
+        await store.receive(
+            .sliderPreviewThumbnailsQueued(
+                PageThumbnailQueueResponse(
+                    job: nil,
+                    message: "No job queued, all thumbnails already exist.",
+                    operation: "generate_page_thumbnails",
+                    success: 1
+                )
+            )
+        ) {
             $0.sliderReadyThumbnailPages = Set([1, 2, 3, 4])
         }
     }
@@ -501,8 +605,9 @@ final class ArchiveReaderFeatureTests: XCTestCase {
     }
 
     @MainActor
-    func testSliderPreviewQueuedResponseStoresJobId() async {
+    func testSliderPreviewQueuedResponseStoresJobId() async throws {
         configureReaderDefaults()
+        try await configureFinishedThumbnailPolling(jobId: 42)
         var initialState = makeState(progress: 2)
         initialState.pages = makePageStates(count: 4)
         let store = makeTestStore(initialState: initialState)
@@ -520,8 +625,18 @@ final class ArchiveReaderFeatureTests: XCTestCase {
             $0.sliderThumbnailJobId = 42
         }
         await store.receive(.pollSliderPreviewThumbnailJob(42))
-        await store.receive(.sliderPreviewThumbnailPollingFailed) {
+        await store.receive(
+            .sliderPreviewThumbnailJobStatus(
+                BasicJobStatus(
+                    task: "generate_page_thumbnails",
+                    state: "finished",
+                    notes: [:],
+                    error: ""
+                )
+            )
+        ) {
             $0.sliderThumbnailJobId = nil
+            $0.sliderReadyThumbnailPages = Set([1, 2, 3, 4])
         }
     }
 
@@ -537,8 +652,9 @@ final class ArchiveReaderFeatureTests: XCTestCase {
     }
 
     @MainActor
-    func testSliderPreviewQueuedResponseUsesUniqueArchivePageCountWhenPagesAreSplit() async {
+    func testSliderPreviewQueuedResponseUsesUniqueArchivePageCountWhenPagesAreSplit() async throws {
         configureReaderDefaults()
+        try await configureFinishedThumbnailPolling(jobId: 42)
         var initialState = makeState(progress: 2)
         initialState.pages = makeSplitPageStates()
         let store = makeTestStore(initialState: initialState)
@@ -556,8 +672,18 @@ final class ArchiveReaderFeatureTests: XCTestCase {
             $0.sliderThumbnailJobId = 42
         }
         await store.receive(.pollSliderPreviewThumbnailJob(42))
-        await store.receive(.sliderPreviewThumbnailPollingFailed) {
+        await store.receive(
+            .sliderPreviewThumbnailJobStatus(
+                BasicJobStatus(
+                    task: "generate_page_thumbnails",
+                    state: "finished",
+                    notes: [:],
+                    error: ""
+                )
+            )
+        ) {
             $0.sliderThumbnailJobId = nil
+            $0.sliderReadyThumbnailPages = Set([1, 2, 3])
         }
     }
 
@@ -617,33 +743,6 @@ final class ArchiveReaderFeatureTests: XCTestCase {
     }
 
     @MainActor
-    func testSliderPreviewInactiveJobStatusStopsPollingAndClearsJobId() async {
-        configureReaderDefaults()
-        var initialState = makeState(progress: 2)
-        initialState.pages = makePageStates(count: 4)
-        initialState.sliderThumbnailJobId = 42
-        initialState.sliderPreviewLoading = true
-        let store = makeTestStore(initialState: initialState)
-
-        await store.send(
-            .sliderPreviewThumbnailJobStatus(
-                BasicJobStatus(
-                    task: "generate_page_thumbnails",
-                    state: "inactive",
-                    notes: [
-                        "1": .string("processed")
-                    ],
-                    error: ""
-                )
-            )
-        ) {
-            $0.sliderThumbnailJobId = nil
-            $0.sliderReadyThumbnailPages = Set([1])
-            $0.sliderPreviewLoading = false
-        }
-    }
-
-    @MainActor
     func testSliderPreviewAlreadyGeneratedMarksAllPagesReady() async {
         configureReaderDefaults()
         var initialState = makeState(progress: 2)
@@ -665,43 +764,6 @@ final class ArchiveReaderFeatureTests: XCTestCase {
     }
 
     @MainActor
-    func testSliderPreviewQueueFailureAllowsLaterRetry() async throws {
-        configureReaderDefaults()
-        try await configureVerifiedClient()
-        stubPageThumbnailQueueFailure()
-
-        var initialState = makeState(progress: 2)
-        initialState.pages = makePageStates(count: 4)
-        initialState.sliderPreviewVisible = true
-        initialState.sliderPreviewPageIndex = 1
-        let store = makeTestStore(initialState: initialState)
-
-        await store.send(.loadSliderPreview(1)) {
-            $0.sliderPreviewImageURL = nil
-            $0.sliderPreviewLoading = true
-        }
-        await store.receive(.prepareSliderPreviewThumbnails) {
-            $0.sliderThumbnailQueueing = true
-        }
-        await store.receive(.sliderPreviewThumbnailQueueFailed) {
-            $0.sliderThumbnailQueueing = false
-            $0.sliderPreviewLoading = false
-        }
-
-        await store.send(.loadSliderPreview(1)) {
-            $0.sliderPreviewImageURL = nil
-            $0.sliderPreviewLoading = true
-        }
-        await store.receive(.prepareSliderPreviewThumbnails) {
-            $0.sliderThumbnailQueueing = true
-        }
-        await store.receive(.sliderPreviewThumbnailQueueFailed) {
-            $0.sliderThumbnailQueueing = false
-            $0.sliderPreviewLoading = false
-        }
-    }
-
-    @MainActor
     func testSliderDragChangedUpdatesPreviewStateWithoutJump() async {
         configureReaderDefaults()
         var initialState = makeState(progress: 2)
@@ -715,31 +777,13 @@ final class ArchiveReaderFeatureTests: XCTestCase {
             $0.sliderPreviewVisible = true
             $0.sliderPreviewPageIndex = 1
         }
-        await store.receive(.loadSliderPreview(1)) {
-            $0.sliderPreviewLoading = true
-        }
-        await store.receive(.prepareSliderPreviewThumbnails) {
-            $0.sliderThumbnailQueueing = true
-        }
-        await store.receive(.sliderPreviewThumbnailQueueFailed) {
-            $0.sliderThumbnailQueueing = false
-            $0.sliderPreviewLoading = false
-        }
+        await store.receive(.loadSliderPreview(1))
 
         await store.send(.sliderDragChanged(3)) {
             $0.sliderDraftIndex = 3
             $0.sliderPreviewPageIndex = 3
         }
-        await store.receive(.loadSliderPreview(3)) {
-            $0.sliderPreviewLoading = true
-        }
-        await store.receive(.prepareSliderPreviewThumbnails) {
-            $0.sliderThumbnailQueueing = true
-        }
-        await store.receive(.sliderPreviewThumbnailQueueFailed) {
-            $0.sliderThumbnailQueueing = false
-            $0.sliderPreviewLoading = false
-        }
+        await store.receive(.loadSliderPreview(3))
     }
 
     @MainActor
@@ -857,7 +901,6 @@ final class ArchiveReaderFeatureTests: XCTestCase {
         state.sliderPreviewPageIndex = 1
         state.sliderPreviewImageURL = URL(fileURLWithPath: "/tmp/preview.jpg")
         state.sliderPreviewLoading = true
-        state.sliderThumbnailQueueing = true
         state.sliderThumbnailJobId = 42
         state.sliderReadyThumbnailPages = Set([1, 2])
 
@@ -875,7 +918,6 @@ final class ArchiveReaderFeatureTests: XCTestCase {
         XCTAssertNil(state.sliderPreviewPageIndex)
         XCTAssertNil(state.sliderPreviewImageURL)
         XCTAssertFalse(state.sliderPreviewLoading)
-        XCTAssertFalse(state.sliderThumbnailQueueing)
         XCTAssertNil(state.sliderThumbnailJobId)
         XCTAssertTrue(state.sliderReadyThumbnailPages.isEmpty)
     }
@@ -923,11 +965,14 @@ private func configureVerifiedClient() async throws {
     _ = try await LANraragiService.shared.verifyClient(url: url, apiKey: apiKey)
 }
 
-private func stubPageThumbnailQueueAlreadyGenerated(archiveId: String = "archive") {
+private func configureReadyThumbnailQueue(
+    archiveId: String = "archive"
+) async throws {
+    try await configureVerifiedClient()
+
     stub(condition: isHost("localhost")
             && isPath("/api/archives/\(archiveId)/files/thumbnails")
-            && isMethodPOST()
-            && hasHeaderNamed("Authorization", value: "Bearer YXBpS2V5")) { _ in
+            && isMethodPOST()) { _ in
         HTTPStubsResponse(
             data: Data("""
             {
@@ -942,26 +987,27 @@ private func stubPageThumbnailQueueAlreadyGenerated(archiveId: String = "archive
     }
 }
 
-private func stubPageThumbnailQueueFailure(archiveId: String = "archive") {
+private func configureFinishedThumbnailPolling(
+    jobId: Int
+) async throws {
+    try await configureVerifiedClient()
+
     stub(condition: isHost("localhost")
-            && isPath("/api/archives/\(archiveId)/files/thumbnails")
-            && isMethodPOST()
-            && hasHeaderNamed("Authorization", value: "Bearer YXBpS2V5")) { _ in
+            && isPath("/api/minion/\(jobId)")
+            && isMethodGET()) { _ in
         HTTPStubsResponse(
-            data: Data(),
-            statusCode: 500,
+            data: Data("""
+            {
+              "task": "generate_page_thumbnails",
+              "state": "finished",
+              "notes": {},
+              "error": ""
+            }
+            """.utf8),
+            statusCode: 200,
             headers: ["Content-Type": "application/json"]
         )
     }
-}
-
-private func makeAlreadyGeneratedThumbnailQueueResponse() -> PageThumbnailQueueResponse {
-    PageThumbnailQueueResponse(
-        job: nil,
-        message: "No job queued, all thumbnails already exist.",
-        operation: "generate_page_thumbnails",
-        success: 1
-    )
 }
 
 @MainActor

--- a/LANreaderTests/LANreaderTests.swift
+++ b/LANreaderTests/LANreaderTests.swift
@@ -1,28 +1,104 @@
 //  Created 22/8/20.
 
 import XCTest
+import UIKit
+import ImageIO
 @testable import LANreader
 
 class LANreaderTests: XCTestCase {
 
+    private var tempDirectory: URL!
+
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: tempDirectory,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
     }
 
     override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
+        if let tempDirectory {
+            try? FileManager.default.removeItem(at: tempDirectory)
         }
+        tempDirectory = nil
     }
 
+    func testStorePreviewImageRejectsTruncatedJPEGData() throws {
+        let previewURL = tempDirectory.appendingPathComponent("preview.jpg")
+        let service = ImageService.shared
+
+        let truncatedJPEG = makeJPEGData(color: .systemBlue).dropLast(32)
+
+        XCTAssertFalse(service.storePreviewImage(imageData: truncatedJPEG, destinationUrl: previewURL))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: previewURL.path(percentEncoded: false)))
+    }
+
+    func testStorePreviewImageWritesPreviewForCompleteJPEGData() throws {
+        let previewURL = tempDirectory.appendingPathComponent("preview.jpg")
+        let service = ImageService.shared
+        let imageData = makeJPEGData(color: .systemGreen)
+
+        XCTAssertTrue(
+            service.storePreviewImage(
+                imageData: imageData,
+                destinationUrl: previewURL
+            )
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: previewURL.path(percentEncoded: false)))
+        XCTAssertEqual(try Data(contentsOf: previewURL), imageData)
+    }
+
+    func testGeneratePreviewImageWritesBoundedJPEGForTransparentPNG() throws {
+        let sourceURL = tempDirectory.appendingPathComponent("source.png")
+        let previewURL = tempDirectory.appendingPathComponent("preview.jpg")
+        let service = ImageService.shared
+
+        try makeTransparentPNGData().write(to: sourceURL, options: .atomic)
+
+        XCTAssertTrue(
+            service.generatePreviewImage(
+                sourceUrl: sourceURL,
+                destinationUrl: previewURL,
+                maxPixelSize: 64
+            )
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: previewURL.path(percentEncoded: false)))
+
+        let previewData = try Data(contentsOf: previewURL)
+        XCTAssertTrue(previewData.starts(with: [0xFF, 0xD8]))
+
+        let imageSource = CGImageSourceCreateWithURL(previewURL as CFURL, nil)
+        let properties = CGImageSourceCopyPropertiesAtIndex(imageSource!, 0, nil) as? [CFString: Any]
+        let width = properties?[kCGImagePropertyPixelWidth] as? Int
+        let height = properties?[kCGImagePropertyPixelHeight] as? Int
+        XCTAssertEqual(width, 64)
+        XCTAssertEqual(height, 32)
+    }
+}
+
+private func makeJPEGData(color: UIColor) -> Data {
+    let renderer = UIGraphicsImageRenderer(size: CGSize(width: 120, height: 180))
+    let image = renderer.image { context in
+        color.setFill()
+        context.fill(CGRect(x: 0, y: 0, width: 120, height: 180))
+    }
+    return image.jpegData(compressionQuality: 0.9)!
+}
+
+private func makeTransparentPNGData() -> Data {
+    let format = UIGraphicsImageRendererFormat.default()
+    format.opaque = false
+
+    let renderer = UIGraphicsImageRenderer(size: CGSize(width: 200, height: 100), format: format)
+    let image = renderer.image { context in
+        UIColor.clear.setFill()
+        context.fill(CGRect(x: 0, y: 0, width: 200, height: 100))
+
+        UIColor.systemBlue.setFill()
+        context.fill(CGRect(x: 20, y: 20, width: 160, height: 60))
+    }
+    return image.pngData()!
 }

--- a/LANreaderTests/Service/LANraragiServiceTest.swift
+++ b/LANreaderTests/Service/LANraragiServiceTest.swift
@@ -8,6 +8,7 @@ import OHHTTPStubsSwift
 import SwiftUI
 @testable import LANreader
 
+// swiftlint:disable type_body_length
 class LANraragiServiceTest: XCTestCase {
 
     private let url = "https://localhost"
@@ -154,6 +155,105 @@ class LANraragiServiceTest: XCTestCase {
 
         let actual = try await service.retrieveArchiveThumbnail(id: "id")
         XCTAssertNil(actual)
+    }
+
+    func testRetrieveGeneratedArchiveThumbnailReturnsImageData() async throws {
+        try await configureVerifiedClient()
+
+        let expected = Data([0x89, 0x50, 0x4E, 0x47])
+        stub(condition: isHost("localhost")
+                && isPath("/api/archives/id/thumbnail")
+                && containsQueryParams([
+                    "cachebust": "99",
+                    "no_fallback": "true",
+                    "page": "5"
+                ])
+                && isMethodGET()
+                && hasHeaderNamed("Authorization", value: "Bearer YXBpS2V5")) { _ in
+            HTTPStubsResponse(data: expected, statusCode: 200, headers: ["Content-Type": "image/png"])
+        }
+
+        let actual = try await service.retrieveGeneratedArchiveThumbnail(id: "id", page: 5, cacheBust: 99)
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testRetrieveGeneratedArchiveThumbnailReturnsNilWhenNotReady() async throws {
+        try await configureVerifiedClient()
+
+        stub(condition: isHost("localhost")
+                && isPath("/api/archives/id/thumbnail")
+                && containsQueryParams([
+                    "cachebust": "100",
+                    "no_fallback": "true",
+                    "page": "5"
+                ])
+                && isMethodGET()
+                && hasHeaderNamed("Authorization", value: "Bearer YXBpS2V5")) { _ in
+            HTTPStubsResponse(
+                data: Data(),
+                statusCode: 202,
+                headers: ["Content-Type": "application/json"]
+            )
+        }
+
+        let actual = try await service.retrieveGeneratedArchiveThumbnail(id: "id", page: 5, cacheBust: 100)
+        XCTAssertNil(actual)
+    }
+
+    func testQueuePageThumbnailsReturnsQueuedJob() async throws {
+        try await configureVerifiedClient()
+
+        let body = Data("""
+        {
+          "job": 42,
+          "operation": "generate_page_thumbnails",
+          "success": 1
+        }
+        """.utf8)
+        stub(condition: isHost("localhost")
+                && isPath("/api/archives/id/files/thumbnails")
+                && isMethodPOST()
+                && hasHeaderNamed("Authorization", value: "Bearer YXBpS2V5")) { _ in
+            HTTPStubsResponse(
+                data: body,
+                statusCode: 202,
+                headers: ["Content-Type": "application/json"]
+            )
+        }
+
+        let actual = try await service.queuePageThumbnails(id: "id").value
+        XCTAssertEqual(actual.job, 42)
+        XCTAssertNil(actual.message)
+        XCTAssertEqual(actual.operation, "generate_page_thumbnails")
+        XCTAssertEqual(actual.success, 1)
+    }
+
+    func testQueuePageThumbnailsReturnsAlreadyGeneratedMessage() async throws {
+        try await configureVerifiedClient()
+
+        let body = Data("""
+        {
+          "message": "No job queued, all thumbnails already exist.",
+          "operation": "generate_page_thumbnails",
+          "success": 1
+        }
+        """.utf8)
+        stub(condition: isHost("localhost")
+                && isPath("/api/archives/id/files/thumbnails")
+                && isMethodPOST()
+                && hasHeaderNamed("Authorization", value: "Bearer YXBpS2V5")) { _ in
+            HTTPStubsResponse(
+                data: body,
+                statusCode: 200,
+                headers: ["Content-Type": "application/json"]
+            )
+        }
+
+        let actual = try await service.queuePageThumbnails(id: "id").value
+        XCTAssertNil(actual.job)
+        XCTAssertEqual(actual.message, "No job queued, all thumbnails already exist.")
+        XCTAssertEqual(actual.operation, "generate_page_thumbnails")
+        XCTAssertEqual(actual.success, 1)
     }
 
     func testSearchArchive() async throws {
@@ -454,6 +554,40 @@ class LANraragiServiceTest: XCTestCase {
         XCTAssertEqual(actual.result?.message, "Done")
     }
 
+    func testCheckBasicJobStatusDecodesPageThumbnailProgress() async throws {
+        try await configureVerifiedClient()
+
+        let body = Data("""
+        {
+          "state": "active",
+          "task": "generate_page_thumbnails",
+          "notes": {
+            "1": "processed",
+            "3": "processed",
+            "total_pages": 10
+          },
+          "error": ""
+        }
+        """.utf8)
+
+        stub(condition: isHost("localhost")
+                && isPath("/api/minion/9")
+                && isMethodGET()
+                && hasHeaderNamed("Authorization", value: "Bearer YXBpS2V5")) { _ in
+            HTTPStubsResponse(
+                data: body,
+                statusCode: 200,
+                headers: ["Content-Type": "application/json"]
+            )
+        }
+
+        let actual = try await service.checkBasicJobStatus(id: 9).value
+        XCTAssertEqual(actual.state, "active")
+        XCTAssertEqual(actual.task, "generate_page_thumbnails")
+        XCTAssertEqual(actual.processedPages, Set([1, 3]))
+        XCTAssertEqual(actual.error, "")
+    }
+
     func testCheckJobStatusAllowsNumericId() async throws {
         try await configureVerifiedClient()
 
@@ -504,3 +638,4 @@ class LANraragiServiceTest: XCTestCase {
     }
 
 }
+// swiftlint:enable type_body_length

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -2495,23 +2495,6 @@
         }
       }
     },
-    "settings.support.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "💰 Support development"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "💰 支持开发者"
-          }
-        }
-      }
-    },
     "settings.support.reportIssue" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -2525,6 +2508,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在 GitHub 上反馈问题"
+          }
+        }
+      }
+    },
+    "settings.support.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "💰 Support development"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "💰 支持开发者"
           }
         }
       }
@@ -3076,5 +3076,5 @@
       }
     }
   },
-  "version" : "1.0"
+  "version" : "1.1"
 }


### PR DESCRIPTION
## What changed
- added a scrub preview bubble to the reader slider so dragging shows a page preview and the reader only jumps on release
- implemented the LANraragi page-thumbnail flow for reader previews, including queueing thumbnail generation, polling minion job status, and fetching generated page thumbnails
- added local cached-page preview generation and temp-file storage for preview images instead of persisting them in the database
- polished the preview UI and interaction details, including larger iPad sizing, bubble placement above the toolbar, split-page archive page handling, and RTL slider/preview positioning
- simplified the preview state and loading flow, and added focused regression coverage for thumbnail queueing, preview generation, and RTL scrub positioning

## Why
- make slider scrubbing much more usable by showing the destination page before committing the jump
- align the app with LANraragi's generated thumbnail APIs while keeping preview files ephemeral
- harden the reader against regressions in RTL mode and preview loading behavior

## Verification
- /opt/homebrew/bin/swiftlint --strict
- LANREADER_USE_LOCAL_XCODE_ENV=1 ./scripts/test-ios