### PR TITLE
Fix slider preview cleanup

### DIFF
--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -916,7 +916,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreader.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 158;
+				CURRENT_PROJECT_VERSION = 159;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -927,7 +927,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.7.0;
+				MARKETING_VERSION = 3.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -944,7 +944,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreaderRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 158;
+				CURRENT_PROJECT_VERSION = 159;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -955,7 +955,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.7.0;
+				MARKETING_VERSION = 3.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1018,7 +1018,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 158;
+				CURRENT_PROJECT_VERSION = 159;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1030,7 +1030,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.7.0;
+				MARKETING_VERSION = 3.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1048,7 +1048,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 158;
+				CURRENT_PROJECT_VERSION = 159;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1060,7 +1060,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.7.0;
+				MARKETING_VERSION = 3.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/LANreader/Page/ArchiveReader.swift
+++ b/LANreader/Page/ArchiveReader.swift
@@ -896,9 +896,6 @@ struct ArchiveReader: View {
                 navigationHelper?.pop()
             }
         }
-        .onDisappear {
-            store.send(.cleanupSliderPreviewResources)
-        }
     }
 
     // swiftlint:disable function_body_length

--- a/LANreader/Page/UIArchiveReader.swift
+++ b/LANreader/Page/UIArchiveReader.swift
@@ -95,4 +95,19 @@ class UIArchiveReaderController: UIViewController {
         super.viewWillDisappear(animated)
         navigationController?.setNavigationBarHidden(false, animated: animated)
     }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        cleanupSliderPreviewResourcesIfNeeded()
+    }
+
+    func cleanupSliderPreviewResourcesIfNeeded(
+        movingFromParent: Bool? = nil,
+        beingDismissed: Bool? = nil
+    ) {
+        let shouldCleanup = (movingFromParent ?? isMovingFromParent)
+            || (beingDismissed ?? isBeingDismissed)
+        guard shouldCleanup else { return }
+        store.send(.cleanupSliderPreviewResources)
+    }
 }

--- a/LANreaderTests/ArchiveReaderFeatureTests.swift
+++ b/LANreaderTests/ArchiveReaderFeatureTests.swift
@@ -573,6 +573,64 @@ final class ArchiveReaderFeatureTests: XCTestCase {
     }
 
     @MainActor
+    func testUIArchiveReaderControllerKeepsSliderPreviewStateWhenTemporarilyCovered() async {
+        configureReaderDefaults()
+        var initialState = makeState(progress: 2)
+        initialState.pages = makePageStates(count: 4)
+        initialState.sliderPreviewVisible = true
+        initialState.sliderPreviewPageIndex = 1
+        initialState.sliderPreviewImageURL = URL(fileURLWithPath: "/tmp/preview.jpg")
+        initialState.sliderPreviewLoading = true
+        initialState.sliderThumbnailJobId = 42
+        initialState.sliderReadyThumbnailPages = Set([1, 2])
+
+        let store = Store(initialState: initialState) {
+            ArchiveReaderFeature()
+        }
+        let controller = UIArchiveReaderController(store: store)
+
+        controller.loadViewIfNeeded()
+        controller.cleanupSliderPreviewResourcesIfNeeded(movingFromParent: false, beingDismissed: false)
+        await Task.yield()
+
+        XCTAssertTrue(store.sliderPreviewVisible)
+        XCTAssertEqual(store.sliderPreviewPageIndex, 1)
+        XCTAssertEqual(store.sliderPreviewImageURL, URL(fileURLWithPath: "/tmp/preview.jpg"))
+        XCTAssertTrue(store.sliderPreviewLoading)
+        XCTAssertEqual(store.sliderThumbnailJobId, 42)
+        XCTAssertEqual(store.sliderReadyThumbnailPages, Set([1, 2]))
+    }
+
+    @MainActor
+    func testUIArchiveReaderControllerCleansSliderPreviewStateWhenDismissed() async {
+        configureReaderDefaults()
+        var initialState = makeState(progress: 2)
+        initialState.pages = makePageStates(count: 4)
+        initialState.sliderPreviewVisible = true
+        initialState.sliderPreviewPageIndex = 1
+        initialState.sliderPreviewImageURL = URL(fileURLWithPath: "/tmp/preview.jpg")
+        initialState.sliderPreviewLoading = true
+        initialState.sliderThumbnailJobId = 42
+        initialState.sliderReadyThumbnailPages = Set([1, 2])
+
+        let store = Store(initialState: initialState) {
+            ArchiveReaderFeature()
+        }
+        let controller = UIArchiveReaderController(store: store)
+
+        controller.loadViewIfNeeded()
+        controller.cleanupSliderPreviewResourcesIfNeeded(movingFromParent: true)
+        await Task.yield()
+
+        XCTAssertFalse(store.sliderPreviewVisible)
+        XCTAssertNil(store.sliderPreviewPageIndex)
+        XCTAssertNil(store.sliderPreviewImageURL)
+        XCTAssertFalse(store.sliderPreviewLoading)
+        XCTAssertNil(store.sliderThumbnailJobId)
+        XCTAssertTrue(store.sliderReadyThumbnailPages.isEmpty)
+    }
+
+    @MainActor
     func testAutoPageTickRequestsNextPage() async {
         configureReaderDefaults(autoPageInterval: 1)
         let clock = TestClock()


### PR DESCRIPTION
## What changed
- avoid cleaning up reader slider preview state when the reader is only temporarily covered by the details screen
- move slider preview cleanup to actual reader dismissal and add regression tests for temporary cover vs. dismissal
- bump the app and Action extension versions to 3.7.1 (159)

## Why
- returning from details could leave some slider previews stuck on the placeholder because preview work was being torn down on every disappear
- the version bump prepares the next build with this fix

## Verification
- `./scripts/lint`
- `./scripts/test-ios`