### PR TITLE
Modernize archive grid thumbnails

### DIFF
--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -916,7 +916,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreader.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 166;
+				CURRENT_PROJECT_VERSION = 167;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -927,7 +927,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.7.2;
+				MARKETING_VERSION = 3.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -944,7 +944,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreaderRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 166;
+				CURRENT_PROJECT_VERSION = 167;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -955,7 +955,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.7.2;
+				MARKETING_VERSION = 3.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1018,7 +1018,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 166;
+				CURRENT_PROJECT_VERSION = 167;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1030,7 +1030,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.7.2;
+				MARKETING_VERSION = 3.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1048,7 +1048,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 166;
+				CURRENT_PROJECT_VERSION = 167;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1060,7 +1060,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.7.2;
+				MARKETING_VERSION = 3.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/LANreader/Common/ArchiveGridV2.swift
+++ b/LANreader/Common/ArchiveGridV2.swift
@@ -69,6 +69,7 @@ struct ArchiveGridV2: View {
     let store: StoreOf<GridFeature>
 
     @Dependency(\.appDatabase) var database
+    private let cornerRadius: CGFloat = 8
 
     init(store: StoreOf<GridFeature>) {
         self.store = store
@@ -76,22 +77,24 @@ struct ArchiveGridV2: View {
 
     var body: some View {
         let thumbnailObj = try? database.readArchiveThumbnail(store.id)
-        VStack(alignment: HorizontalAlignment.center, spacing: 2) {
-            Text(buildTitle(archive: store.archive))
-                .lineLimit(2)
-                .foregroundStyle(Color.primary)
-                .padding(4)
-                .font(.caption)
+        ZStack {
             imageView(thumbnailObj: thumbnailObj)
                 .id(store.nonce)
+            bottomGradient
+            topBadges
+            titleOverlay
         }
-        .frame(maxHeight: .infinity, alignment: .top)
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .aspectRatio(ArchiveGridMetrics.coverAspectRatio, contentMode: .fit)
+        .background(Color(uiColor: .secondarySystemGroupedBackground))
+        .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
         .overlay(
-            RoundedRectangle(cornerRadius: 8)
-                .stroke(Color.secondary, lineWidth: 2)
-                .opacity(0.9)
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
         )
+        .shadow(color: Color.black.opacity(0.14), radius: 10, x: 0, y: 6)
+        .padding(2)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
         .onChange(of: store.archive.refresh) { _, newValue in
             if newValue {
                 store.send(.increaseNonce)
@@ -100,17 +103,70 @@ struct ArchiveGridV2: View {
         }
     }
 
-    func buildTitle(archive: ArchiveItem) -> String {
-        var title = archive.name
-        if store.cached {
-            return title
+    private var bottomGradient: some View {
+        LinearGradient(
+            colors: [
+                Color.black.opacity(0),
+                Color.black.opacity(0.24),
+                Color.black.opacity(0.78)
+            ],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+        .frame(height: 128)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+        .allowsHitTesting(false)
+    }
+
+    private var titleOverlay: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(store.archive.name)
+                .font(.subheadline.weight(.semibold))
+                .lineLimit(2)
+                .minimumScaleFactor(0.82)
+                .foregroundStyle(.white)
+                .shadow(color: .black.opacity(0.45), radius: 2, x: 0, y: 1)
+
+            if let progressFraction {
+                progressBar(progressFraction)
+            }
         }
-        if archive.pagecount == archive.progress {
-            title = "👑 " + title
-        } else if archive.progress < 2 {
-            title = "🆕 " + title
+        .padding(.horizontal, 10)
+        .padding(.bottom, 10)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
+        .allowsHitTesting(false)
+    }
+
+    private var topBadges: some View {
+        HStack(alignment: .top) {
+            if let status {
+                Image(systemName: status.systemImage)
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(.white)
+                    .frame(width: 26, height: 26)
+                    .background(status.tint, in: Circle())
+                    .shadow(color: .black.opacity(0.22), radius: 4, x: 0, y: 2)
+            }
+
+            Spacer(minLength: 6)
+
+            if store.archive.pagecount > 0 {
+                HStack(spacing: 4) {
+                    Image(systemName: "rectangle.stack.fill")
+                        .font(.caption2.weight(.semibold))
+                    Text("\(store.archive.pagecount)")
+                        .font(.caption2.weight(.bold))
+                        .monospacedDigit()
+                }
+                .foregroundStyle(.primary)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 5)
+                .background(.ultraThinMaterial, in: Capsule())
+            }
         }
-        return title
+        .padding(8)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .allowsHitTesting(false)
     }
 
     @ViewBuilder
@@ -119,14 +175,126 @@ struct ArchiveGridV2: View {
             Image(uiImage: uiImage)
                 .resizable()
                 .scaledToFit()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
-            Image("noThumb")
-                .resizable()
-                .scaledToFit()
-                .frame(height: 240)
-                .onAppear {
-                    store.send(.load(false))
-                }
+            ZStack {
+                LinearGradient(
+                    colors: [
+                        Color(uiColor: .secondarySystemGroupedBackground),
+                        Color(uiColor: .tertiarySystemGroupedBackground)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+
+                Image("noThumb")
+                    .resizable()
+                    .scaledToFit()
+                    .padding(30)
+                    .opacity(0.66)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .onAppear {
+                store.send(.load(false))
+            }
+        }
+    }
+
+    private var status: ArchiveGridStatus? {
+        if store.cached {
+            return .cached
+        }
+        if store.archive.pagecount > 0 && store.archive.pagecount == store.archive.progress {
+            return .read
+        }
+        if store.archive.progress < 2 {
+            return .new
+        }
+        return nil
+    }
+
+    private var progressFraction: Double? {
+        guard store.cached == false,
+              store.archive.pagecount > 0,
+              store.archive.progress > 1 else {
+            return nil
+        }
+        let fraction = Double(store.archive.progress) / Double(store.archive.pagecount)
+        return min(max(fraction, 0), 1)
+    }
+
+    private var accessibilityLabel: Text {
+        if let status {
+            Text(verbatim: "\(store.archive.name), \(status.accessibilityLabel)")
+        } else {
+            Text(verbatim: store.archive.name)
+        }
+    }
+
+    private func progressBar(_ value: Double) -> some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(Color.white.opacity(0.24))
+                Capsule()
+                    .fill(progressTint)
+                    .frame(width: proxy.size.width * value)
+            }
+        }
+        .frame(height: 4)
+    }
+
+    private var progressTint: Color {
+        if store.archive.pagecount > 0 && store.archive.pagecount == store.archive.progress {
+            Color(uiColor: .systemGreen)
+        } else {
+            Color(uiColor: .systemBlue)
+        }
+    }
+}
+
+enum ArchiveGridMetrics {
+    // Most manga/book covers are close to A/B-series paper proportions
+    // (width / height ~= 0.707), which avoids vertical gaps for normal covers
+    // while wide/double-page thumbnails still fit inside the card.
+    static let coverAspectRatio: CGFloat = 0.707
+}
+
+private enum ArchiveGridStatus {
+    case cached
+    case read
+    case new
+
+    var systemImage: String {
+        switch self {
+        case .cached:
+            "tray.full.fill"
+        case .read:
+            "crown.fill"
+        case .new:
+            "sparkles"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .cached:
+            Color(uiColor: .systemOrange)
+        case .read:
+            Color(uiColor: .systemGreen)
+        case .new:
+            Color(uiColor: .systemBlue)
+        }
+    }
+
+    var accessibilityLabel: String {
+        switch self {
+        case .cached:
+            "cached"
+        case .read:
+            "read"
+        case .new:
+            "new"
         }
     }
 }

--- a/LANreader/Common/UIArchiveCell.swift
+++ b/LANreader/Common/UIArchiveCell.swift
@@ -3,27 +3,41 @@ import ComposableArchitecture
 import SwiftUI
 
 class UIArchiveCell: UICollectionViewCell {
-    private var hostingController: UIHostingController<ArchiveGridV2>?
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        backgroundColor = .clear
+        contentView.backgroundColor = .clear
+        clipsToBounds = false
+        contentView.clipsToBounds = false
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     func configure(with store: StoreOf<GridFeature>) {
-        hostingController = nil
-        let hostingController = UIHostingController(rootView: ArchiveGridV2(store: store))
-        contentView.addSubview(hostingController.view)
-
-        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            hostingController.view.topAnchor.constraint(equalTo: contentView.topAnchor),
-            hostingController.view.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            hostingController.view.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            hostingController.view.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
-
-        ])
-        self.hostingController = hostingController
+        contentConfiguration = UIHostingConfiguration {
+            ArchiveGridV2(store: store)
+        }
+        .margins(.all, 0)
     }
 
     override func prepareForReuse() {
         super.prepareForReuse()
-        hostingController?.view.removeFromSuperview()
-        hostingController = nil
+        contentConfiguration = nil
+    }
+
+    override var isHighlighted: Bool {
+        didSet {
+            UIView.animate(
+                withDuration: 0.16,
+                delay: 0,
+                options: [.allowUserInteraction, .beginFromCurrentState]
+            ) {
+                self.transform = self.isHighlighted ? CGAffineTransform(scaleX: 0.97, y: 0.97) : .identity
+                self.alpha = self.isHighlighted ? 0.92 : 1.0
+            }
+        }
     }
 }

--- a/LANreader/Common/UIArchiveList.swift
+++ b/LANreader/Common/UIArchiveList.swift
@@ -513,53 +513,91 @@ class UIArchiveListViewController: UIViewController {
     }
 
     func setupCollectionView() {
-        let layout = UICollectionViewCompositionalLayout { _, layoutEnvironment -> NSCollectionLayoutSection? in
-            let containerWidth = layoutEnvironment.container.effectiveContentSize.width
-            let columns = max(Int(containerWidth / 180), 1)
-            let interItemSpacing: CGFloat = 8.0
-            let totalSpacing = CGFloat(columns - 1) * interItemSpacing
-
-            let availableWidth = containerWidth - totalSpacing
-            let cellWidth = availableWidth / CGFloat(columns)
-            let cellHeight = (cellWidth / 2.0 * 3.0) + 10.0
-
-            let itemSize = NSCollectionLayoutSize(
-                widthDimension: .fractionalWidth(1.0 / CGFloat(columns)),
-                heightDimension: .fractionalHeight(1.0)
-            )
-            let item = NSCollectionLayoutItem(layoutSize: itemSize)
-            item.contentInsets = NSDirectionalEdgeInsets(top: 4, leading: 4, bottom: 4, trailing: 4)
-
-            let groupSize = NSCollectionLayoutSize(
-                widthDimension: .fractionalWidth(1.0),
-                heightDimension: .absolute(cellHeight)
-            )
-            let group = NSCollectionLayoutGroup.horizontal(
-                layoutSize: groupSize,
-                repeatingSubitem: item,
-                count: columns
-            )
-            group.interItemSpacing = .fixed(interItemSpacing)
-
-            let section = NSCollectionLayoutSection(group: group)
-
-            let footerSize = NSCollectionLayoutSize(
-                widthDimension: .fractionalWidth(1.0),
-                heightDimension: .absolute(80)
-            )
-            let footer = NSCollectionLayoutBoundarySupplementaryItem(
-                layoutSize: footerSize,
-                elementKind: UICollectionView.elementKindSectionFooter,
-                alignment: .bottom
-            )
-            section.boundarySupplementaryItems = [footer]
-
-            return section
-        }
+        let layout = makeCollectionViewLayout()
+        view.backgroundColor = .systemGroupedBackground
         collectionView = UICollectionView(frame: view.bounds, collectionViewLayout: layout)
-        collectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        collectionView.backgroundColor = .systemGroupedBackground
+        collectionView.contentInsetAdjustmentBehavior = .automatic
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(collectionView)
+        NSLayoutConstraint.activate([
+            collectionView.topAnchor.constraint(equalTo: view.topAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+    }
+
+    private func makeCollectionViewLayout() -> UICollectionViewCompositionalLayout {
+        UICollectionViewCompositionalLayout { _, layoutEnvironment -> NSCollectionLayoutSection? in
+            Self.makeArchiveGridSection(layoutEnvironment: layoutEnvironment)
+        }
+    }
+
+    private static func makeArchiveGridSection(
+        layoutEnvironment: NSCollectionLayoutEnvironment
+    ) -> NSCollectionLayoutSection {
+        let containerWidth = layoutEnvironment.container.effectiveContentSize.width
+        let sideInset: CGFloat = 12.0
+        let interItemSpacing: CGFloat = 12.0
+        let contentWidth = max(containerWidth - sideInset * 2, 1)
+        let columns = max(Int(contentWidth / 172), 1)
+        let totalSpacing = CGFloat(columns - 1) * interItemSpacing
+        let cellWidth = (contentWidth - totalSpacing) / CGFloat(columns)
+        let cellHeight = cellWidth / ArchiveGridMetrics.coverAspectRatio + 4.0
+
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0 / CGFloat(columns)),
+            heightDimension: .fractionalHeight(1.0)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        let group = makeArchiveGridGroup(
+            item: item,
+            columns: columns,
+            cellHeight: cellHeight,
+            interItemSpacing: interItemSpacing
+        )
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(
+            top: 12,
+            leading: sideInset,
+            bottom: 20,
+            trailing: sideInset
+        )
+        section.interGroupSpacing = interItemSpacing
+        section.boundarySupplementaryItems = [makeArchiveGridFooter()]
+        return section
+    }
+
+    private static func makeArchiveGridGroup(
+        item: NSCollectionLayoutItem,
+        columns: Int,
+        cellHeight: CGFloat,
+        interItemSpacing: CGFloat
+    ) -> NSCollectionLayoutGroup {
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(cellHeight)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: groupSize,
+            repeatingSubitem: item,
+            count: columns
+        )
+        group.interItemSpacing = .fixed(interItemSpacing)
+        return group
+    }
+
+    private static func makeArchiveGridFooter() -> NSCollectionLayoutBoundarySupplementaryItem {
+        let footerSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(80)
+        )
+        return NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: footerSize,
+            elementKind: UICollectionView.elementKindSectionFooter,
+            alignment: .bottom
+        )
     }
 
     func setupRefresh() {


### PR DESCRIPTION
## What changed
- Restyled archive grid cells with poster-style thumbnails, overlays, badges, progress indicators, and updated spacing.
- Kept thumbnails fitted inside their card so wide/double-page covers do not span or overlap adjacent cells.
- Adjusted the shared cover aspect ratio to better match common manga/book covers and documented the choice.
- Bumped app version from 3.7.2 to 3.8.0 and build from 166 to 167.

## Why
- Makes the archive page look more modern while preserving the previous containment behavior for wide covers.
- Reduces top/bottom letterboxing for normal portrait thumbnails.
- Uses a minor version bump for marketing.

## Verified
- `PATH="/tmp/codex-swiftlint:$PATH" ./scripts/lint`
- `./scripts/test-ios`