### PR TITLE
Modernize archive details page

### DIFF
--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -95,6 +95,8 @@
 		E9F3B0122B01A21C00F60F62 /* CategoryListV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F3B0112B01A21C00F60F62 /* CategoryListV2.swift */; };
 		F1A2B3C42F60000100AAA001 /* ReaderPositioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C72F60000100AAA001 /* ReaderPositioning.swift */; };
 		F1A2B3C52F60000100AAA001 /* ArchiveReaderFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C82F60000100AAA001 /* ArchiveReaderFeatureTests.swift */; };
+		F1A2B3C62F60000200AAA001 /* ArchiveDetailsTagParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C92F60000200AAA001 /* ArchiveDetailsTagParserTests.swift */; };
+		F1A2B3CA2F60000300AAA001 /* ArchiveDetailsTagParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3CB2F60000300AAA001 /* ArchiveDetailsTagParser.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -214,6 +216,8 @@
 		E9F3B0112B01A21C00F60F62 /* CategoryListV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryListV2.swift; sourceTree = "<group>"; };
 		F1A2B3C72F60000100AAA001 /* ReaderPositioning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPositioning.swift; sourceTree = "<group>"; };
 		F1A2B3C82F60000100AAA001 /* ArchiveReaderFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveReaderFeatureTests.swift; sourceTree = "<group>"; };
+		F1A2B3C92F60000200AAA001 /* ArchiveDetailsTagParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailsTagParserTests.swift; sourceTree = "<group>"; };
+		F1A2B3CB2F60000300AAA001 /* ArchiveDetailsTagParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailsTagParser.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -291,6 +295,7 @@
 				E91EE6842CAB94F60046853C /* UIPageCollection.swift */,
 				E91EE6822CAB78E80046853C /* UIArchiveReader.swift */,
 				E9DAEC542B07295D00ADC215 /* ArchiveDetailsV2.swift */,
+				F1A2B3CB2F60000300AAA001 /* ArchiveDetailsTagParser.swift */,
 				E9BFA2062AF52C3300DDE107 /* PageImageV2.swift */,
 				F1A2B3C72F60000100AAA001 /* ReaderPositioning.swift */,
 				E90576B529F6BF8700C3CE3F /* WrappingHStack.swift */,
@@ -418,6 +423,7 @@
 				7D354CEB24F1FBEE00617F4A /* Resources */,
 				7D354CB624F1316E00617F4A /* LANreaderTests.swift */,
 				F1A2B3C82F60000100AAA001 /* ArchiveReaderFeatureTests.swift */,
+				F1A2B3C92F60000200AAA001 /* ArchiveDetailsTagParserTests.swift */,
 				7D354CB824F1316E00617F4A /* Info.plist */,
 				4BD820A697A4726B7B747BFD /* Service */,
 			);
@@ -699,6 +705,7 @@
 				7D354CDA24F13C4900617F4A /* LANraragiResponse.swift in Sources */,
 				E98B8B902A0BA9D1004CBBC0 /* UploadView.swift in Sources */,
 				E9DAEC552B07295D00ADC215 /* ArchiveDetailsV2.swift in Sources */,
+				F1A2B3CA2F60000300AAA001 /* ArchiveDetailsTagParser.swift in Sources */,
 				E9A8612D2BF31534003534FA /* AutomaticPageConfig.swift in Sources */,
 				4BD82FB1458C45231D987E32 /* LANraragiService.swift in Sources */,
 				E9A4DD122D5ACEA300E16FEC /* UINavigationHelper.swift in Sources */,
@@ -741,6 +748,7 @@
 			files = (
 				7D354CB724F1316E00617F4A /* LANreaderTests.swift in Sources */,
 				F1A2B3C52F60000100AAA001 /* ArchiveReaderFeatureTests.swift in Sources */,
+				F1A2B3C62F60000200AAA001 /* ArchiveDetailsTagParserTests.swift in Sources */,
 				4BD82555CE41A0467CCC6411 /* LANraragiServiceTest.swift in Sources */,
 				7DF6FFAA252DC3BB009280A5 /* FileUtils.swift in Sources */,
 			);
@@ -916,7 +924,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreader.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 169;
+				CURRENT_PROJECT_VERSION = 170;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -944,7 +952,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreaderRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 169;
+				CURRENT_PROJECT_VERSION = 170;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1018,7 +1026,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 169;
+				CURRENT_PROJECT_VERSION = 170;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1048,7 +1056,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 169;
+				CURRENT_PROJECT_VERSION = 170;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;

--- a/LANreader/Page/ArchiveDetailsTagParser.swift
+++ b/LANreader/Page/ArchiveDetailsTagParser.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+enum ArchiveDetailsTagParser {
+    static let artistTag = "artist"
+    static let sourceTag = "source"
+    static let dateTag = "date_added"
+    static let otherTag = "other"
+
+    static func tagGroups(from tags: String) -> [ArchiveTagGroup] {
+        let parsedTags = tags
+            .split(separator: ",")
+            .enumerated()
+            .compactMap { index, rawTag in
+                parseTag(rawTag: String(rawTag), id: index)
+            }
+
+        return Dictionary(grouping: parsedTags, by: \.namespaceKey)
+            .map { namespaceKey, tags in
+                ArchiveTagGroup(
+                    id: namespaceKey,
+                    title: tagGroupTitle(for: namespaceKey),
+                    tags: tags.sorted { first, second in
+                        if first.displayText == second.displayText {
+                            return first.id < second.id
+                        }
+                        let order = first.displayText.localizedCaseInsensitiveCompare(second.displayText)
+                        return order == .orderedAscending
+                    }
+                )
+            }
+            .sorted { first, second in
+                let firstRank = tagGroupRank(first.id)
+                let secondRank = tagGroupRank(second.id)
+                if firstRank != secondRank {
+                    return firstRank < secondRank
+                }
+                return first.id.localizedCaseInsensitiveCompare(second.id) == .orderedAscending
+            }
+    }
+
+    private static func parseTag(rawTag: String, id: Int) -> ArchiveDetailsTag? {
+        let raw = rawTag.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !raw.isEmpty else {
+            return nil
+        }
+
+        let tagPair = raw.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+        let rawNamespace = tagPair.first?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let hasNamespace = tagPair.count == 2 && !rawNamespace.isEmpty
+        let namespaceKey = hasNamespace ? rawNamespace.lowercased() : otherTag
+        let value = hasNamespace
+            ? tagPair[1].trimmingCharacters(in: .whitespacesAndNewlines)
+            : raw
+        let displayText = tagDisplayText(namespaceKey: namespaceKey, value: value, raw: raw)
+
+        return ArchiveDetailsTag(
+            id: id,
+            raw: raw,
+            namespaceKey: namespaceKey,
+            value: value,
+            displayText: displayText.isEmpty ? raw : displayText,
+            accessibilityLabel: "\(tagGroupTitle(for: namespaceKey)), \(displayText.isEmpty ? raw : displayText)"
+        )
+    }
+
+    private static func tagDisplayText(namespaceKey: String, value: String, raw: String) -> String {
+        if namespaceKey == dateTag, let timestamp = TimeInterval(value), timestamp > 0 {
+            let date = Date(timeIntervalSince1970: timestamp)
+            return date.formatted(date: .abbreviated, time: .omitted)
+        }
+
+        if value.isEmpty {
+            return raw
+        }
+
+        return value
+    }
+
+    private static func tagGroupTitle(for namespaceKey: String) -> String {
+        switch namespaceKey {
+        case otherTag:
+            return String(localized: "archive.tags.group.other")
+        case dateTag:
+            return String(localized: "archive.tags.group.dateAdded")
+        default:
+            return namespaceKey
+                .replacingOccurrences(of: "_", with: " ")
+                .replacingOccurrences(of: "-", with: " ")
+                .localizedCapitalized
+        }
+    }
+
+    private static func tagGroupRank(_ namespaceKey: String) -> Int {
+        switch namespaceKey {
+        case artistTag:
+            return 0
+        case sourceTag:
+            return 2
+        case dateTag:
+            return 3
+        default:
+            return 1
+        }
+    }
+}
+
+struct ArchiveDetailsTag: Identifiable, Hashable {
+    let id: Int
+    let raw: String
+    let namespaceKey: String
+    let value: String
+    let displayText: String
+    let accessibilityLabel: String
+}
+
+struct ArchiveTagGroup: Identifiable {
+    let id: String
+    let title: String
+    let tags: [ArchiveDetailsTag]
+}

--- a/LANreader/Page/ArchiveDetailsV2.swift
+++ b/LANreader/Page/ArchiveDetailsV2.swift
@@ -190,9 +190,6 @@ import GRDBQuery
 }
 
 struct ArchiveDetailsV2: View {
-    private static let sourceTag = "source"
-    private static let dateTag = "date_added"
-
     @Query<ThumbnailRequest> var thumbnailObj: ArchiveThumbnail?
 
     @Environment(\.openURL) var openURL
@@ -214,23 +211,17 @@ struct ArchiveDetailsV2: View {
 
     var body: some View {
         ScrollView {
-            titleView(store: store)
-            thumbnailView()
-            tagsView(store: store)
-            Button(
-                role: .destructive,
-                action: { store.send(.deleteButtonTapped) },
-                label: {
-                    Text("archive.delete")
-                }
-            )
-            .padding()
-            .background(.red)
-            .foregroundStyle(.white)
-            .clipShape(Capsule())
-            .disabled(store.loading)
-            .opacity(store.editMode != .active && !store.cached ? 1 : 0)
+            VStack(spacing: 22) {
+                headerView(store: store)
+                tagsView(store: store)
+                deleteButton(store: store)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 18)
+            .frame(maxWidth: 720)
+            .frame(maxWidth: .infinity)
         }
+        .background(Color(uiColor: .systemGroupedBackground).ignoresSafeArea())
         .onAppear {
             store.send(.loadLocalFields)
         }
@@ -311,96 +302,266 @@ struct ArchiveDetailsV2: View {
         }
     }
 
-    @ViewBuilder
-    private func titleView(store: StoreOf<ArchiveDetailsFeature>) -> some View {
-        if store.editMode == .active {
-            TextField("", text: $store.title, axis: .vertical)
-                .textInputAutocapitalization(.never)
-                .autocorrectionDisabled()
-                .textFieldStyle(.roundedBorder)
-                .padding()
-        } else {
-            Text(store.title)
-                .textFieldStyle(.roundedBorder)
-                .textSelection(.enabled)
-                .padding()
+    private func headerView(store: StoreOf<ArchiveDetailsFeature>) -> some View {
+        HStack(alignment: .top, spacing: 16) {
+            thumbnailView()
+
+            titleView(store: store)
+                .padding(.top, 4)
+                .layoutPriority(1)
         }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            Color(uiColor: .secondarySystemGroupedBackground),
+            in: RoundedRectangle(cornerRadius: 22, style: .continuous)
+        )
     }
 
     @ViewBuilder
-    private func tagsView(store: StoreOf<ArchiveDetailsFeature>) -> some View {
+    private func titleView(store: StoreOf<ArchiveDetailsFeature>) -> some View {
         if store.editMode == .active {
-            TextField("", text: $store.tags, axis: .vertical)
-                .textFieldStyle(.roundedBorder)
-                .textInputAutocapitalization(.never)
-                .disableAutocorrection(true)
-                .padding()
-        } else {
-            let tags = store.tags.split(separator: ",")
-            WrappingHStack.ForEach(tags) { tag in
-                parseTag(tag: String(tag))
-                    .padding()
-                    .controlSize(.mini)
-                    .foregroundStyle(.white)
-                    .background(.blue)
-                    .clipShape(Capsule())
+            VStack(alignment: .leading, spacing: 10) {
+                Text("archive.details.title")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .textCase(.uppercase)
+
+                TextField("archive.details.title", text: $store.title, axis: .vertical)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .font(.title3.weight(.semibold))
+                    .lineLimit(2...8)
+                    .padding(14)
+                    .background(
+                        Color(uiColor: .tertiarySystemGroupedBackground),
+                        in: RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    )
             }
-            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("details")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .textCase(.uppercase)
+
+                Text(store.title)
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func tagsView(store: StoreOf<ArchiveDetailsFeature>) -> some View {
+        let groups = ArchiveDetailsTagParser.tagGroups(from: store.tags)
+        let tagCount = groups.reduce(0) { count, group in
+            count + group.tags.count
+        }
+
+        return VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Label("archive.details.tags", systemImage: "tag")
+                    .font(.headline)
+
+                Spacer()
+
+                if tagCount > 0 && store.editMode != .active {
+                    Text("\(tagCount)")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 9)
+                        .padding(.vertical, 5)
+                        .background(.thinMaterial, in: Capsule())
+                }
+            }
+
+            if store.editMode == .active {
+                TextField("archive.details.tags", text: $store.tags, axis: .vertical)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .font(.body.monospaced())
+                    .lineLimit(5...14)
+                    .padding(14)
+                    .background(
+                        Color(uiColor: .secondarySystemGroupedBackground),
+                        in: RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    )
+            } else if groups.isEmpty {
+                Label("archive.tags.empty", systemImage: "tag")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, minHeight: 76)
+                    .background(
+                        Color(uiColor: .secondarySystemGroupedBackground),
+                        in: RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    )
+            } else {
+                ForEach(groups) { group in
+                    tagGroupView(group)
+                }
+            }
         }
     }
 
     @ViewBuilder
     private func thumbnailView() -> some View {
-        if let thumbnailData = thumbnailObj?.thumbnail, let uiImage = UIImage(data: thumbnailData) {
-            Image(uiImage: uiImage)
-                .resizable()
-                .scaledToFit()
-                .padding()
-                .frame(width: 200, height: 250)
-        } else {
-            Image("noThumb")
-                .resizable()
-                .scaledToFit()
-                .padding()
-                .frame(width: 200, height: 250)
+        Group {
+            if let thumbnailData = thumbnailObj?.thumbnail, let uiImage = UIImage(data: thumbnailData) {
+                Image(uiImage: uiImage)
+                    .resizable()
+            } else {
+                Image("noThumb")
+                    .resizable()
+            }
+        }
+        .scaledToFit()
+        .padding(8)
+        .frame(width: 132, height: 178)
+        .background(
+            Color(uiColor: .tertiarySystemGroupedBackground),
+            in: RoundedRectangle(cornerRadius: 18, style: .continuous)
+        )
+        .shadow(color: Color.black.opacity(0.10), radius: 12, x: 0, y: 6)
+        .accessibilityHidden(true)
+    }
+
+    @ViewBuilder
+    private func deleteButton(store: StoreOf<ArchiveDetailsFeature>) -> some View {
+        if store.editMode != .active && !store.cached {
+            Button(
+                role: .destructive,
+                action: { store.send(.deleteButtonTapped) },
+                label: {
+                    Label("archive.delete", systemImage: "trash")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                }
+            )
+            .buttonStyle(.plain)
+            .foregroundStyle(.white)
+            .background(Color.red, in: Capsule())
+            .disabled(store.loading)
+            .opacity(store.loading ? 0.55 : 1)
         }
     }
 
-    private func parseTag(tag: String) -> some View {
-        let tagPair = tag.split(separator: ":", maxSplits: 1)
+    private func tagGroupView(_ group: ArchiveTagGroup) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(group.title)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
 
-        let tagName = tagPair[0].trimmingCharacters(in: .whitespacesAndNewlines)
-        let tagValue = tagPair.count == 2 ? tagPair[1].trimmingCharacters(in: .whitespacesAndNewlines) : ""
-        if tagName == ArchiveDetailsV2.sourceTag {
-            let urlString = tagValue.hasPrefix("http") ? tagValue : "https://\(tagValue)"
-            return Text(tag)
-                .lineLimit(1)
-                .onTapGesture {
-                    openURL(URL(string: urlString)!)
+            WrappingHStack(horizontalSpacing: 4, verticalSpacing: 4) {
+                ForEach(group.tags) { tag in
+                    tagButton(tag)
                 }
-
-        }
-        let processedTag: String
-        if tagName == ArchiveDetailsV2.dateTag {
-            let date = Date(timeIntervalSince1970: TimeInterval(tagValue) ?? 0)
-            processedTag = "\(ArchiveDetailsV2.dateTag): \(date.formatted(date: .abbreviated, time: .omitted))"
-        } else {
-            processedTag = tag
-        }
-        let normalizedTag = String(tag.trimmingCharacters(in: .whitespacesAndNewlines))
-        return Text(processedTag)
-            .lineLimit(1)
-            .onTapGesture {
-                let searchStore = Store(initialState: SearchFeature.State.init(
-                    keyword: normalizedTag, archiveList: ArchiveListFeature.State(
-                        filter: SearchFilter(category: nil, filter: normalizedTag),
-                        loadOnAppear: true,
-                        currentTab: .search
-                    )
-                )) {
-                    SearchFeature()
-                }
-                onTagNavigation(searchStore)
             }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            Color(uiColor: .secondarySystemGroupedBackground),
+            in: RoundedRectangle(cornerRadius: 16, style: .continuous)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.06), lineWidth: 1)
+        }
+    }
+
+    private func tagButton(_ tag: ArchiveDetailsTag) -> some View {
+        let tint = tagTint(for: tag.namespaceKey)
+
+        return Button {
+            if tag.namespaceKey == ArchiveDetailsTagParser.sourceTag, let url = sourceURL(for: tag) {
+                openURL(url)
+            } else {
+                navigateToTag(tag.raw)
+            }
+        } label: {
+            HStack(spacing: 6) {
+                if let iconName = tagIconName(for: tag.namespaceKey) {
+                    Image(systemName: iconName)
+                        .font(.caption2.weight(.bold))
+                }
+
+                Text(tag.displayText)
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            .padding(.horizontal, 11)
+            .padding(.vertical, 7)
+            .frame(maxWidth: 280, alignment: .leading)
+            .foregroundStyle(tint)
+            .background(tint.opacity(0.14), in: Capsule())
+            .overlay {
+                Capsule()
+                    .strokeBorder(tint.opacity(0.18), lineWidth: 1)
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(Text(verbatim: tag.accessibilityLabel))
+    }
+
+    private func tagTint(for namespaceKey: String) -> Color {
+        switch namespaceKey {
+        case ArchiveDetailsTagParser.artistTag:
+            return .orange
+        case ArchiveDetailsTagParser.sourceTag:
+            return .teal
+        case ArchiveDetailsTagParser.dateTag:
+            return .indigo
+        case ArchiveDetailsTagParser.otherTag:
+            return .secondary
+        default:
+            return .blue
+        }
+    }
+
+    private func tagIconName(for namespaceKey: String) -> String? {
+        switch namespaceKey {
+        case ArchiveDetailsTagParser.sourceTag:
+            return "link"
+        case ArchiveDetailsTagParser.dateTag:
+            return "calendar"
+        default:
+            return nil
+        }
+    }
+
+    private func sourceURL(for tag: ArchiveDetailsTag) -> URL? {
+        let value = tag.value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else {
+            return nil
+        }
+
+        let lowercasedValue = value.lowercased()
+        let urlString = if lowercasedValue.hasPrefix("http://") || lowercasedValue.hasPrefix("https://") {
+            value
+        } else {
+            "https://\(value)"
+        }
+        return URL(string: urlString)
+    }
+
+    private func navigateToTag(_ tag: String) {
+        let normalizedTag = String(tag.trimmingCharacters(in: .whitespacesAndNewlines))
+        let searchStore = Store(initialState: SearchFeature.State.init(
+            keyword: normalizedTag,
+            archiveList: ArchiveListFeature.State(
+                filter: SearchFilter(category: nil, filter: normalizedTag),
+                loadOnAppear: true,
+                currentTab: .search
+            )
+        )) {
+            SearchFeature()
+        }
+        onTagNavigation(searchStore)
     }
 }

--- a/LANreader/Page/WrappingHStack.swift
+++ b/LANreader/Page/WrappingHStack.swift
@@ -55,33 +55,3 @@ struct WrappingHStack: Layout {
         return (CGSize(width: totalWidth, height: totalHeight), positions)
     }
 }
-
-// Convenience wrapper for generic content
-extension WrappingHStack {
-    struct ForEach<Model: Hashable, Content: View>: View {
-        let models: [Model]
-        let horizontalSpacing: CGFloat
-        let verticalSpacing: CGFloat
-        let content: (Model) -> Content
-
-        init(
-            _ models: [Model],
-            horizontalSpacing: CGFloat = 2,
-            verticalSpacing: CGFloat = 2,
-            @ViewBuilder content: @escaping (Model) -> Content
-        ) {
-            self.models = models
-            self.horizontalSpacing = horizontalSpacing
-            self.verticalSpacing = verticalSpacing
-            self.content = content
-        }
-
-        var body: some View {
-            WrappingHStack(horizontalSpacing: horizontalSpacing, verticalSpacing: verticalSpacing) {
-                SwiftUI.ForEach(models, id: \.self) { model in
-                    content(model)
-                }
-            }
-        }
-    }
-}

--- a/LANreaderTests/ArchiveDetailsTagParserTests.swift
+++ b/LANreaderTests/ArchiveDetailsTagParserTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import LANreader
+
+final class ArchiveDetailsTagParserTests: XCTestCase {
+    func testTagGroupsUseRequestedNamespaceOrder() {
+        let groups = ArchiveDetailsTagParser.tagGroups(
+            from: "series:z,source:example.com,character:alice,date_added:1700000000,misc,artist:bob,group:a"
+        )
+
+        XCTAssertEqual(
+            groups.map(\.id),
+            ["artist", "character", "group", "other", "series", "source", "date_added"]
+        )
+    }
+
+    func testTagGroupsTrimTagsAndDisplayNamespaceValues() {
+        let groups = ArchiveDetailsTagParser.tagGroups(
+            from: " artist: Bob , plain tag , artist:Alice , source: example.com "
+        )
+
+        let artistTags = groups.first { $0.id == "artist" }?.tags
+        XCTAssertEqual(artistTags?.map(\.displayText), ["Alice", "Bob"])
+        XCTAssertEqual(artistTags?.map(\.raw), ["artist:Alice", "artist: Bob"])
+
+        let otherTags = groups.first { $0.id == "other" }?.tags
+        XCTAssertEqual(otherTags?.map(\.displayText), ["plain tag"])
+        XCTAssertEqual(otherTags?.map(\.raw), ["plain tag"])
+
+        let sourceTags = groups.first { $0.id == "source" }?.tags
+        XCTAssertEqual(sourceTags?.map(\.displayText), ["example.com"])
+        XCTAssertEqual(sourceTags?.map(\.raw), ["source: example.com"])
+    }
+}

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -288,6 +288,40 @@
         }
       }
     },
+    "archive.details.tags" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tags"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标签"
+          }
+        }
+      }
+    },
+    "archive.details.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Title"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标题"
+          }
+        }
+      }
+    },
     "archive.metadata.update.success" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -654,6 +688,57 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "成功删除选定文档"
+          }
+        }
+      }
+    },
+    "archive.tags.empty" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No tags"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有标签"
+          }
+        }
+      }
+    },
+    "archive.tags.group.dateAdded" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Date Added"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加日期"
+          }
+        }
+      }
+    },
+    "archive.tags.group.other" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Other"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "其他"
           }
         }
       }


### PR DESCRIPTION
## Summary
- Refresh the archive details page with a more modern cover/title header, grouped tag sections, and updated edit/read-only states.
- Group tags by namespace with artist first, source/date-added last, and unnamespaced tags under Other.
- Add parser coverage for tag ordering/trimming and bump the build number from 169 to 170.

## Verification
- `PATH="/tmp/codex-swiftlint:$PATH" ./scripts/lint`
- `git diff --check`
- `./scripts/test-ios` (92 tests passed)