### PR TITLE
Fix empty search archive reload

### DIFF
--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		F1A2B3C52F60000100AAA001 /* ArchiveReaderFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C82F60000100AAA001 /* ArchiveReaderFeatureTests.swift */; };
 		F1A2B3C62F60000200AAA001 /* ArchiveDetailsTagParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C92F60000200AAA001 /* ArchiveDetailsTagParserTests.swift */; };
 		F1A2B3CA2F60000300AAA001 /* ArchiveDetailsTagParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3CB2F60000300AAA001 /* ArchiveDetailsTagParser.swift */; };
+		F1A2B3CC2F70000100AAA001 /* ArchiveListFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3CD2F70000100AAA001 /* ArchiveListFeatureTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -218,6 +219,7 @@
 		F1A2B3C82F60000100AAA001 /* ArchiveReaderFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveReaderFeatureTests.swift; sourceTree = "<group>"; };
 		F1A2B3C92F60000200AAA001 /* ArchiveDetailsTagParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailsTagParserTests.swift; sourceTree = "<group>"; };
 		F1A2B3CB2F60000300AAA001 /* ArchiveDetailsTagParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailsTagParser.swift; sourceTree = "<group>"; };
+		F1A2B3CD2F70000100AAA001 /* ArchiveListFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveListFeatureTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -424,6 +426,7 @@
 				7D354CB624F1316E00617F4A /* LANreaderTests.swift */,
 				F1A2B3C82F60000100AAA001 /* ArchiveReaderFeatureTests.swift */,
 				F1A2B3C92F60000200AAA001 /* ArchiveDetailsTagParserTests.swift */,
+				F1A2B3CD2F70000100AAA001 /* ArchiveListFeatureTests.swift */,
 				7D354CB824F1316E00617F4A /* Info.plist */,
 				4BD820A697A4726B7B747BFD /* Service */,
 			);
@@ -749,6 +752,7 @@
 				7D354CB724F1316E00617F4A /* LANreaderTests.swift in Sources */,
 				F1A2B3C52F60000100AAA001 /* ArchiveReaderFeatureTests.swift in Sources */,
 				F1A2B3C62F60000200AAA001 /* ArchiveDetailsTagParserTests.swift in Sources */,
+				F1A2B3CC2F70000100AAA001 /* ArchiveListFeatureTests.swift in Sources */,
 				4BD82555CE41A0467CCC6411 /* LANraragiServiceTest.swift in Sources */,
 				7DF6FFAA252DC3BB009280A5 /* FileUtils.swift in Sources */,
 			);
@@ -924,7 +928,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreader.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 171;
+				CURRENT_PROJECT_VERSION = 172;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -952,7 +956,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreaderRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 171;
+				CURRENT_PROJECT_VERSION = 172;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1026,7 +1030,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 171;
+				CURRENT_PROJECT_VERSION = 172;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1056,7 +1060,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 171;
+				CURRENT_PROJECT_VERSION = 172;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;

--- a/LANreader/Common/UIArchiveList.swift
+++ b/LANreader/Common/UIArchiveList.swift
@@ -33,6 +33,19 @@ import Logging
         var currentTab: TabName
 
         var archivesToDisplay: IdentifiedArrayOf<GridFeature.State> = []
+
+        // Library/category can load an unfiltered list; Search treats an empty filter as no query yet.
+        var canLoadArchives: Bool {
+            currentTab != .search || hasSearchFilter
+        }
+
+        private var hasSearchFilter: Bool {
+            guard currentTab == .search else { return true }
+            if filter.category != nil {
+                return true
+            }
+            return filter.filter?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        }
     }
 
     public enum Action: Equatable {
@@ -86,6 +99,10 @@ import Logging
                 state.archives = .init()
                 return .none
             case let .load(showLoading):
+                guard state.canLoadArchives else {
+                    clearArchives(state: &state)
+                    return .none
+                }
                 guard state.loading == false else {
                     return .none
                 }
@@ -100,6 +117,9 @@ import Logging
                     searchFilter: state.filter, sortby: sortby, start: "0", order: order, append: false
                 )
             case let .appendArchives(start):
+                guard state.canLoadArchives else {
+                    return .none
+                }
                 guard state.loading == false else {
                     return .none
                 }
@@ -415,6 +435,14 @@ import Logging
             GridFeature()
         }
         .ifLet(\.$alert, action: \.alert)
+    }
+
+    func clearArchives(state: inout State) {
+        state.archivesToDisplay = .init()
+        state.archives = .init()
+        state.total = 0
+        state.loading = false
+        state.showLoading = false
     }
 
     func populateTags(state: inout State) {

--- a/LANreaderTests/ArchiveListFeatureTests.swift
+++ b/LANreaderTests/ArchiveListFeatureTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+import ComposableArchitecture
+@testable import LANreader
+
+final class ArchiveListFeatureTests: XCTestCase {
+    @MainActor
+    func testSearchTabDoesNotLoadWithoutSearchFilter() async {
+        let archive = ArchiveItem(
+            id: "existing",
+            name: "Existing",
+            extension: "zip",
+            tags: "",
+            isNew: false,
+            progress: 0,
+            pagecount: 10,
+            dateAdded: nil
+        )
+        var initialState = ArchiveListFeature.State(
+            filter: SearchFilter(category: nil, filter: nil),
+            loadOnAppear: false,
+            currentTab: .search
+        )
+        initialState.archives = [GridFeature.State(archive: Shared(value: archive))]
+        initialState.archivesToDisplay = initialState.archives
+        initialState.total = 1
+
+        let store = TestStore(initialState: initialState) {
+            ArchiveListFeature()
+        }
+
+        await store.send(.load(true)) {
+            $0.archives = []
+            $0.archivesToDisplay = []
+            $0.total = 0
+        }
+    }
+
+    func testLibraryTabCanLoadWithoutSearchFilter() {
+        let state = ArchiveListFeature.State(
+            filter: SearchFilter(category: nil, filter: nil),
+            currentTab: .library
+        )
+
+        XCTAssertTrue(state.canLoadArchives)
+    }
+}


### PR DESCRIPTION
## What
- Prevent the Search tab archive list from loading unfiltered Library results before a query exists.
- Clear stale Search archive results when an empty Search load is triggered by shared sort changes or view timing.
- Add reducer coverage for the empty Search state and keep Library unfiltered loading behavior intact.
- Bump build number from 171 to 172.

## Why
Library and Search both use `ArchiveListFeature`, but an empty filter means different things: Library should load all archives, while Search should show nothing until a query/category exists. A shared sort refresh could make Search load the Library-style unfiltered archive list.

## Verification
- `./scripts/test-ios` passed: 94 tests, 0 failures.
- `git diff --check` passed.
- `./scripts/lint` could not run because `swiftlint` is not installed in this environment.