### PR TITLE
Update CI to Xcode 26.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        destination: ['platform=iOS Simulator,OS=26.4.1,name=iPad Pro 11-inch (M5)']
+        destination: ['platform=iOS Simulator,OS=26.5,name=iPad Pro 11-inch (M5)']
     steps:
       - uses: actions/checkout@v6
 
@@ -22,7 +22,7 @@ jobs:
 
       - name: Select Xcode version
         run: |
-          sudo xcode-select -switch /Applications/Xcode_26.4.app
+          sudo xcode-select -switch /Applications/Xcode_26.5.app
           xcodebuild -version
 
       - name: Build and test

--- a/.github/workflows/manual-ipa-release.yml
+++ b/.github/workflows/manual-ipa-release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Select Xcode version
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.4.app
+          sudo xcode-select -s /Applications/Xcode_26.5.app
           xcodebuild -version
 
       - name: Resolve app versions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Use this file as the source of truth for Codex-style work in this repository.
 - Main app scheme: `LANreader`
 - Secondary scheme: `Action`
 - Test target: `LANreaderTests`
-- CI simulator destination: `platform=iOS Simulator,OS=26.4,name=iPad Pro 11-inch (M5)`
+- CI simulator destination: `platform=iOS Simulator,OS=26.5,name=iPad Pro 11-inch (M5)`
 - CI lint command: `swiftlint --strict`
 - CI test command: `xcodebuild clean test -project LANreader.xcodeproj -scheme LANreader ... -skipMacroValidation`
 - Current active GitHub workflows are `ci.yml` and `manual-ipa-release.yml`.

--- a/scripts/test-ios
+++ b/scripts/test-ios
@@ -9,7 +9,7 @@ source "$SCRIPT_DIR/_xcode_env.sh"
 prepare_xcode_environment
 trust_swift_macros
 
-DESTINATION="${LANREADER_DESTINATION:-platform=iOS Simulator,OS=26.4.1,name=iPad Pro 11-inch (M5)}"
+DESTINATION="${LANREADER_DESTINATION:-platform=iOS Simulator,OS=26.5,name=iPad Pro 11-inch (M5)}"
 RESULT_BUNDLE_PATH="$LANREADER_RESULTS_DIR/LANreader-tests.xcresult"
 
 rm -rf "$RESULT_BUNDLE_PATH"


### PR DESCRIPTION
## What changed
- Updated CI and manual IPA release workflows to select `/Applications/Xcode_26.5.app`.
- Updated the CI simulator destination and local `scripts/test-ios` default to iOS 26.5 for `iPad Pro 11-inch (M5)`.
- Updated the repo agent guide to match the new CI simulator destination.

## Why
The `macos-26-arm64` runner image now provides Xcode 26.5 and the matching iOS 26.5 simulator runtime.

## Verification
- `./scripts/lint`
- Parsed `.github/workflows/ci.yml` and `.github/workflows/manual-ipa-release.yml` as YAML.
- Confirmed no stale Xcode 26.4 / iOS 26.4 pins remain in `.github`, `scripts`, or `AGENTS.md`.

## Not run
- `./scripts/test-ios`: not run because this change only updates CI/runtime pins and documentation; no app or test behavior changed.