### PR TITLE
Add Japanese, Korean, and Traditional Chinese localization

### DIFF
--- a/Action/InfoPlist.xcstrings
+++ b/Action/InfoPlist.xcstrings
@@ -27,6 +27,12 @@
             "state" : "translated",
             "value" : "上传至LANraragi"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上傳至LANraragi"
+          }
         }
       }
     },

--- a/Action/InfoPlist.xcstrings
+++ b/Action/InfoPlist.xcstrings
@@ -10,6 +10,18 @@
             "value" : "Upload to LANraragi"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LANraragiにアップロード"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LANraragi에 업로드"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -27,6 +39,18 @@
             "state" : "new",
             "value" : "Action"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アクション"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "액션"
+          }
         }
       }
     },
@@ -37,6 +61,18 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
+            "value" : "Copyright © 2023 Jin Yifan. All rights reserved."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copyright © 2023 Jin Yifan. All rights reserved."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "Copyright © 2023 Jin Yifan. All rights reserved."
           }
         }

--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -618,6 +618,7 @@
 				ja,
 				ko,
 				"zh-Hans",
+				"zh-Hant",
 			);
 			mainGroup = 7D354C9324F1316800617F4A;
 			packageReferences = (

--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -938,7 +938,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreader.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 173;
+				CURRENT_PROJECT_VERSION = 174;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -949,7 +949,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.8.0;
+				MARKETING_VERSION = 3.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -966,7 +966,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreaderRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 173;
+				CURRENT_PROJECT_VERSION = 174;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -977,7 +977,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.8.0;
+				MARKETING_VERSION = 3.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1040,7 +1040,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 173;
+				CURRENT_PROJECT_VERSION = 174;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1052,7 +1052,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.0;
+				MARKETING_VERSION = 3.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1070,7 +1070,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 173;
+				CURRENT_PROJECT_VERSION = 174;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1082,7 +1082,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.0;
+				MARKETING_VERSION = 3.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		E9CBC0F02A3DD62F00CCD592 /* LogFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9CBC0EF2A3DD62F00CCD592 /* LogFormatter.swift */; };
 		E9DA93612C16960E003272B9 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = E9DA93602C16960E003272B9 /* Localizable.xcstrings */; };
 		E9DAEC552B07295D00ADC215 /* ArchiveDetailsV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9DAEC542B07295D00ADC215 /* ArchiveDetailsV2.swift */; };
+		E9F0ABCD2F90000100ABCDEF /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = E9F0ABCC2F90000100ABCDEF /* InfoPlist.xcstrings */; };
 		E9E3631426F463F800C58D01 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 7D354CD024F1390400617F4A /* Alamofire */; };
 		E9E3631626F463F800C58D01 /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = 7D354CE124F15F1800617F4A /* Logging */; };
 		E9E3631726F463F800C58D01 /* NotificationBannerSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 7D7A6842250239750051F232 /* NotificationBannerSwift */; };
@@ -215,6 +216,7 @@
 		E9CBC0EF2A3DD62F00CCD592 /* LogFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogFormatter.swift; sourceTree = "<group>"; };
 		E9DA93602C16960E003272B9 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		E9DAEC542B07295D00ADC215 /* ArchiveDetailsV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailsV2.swift; sourceTree = "<group>"; };
+		E9F0ABCC2F90000100ABCDEF /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		E9E3631E26F471E400C58D01 /* LogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogView.swift; sourceTree = "<group>"; };
 		E9F3B0112B01A21C00F60F62 /* CategoryListV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryListV2.swift; sourceTree = "<group>"; };
 		F1A2B3C72F60000100AAA001 /* ReaderPositioning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPositioning.swift; sourceTree = "<group>"; };
@@ -406,6 +408,7 @@
 				7D354CA524F1316D00617F4A /* Assets.xcassets */,
 				7D354CAA24F1316D00617F4A /* LaunchScreen.storyboard */,
 				7D354CAD24F1316D00617F4A /* Info.plist */,
+				E9F0ABCC2F90000100ABCDEF /* InfoPlist.xcstrings */,
 				7D354CA724F1316D00617F4A /* Preview Content */,
 				4BD82228A995BCC00EDC8A0C /* Service */,
 				4BD8260DA98B959BE0550327 /* Models */,
@@ -612,6 +615,8 @@
 			knownRegions = (
 				en,
 				Base,
+				ja,
+				ko,
 				"zh-Hans",
 			);
 			mainGroup = 7D354C9324F1316800617F4A;
@@ -644,6 +649,7 @@
 			files = (
 				7D7B26A224F4D13600149341 /* LICENSE.md in Resources */,
 				E9DA93612C16960E003272B9 /* Localizable.xcstrings in Resources */,
+				E9F0ABCD2F90000100ABCDEF /* InfoPlist.xcstrings in Resources */,
 				7D354CAC24F1316D00617F4A /* LaunchScreen.storyboard in Resources */,
 				7D354CA924F1316D00617F4A /* Preview Assets.xcassets in Resources */,
 				7D354CF324F222FC00617F4A /* README.md in Resources */,

--- a/LANreader/InfoPlist.xcstrings
+++ b/LANreader/InfoPlist.xcstrings
@@ -1,0 +1,47 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "CFBundleName" : {
+      "comment" : "Bundle name",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "LANreader"
+          }
+        }
+      }
+    },
+    "NSFaceIDUsageDescription" : {
+      "comment" : "Privacy - Face ID usage description",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We need to unlock your App"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アプリのロックを解除するために使用します"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "앱 잠금을 해제하는 데 사용됩니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "我们需要解锁您的App"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/LANreader/InfoPlist.xcstrings
+++ b/LANreader/InfoPlist.xcstrings
@@ -39,6 +39,12 @@
             "state" : "translated",
             "value" : "我们需要解锁您的App"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "我們需要解鎖您的App"
+          }
         }
       }
     }

--- a/LANreader/Page/ArchiveReader.swift
+++ b/LANreader/Page/ArchiveReader.swift
@@ -1165,7 +1165,7 @@ struct ArchiveReader: View {
                 systemImage: "arrow.clockwise",
                 tint: Color(uiColor: .systemBlue),
                 disabled: store.cached,
-                accessibilityLabel: "Reload current page"
+                accessibilityLabel: "archive.reader.reload.currentPage"
             ) {
                 let indexString = store.pages[store.safeCurrentPageIndex].id
                 store.send(.page(.element(id: indexString, action: .load(true))))
@@ -1175,7 +1175,7 @@ struct ArchiveReader: View {
                 systemImage: "play.fill",
                 tint: Color(uiColor: .systemPurple),
                 disabled: autoPageDisabled,
-                accessibilityLabel: "Auto page"
+                accessibilityLabel: "archive.reader.autoPage"
             ) {
                 store.send(.showAutoPageConfig)
             }
@@ -1192,7 +1192,7 @@ struct ArchiveReader: View {
             readerToolbarButton(
                 systemImage: cacheActionRemoves ? "trash.fill" : "tray.and.arrow.down.fill",
                 tint: cacheActionRemoves ? Color(uiColor: .systemRed) : Color(uiColor: .systemOrange),
-                accessibilityLabel: cacheActionRemoves ? "Remove cache" : "Download pages"
+                accessibilityLabel: cacheActionRemoves ? "archive.reader.cache.remove" : "archive.reader.pages.download"
             ) {
                 if cacheActionRemoves {
                     store.send(.removeCache)
@@ -1205,7 +1205,7 @@ struct ArchiveReader: View {
                 systemImage: "photo.artframe",
                 tint: Color(uiColor: .systemTeal),
                 disabled: store.settingThumbnail || store.cached,
-                accessibilityLabel: "Set archive thumbnail"
+                accessibilityLabel: "archive.thumbnail.current"
             ) {
                 store.send(.setThumbnail)
             }
@@ -1228,14 +1228,21 @@ struct ArchiveReader: View {
         .foregroundStyle(.primary)
         .background(Color(uiColor: .tertiarySystemFill), in: Capsule())
         .environment(\.layoutDirection, .leftToRight)
-        .accessibilityLabel(Text(verbatim: "Page \(currentPage) of \(pageCount)"))
+        .accessibilityLabel(
+            Text(verbatim: pageCounterAccessibilityLabel(currentPage: currentPage, pageCount: pageCount))
+        )
+    }
+
+    private func pageCounterAccessibilityLabel(currentPage: Int, pageCount: Int) -> String {
+        let format = String(localized: "archive.reader.page.accessibility %lld %lld")
+        return String(format: format, Int64(currentPage), Int64(pageCount))
     }
 
     private func readerToolbarButton(
         systemImage: String,
         tint: Color,
         disabled: Bool = false,
-        accessibilityLabel: String,
+        accessibilityLabel: LocalizedStringKey,
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
@@ -1252,7 +1259,7 @@ struct ArchiveReader: View {
         .buttonStyle(.plain)
         .disabled(disabled)
         .opacity(disabled ? 0.42 : 1)
-        .accessibilityLabel(Text(verbatim: accessibilityLabel))
+        .accessibilityLabel(Text(accessibilityLabel))
     }
 
     private func readerPageSlider(
@@ -1303,7 +1310,7 @@ struct ArchiveReader: View {
         }
         .frame(height: 34)
         .environment(\.layoutDirection, .leftToRight)
-        .accessibilityLabel(Text(verbatim: "Page slider"))
+        .accessibilityLabel(Text("archive.reader.page.slider"))
     }
 
     private func sendSliderDragChanged(

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -20,6 +20,12 @@
             "state" : "translated",
             "value" : ""
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
         }
       }
     },
@@ -48,6 +54,12 @@
             "state" : "translated",
             "value" : "%.0fs"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%.0fs"
+          }
         }
       }
     },
@@ -66,6 +78,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld"
@@ -92,6 +110,12 @@
             "state" : "translated",
             "value" : "🍬"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "🍬"
+          }
         }
       }
     },
@@ -114,6 +138,12 @@
             "state" : "translated",
             "value" : "🍵"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "🍵"
+          }
         }
       }
     },
@@ -132,6 +162,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "🤯"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "🤯"
@@ -165,6 +201,12 @@
             "state" : "translated",
             "value" : "已开始缓存文档"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已開始緩存文檔"
+          }
         }
       }
     },
@@ -193,6 +235,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "从缓存中读取文档失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從緩存中讀取文檔失敗"
           }
         }
       }
@@ -223,6 +271,12 @@
             "state" : "translated",
             "value" : "从缓存中读取图片失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從緩存中讀取圖片失敗"
+          }
         }
       }
     },
@@ -251,6 +305,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "从缓存中删除文档"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從緩存中刪除文檔"
           }
         }
       }
@@ -281,6 +341,12 @@
             "state" : "translated",
             "value" : "无法从缓存中删除文档, 请重试"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法從緩存中刪除文檔, 請重試"
+          }
         }
       }
     },
@@ -309,6 +375,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "从缓存中删除文档?\n这不会从服务器上删除文档"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從緩存中刪除文檔?\n這不會從服務器上刪除文檔"
           }
         }
       }
@@ -339,6 +411,12 @@
             "state" : "translated",
             "value" : "添加文档至类别失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加文檔至類別失敗"
+          }
         }
       }
     },
@@ -367,6 +445,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "成功添加文档至类别"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "成功添加文檔至類別"
           }
         }
       }
@@ -397,6 +481,12 @@
             "state" : "translated",
             "value" : "管理文档所属类别"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "管理文檔所屬類別"
+          }
         }
       }
     },
@@ -425,6 +515,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "从类别中移除文档失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從類別中移除文檔失敗"
           }
         }
       }
@@ -455,6 +551,12 @@
             "state" : "translated",
             "value" : "成功从类别中移除文档"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "成功從類別中移除文檔"
+          }
         }
       }
     },
@@ -483,6 +585,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除文档"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除文檔"
           }
         }
       }
@@ -513,6 +621,12 @@
             "state" : "translated",
             "value" : "确定要删除此文档吗？"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確定要刪除此文檔嗎？"
+          }
         }
       }
     },
@@ -541,6 +655,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "标签"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標籤"
           }
         }
       }
@@ -571,6 +691,12 @@
             "state" : "translated",
             "value" : "标题"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標題"
+          }
         }
       }
     },
@@ -600,6 +726,12 @@
             "state" : "translated",
             "value" : "成功更新文档元数据"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "成功更新文檔元數據"
+          }
         }
       }
     },
@@ -627,6 +759,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "翻译等待中"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻譯等待中"
           }
         }
       }
@@ -656,6 +794,12 @@
             "state" : "translated",
             "value" : "翻译进度:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻譯進度:"
+          }
         }
       }
     },
@@ -684,6 +828,12 @@
             "state" : "translated",
             "value" : "翻译队列位置:"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻譯隊列位置:"
+          }
         }
       }
     },
@@ -711,6 +861,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "翻译请求失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻譯請求失敗"
           }
         }
       }
@@ -741,6 +897,12 @@
             "state" : "translated",
             "value" : "已在第一个"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已在第一個"
+          }
         }
       }
     },
@@ -769,6 +931,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "从头开始阅读"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從頭開始閱讀"
           }
         }
       }
@@ -799,6 +967,12 @@
             "state" : "translated",
             "value" : "已在最后一个"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已在最後一個"
+          }
         }
       }
     },
@@ -827,6 +1001,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "释放以加载"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "釋放以加載"
           }
         }
       }
@@ -857,6 +1037,12 @@
             "state" : "translated",
             "value" : "下一个"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下一個"
+          }
         }
       }
     },
@@ -885,6 +1071,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "上一个"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上一個"
           }
         }
       }
@@ -915,6 +1107,12 @@
             "state" : "translated",
             "value" : "自动翻页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動翻頁"
+          }
         }
       }
     },
@@ -943,6 +1141,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除缓存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除緩存"
           }
         }
       }
@@ -973,6 +1177,12 @@
             "state" : "translated",
             "value" : "第 %lld 页，共 %lld 页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第 %lld 頁，共 %lld 頁"
+          }
         }
       }
     },
@@ -1001,6 +1211,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "页面滑块"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "頁面滑塊"
           }
         }
       }
@@ -1031,6 +1247,12 @@
             "state" : "translated",
             "value" : "下载页面"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下載頁面"
+          }
         }
       }
     },
@@ -1060,6 +1282,12 @@
             "state" : "translated",
             "value" : "重新加载当前页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新加載當前頁"
+          }
         }
       }
     },
@@ -1085,6 +1313,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刷新封面"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "刷新封面"
@@ -1118,6 +1352,12 @@
             "state" : "translated",
             "value" : "%d 已选"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d 已選"
+          }
         }
       }
     },
@@ -1146,6 +1386,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加选定的文档至类别"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加選定的文檔至類別"
           }
         }
       }
@@ -1176,6 +1422,12 @@
             "state" : "translated",
             "value" : "部分文档添加失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "部分文檔添加失敗"
+          }
         }
       }
     },
@@ -1204,6 +1456,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "成功添加文档至类别"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "成功添加文檔至類別"
           }
         }
       }
@@ -1234,6 +1492,12 @@
             "state" : "translated",
             "value" : "确定从类别中移除所选文档吗?"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確定從類別中移除所選文檔嗎?"
+          }
         }
       }
     },
@@ -1262,6 +1526,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "部分文档删除失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "部分文檔刪除失敗"
           }
         }
       }
@@ -1292,6 +1562,12 @@
             "state" : "translated",
             "value" : "成功删除选定文档"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "成功刪除選定文檔"
+          }
         }
       }
     },
@@ -1320,6 +1596,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "确定要删除全部选定文档吗?"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確定要刪除全部選定文檔嗎?"
           }
         }
       }
@@ -1350,6 +1632,12 @@
             "state" : "translated",
             "value" : "部分文档删除失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "部分文檔刪除失敗"
+          }
         }
       }
     },
@@ -1378,6 +1666,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "成功删除选定文档"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "成功刪除選定文檔"
           }
         }
       }
@@ -1408,6 +1702,12 @@
             "state" : "translated",
             "value" : "没有标签"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有標籤"
+          }
         }
       }
     },
@@ -1433,6 +1733,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加日期"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加日期"
@@ -1466,6 +1772,12 @@
             "state" : "translated",
             "value" : "其他"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "其他"
+          }
         }
       }
     },
@@ -1494,6 +1806,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "设置当前页为封面"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設置當前頁爲封面"
           }
         }
       }
@@ -1524,6 +1842,12 @@
             "state" : "translated",
             "value" : "成功设置当前页为封面"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "成功設置當前頁爲封面"
+          }
         }
       }
     },
@@ -1553,6 +1877,12 @@
             "state" : "translated",
             "value" : "已缓存"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已緩存"
+          }
         }
       }
     },
@@ -1578,6 +1908,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消"
@@ -1611,6 +1947,12 @@
             "state" : "translated",
             "value" : "类别"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "類別"
+          }
         }
       }
     },
@@ -1639,6 +1981,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "确定要删除此类别吗？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確定要刪除此類別嗎？"
           }
         }
       }
@@ -1669,6 +2017,12 @@
             "state" : "translated",
             "value" : "删除类别失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除類別失敗"
+          }
         }
       }
     },
@@ -1697,6 +2051,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "没有类别"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有類別"
           }
         }
       }
@@ -1727,6 +2087,12 @@
             "state" : "translated",
             "value" : "%lld 个文档"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 個文檔"
+          }
         }
       }
     },
@@ -1752,6 +2118,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索: %@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "搜索: %@"
@@ -1785,6 +2157,12 @@
             "state" : "translated",
             "value" : "已固定"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已固定"
+          }
         }
       }
     },
@@ -1813,6 +2191,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "编辑类别"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯類別"
           }
         }
       }
@@ -1843,6 +2227,12 @@
             "state" : "translated",
             "value" : "编辑类别失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯類別失敗"
+          }
         }
       }
     },
@@ -1872,6 +2262,12 @@
             "state" : "translated",
             "value" : "类别名"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "類別名"
+          }
         }
       }
     },
@@ -1897,6 +2293,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加"
@@ -1930,6 +2332,12 @@
             "state" : "translated",
             "value" : "添加类别失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加類別失敗"
+          }
         }
       }
     },
@@ -1958,6 +2366,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "动态类别"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動態類別"
           }
         }
       }
@@ -1988,6 +2402,12 @@
             "state" : "translated",
             "value" : "搜索关键词"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索關鍵詞"
+          }
         }
       }
     },
@@ -2016,6 +2436,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製"
           }
         }
       }
@@ -2046,6 +2472,12 @@
             "state" : "translated",
             "value" : "删除"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除"
+          }
         }
       }
     },
@@ -2075,6 +2507,12 @@
             "state" : "translated",
             "value" : "详细"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "詳細"
+          }
         }
       }
     },
@@ -2100,6 +2538,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "完成"
@@ -2132,6 +2576,12 @@
             "state" : "translated",
             "value" : "任务ID: %lld"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "任務ID: %lld"
+          }
         }
       }
     },
@@ -2160,6 +2610,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "下载任务已添加，请前往 设置 - 服务器 - 上传文档 查看进度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下載任務已添加，請前往 設置 - 服務器 - 上傳文檔 查看進度"
           }
         }
       }
@@ -2190,6 +2646,12 @@
             "state" : "translated",
             "value" : "正在缩小图片尺寸"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在縮小圖片尺寸"
+          }
         }
       }
     },
@@ -2218,6 +2680,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "编辑"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯"
           }
         }
       }
@@ -2248,6 +2716,12 @@
             "state" : "translated",
             "value" : "错误"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "錯誤"
+          }
         }
       }
     },
@@ -2276,6 +2750,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除文档失败，请重试"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除文檔失敗，請重試"
           }
         }
       }
@@ -2306,6 +2786,12 @@
             "state" : "translated",
             "value" : "添加下载任务失败，请重试"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加下載任務失敗，請重試"
+          }
         }
       }
     },
@@ -2334,6 +2820,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "服务器未返回任何页面"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服務器未返回任何頁面"
           }
         }
       }
@@ -2364,6 +2856,12 @@
             "state" : "translated",
             "value" : "密码不正确，请重试"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密碼不正確，請重試"
+          }
         }
       }
     },
@@ -2392,6 +2890,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "密码不匹配，请重试"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密碼不匹配，請重試"
           }
         }
       }
@@ -2422,6 +2926,12 @@
             "state" : "translated",
             "value" : "历史记录"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歷史記錄"
+          }
         }
       }
     },
@@ -2451,6 +2961,12 @@
             "state" : "translated",
             "value" : "API Key, 可以在设置里设定. 这不是你的密"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API Key, 可以在設置裏設定. 這不是你的密"
+          }
         }
       }
     },
@@ -2476,6 +2992,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提交"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "提交"
@@ -2509,6 +3031,12 @@
             "state" : "translated",
             "value" : "http(s)://10.0.1.10:3000"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "http(s)://10.0.1.10:3000"
+          }
         }
       }
     },
@@ -2537,6 +3065,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "非本地网络必须使用https协议"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "非本地網絡必須使用https協議"
           }
         }
       }
@@ -2567,6 +3101,12 @@
             "state" : "translated",
             "value" : "库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "庫"
+          }
         }
       }
     },
@@ -2595,6 +3135,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "加载中"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加載中"
           }
         }
       }
@@ -2625,6 +3171,12 @@
             "state" : "translated",
             "value" : "我们需要解锁您的App"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "我們需要解鎖您的App"
+          }
         }
       }
     },
@@ -2653,6 +3205,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "输入新密码"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入新密碼"
           }
         }
       }
@@ -2683,6 +3241,12 @@
             "state" : "translated",
             "value" : "输入密码"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入密碼"
+          }
         }
       }
     },
@@ -2711,6 +3275,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "输入当前密码"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入當前密碼"
           }
         }
       }
@@ -2741,6 +3311,12 @@
             "state" : "translated",
             "value" : "确认新密码"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確認新密碼"
+          }
         }
       }
     },
@@ -2769,6 +3345,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "开始"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始"
           }
         }
       }
@@ -2799,6 +3381,12 @@
             "state" : "translated",
             "value" : "随机"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隨機"
+          }
         }
       }
     },
@@ -2824,6 +3412,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "移除"
@@ -2857,6 +3451,12 @@
             "state" : "translated",
             "value" : "保存"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存"
+          }
         }
       }
     },
@@ -2882,6 +3482,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "搜索"
@@ -2915,6 +3521,12 @@
             "state" : "translated",
             "value" : "选择"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇"
+          }
         }
       }
     },
@@ -2944,6 +3556,12 @@
             "state" : "translated",
             "value" : "设置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設置"
+          }
         }
       }
     },
@@ -2971,6 +3589,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "高级"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高級"
           }
         }
       }
@@ -3000,6 +3624,12 @@
             "state" : "translated",
             "value" : "实时翻译"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "實時翻譯"
+          }
         }
       }
     },
@@ -3027,6 +3657,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此功能使用[mange-image-translator](https://github.com/zyddnys/manga-image-translator) 来即时翻译漫画页面. 你需要一个本地部署的 mange-image-translator 来使用这个功能"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此功能使用[mange-image-translator](https://github.com/zyddnys/manga-image-translator) 來即時翻譯漫畫頁面. 你需要一個本地部署的 mange-image-translator 來使用這個功能"
           }
         }
       }
@@ -3056,6 +3692,12 @@
             "state" : "translated",
             "value" : "边界框生成阈值"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "邊界框生成閾值"
+          }
         }
       }
     },
@@ -3083,6 +3725,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "检测图像大小"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檢測圖像大小"
           }
         }
       }
@@ -3112,6 +3760,12 @@
             "state" : "translated",
             "value" : "启用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啓用"
+          }
         }
       }
     },
@@ -3139,6 +3793,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "修补器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "修補器"
           }
         }
       }
@@ -3168,6 +3828,12 @@
             "state" : "translated",
             "value" : "修复图像大小"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "修復圖像大小"
+          }
         }
       }
     },
@@ -3195,6 +3861,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "目标语言"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目標語言"
           }
         }
       }
@@ -3224,6 +3896,12 @@
             "state" : "translated",
             "value" : "文本遮罩扩展"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文本遮罩擴展"
+          }
         }
       }
     },
@@ -3248,6 +3926,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文本渲染方向"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "文本渲染方向"
@@ -3280,6 +3964,12 @@
             "state" : "translated",
             "value" : "翻译服务"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻譯服務"
+          }
         }
       }
     },
@@ -3307,6 +3997,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "文本检测器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文本檢測器"
           }
         }
       }
@@ -3336,6 +4032,12 @@
             "state" : "translated",
             "value" : "文本骨架扩展"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文本骨架擴展"
+          }
         }
       }
     },
@@ -3363,6 +4065,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "服务器地址"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服務器地址"
           }
         }
       }
@@ -3393,6 +4101,12 @@
             "state" : "translated",
             "value" : "艺术家"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "藝術家"
+          }
         }
       }
     },
@@ -3418,6 +4132,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "角色"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "角色"
@@ -3451,6 +4171,12 @@
             "state" : "translated",
             "value" : "自定义"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自定義"
+          }
         }
       }
     },
@@ -3479,6 +4205,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自定义排序可以是任意标签名"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自定義排序可以是任意標籤名"
           }
         }
       }
@@ -3509,6 +4241,12 @@
             "state" : "translated",
             "value" : "自定义排序"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自定義排序"
+          }
         }
       }
     },
@@ -3534,6 +4272,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日期"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "日期"
@@ -3567,6 +4311,12 @@
             "state" : "translated",
             "value" : "展会"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "展會"
+          }
         }
       }
     },
@@ -3595,6 +4345,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "社团"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "社團"
           }
         }
       }
@@ -3625,6 +4381,12 @@
             "state" : "translated",
             "value" : "最近阅读"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近閱讀"
+          }
         }
       }
     },
@@ -3654,6 +4416,12 @@
             "state" : "translated",
             "value" : "标题"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標題"
+          }
         }
       }
     },
@@ -3679,6 +4447,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同人"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "同人"
@@ -3712,6 +4486,12 @@
             "state" : "translated",
             "value" : "随机"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隨機"
+          }
         }
       }
     },
@@ -3737,6 +4517,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系列"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "系列"
@@ -3770,6 +4556,12 @@
             "state" : "translated",
             "value" : "升序"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "升序"
+          }
         }
       }
     },
@@ -3795,6 +4587,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "降序"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "降序"
@@ -3828,6 +4626,12 @@
             "state" : "translated",
             "value" : "数据库"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "數據庫"
+          }
         }
       }
     },
@@ -3856,6 +4660,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除数据库缓存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除數據庫緩存"
           }
         }
       }
@@ -3886,6 +4696,12 @@
             "state" : "translated",
             "value" : "读取数据库失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "讀取數據庫失敗"
+          }
         }
       }
     },
@@ -3914,6 +4730,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "调试"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "調試"
           }
         }
       }
@@ -3944,6 +4766,12 @@
             "state" : "translated",
             "value" : "App日志"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App日誌"
+          }
         }
       }
     },
@@ -3972,6 +4800,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "服务器设定"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服務器設定"
           }
         }
       }
@@ -4002,6 +4836,12 @@
             "state" : "translated",
             "value" : "启动后总是从服务器自动拉取数据"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啓動後總是從服務器自動拉取數據"
+          }
         }
       }
     },
@@ -4030,6 +4870,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "服务器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服務器"
           }
         }
       }
@@ -4060,6 +4906,12 @@
             "state" : "translated",
             "value" : "上传文档"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上傳文檔"
+          }
         }
       }
     },
@@ -4088,6 +4940,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "上传"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上傳"
           }
         }
       }
@@ -4118,6 +4976,12 @@
             "state" : "translated",
             "value" : "从指定URL上传文档，一行一个"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從指定URL上傳文檔，一行一個"
+          }
         }
       }
     },
@@ -4146,6 +5010,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已结束任务将在一段时间后自动被移除"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已結束任務將在一段時間後自動被移除"
           }
         }
       }
@@ -4176,6 +5046,12 @@
             "state" : "translated",
             "value" : "切换导航"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換導航"
+          }
         }
       }
     },
@@ -4204,6 +5080,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "下一页"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下一頁"
           }
         }
       }
@@ -4234,6 +5116,12 @@
             "state" : "translated",
             "value" : "上一页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上一頁"
+          }
         }
       }
     },
@@ -4262,6 +5150,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "阅读设定"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閱讀設定"
           }
         }
       }
@@ -4292,6 +5186,12 @@
             "state" : "translated",
             "value" : "自动翻页间隔"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動翻頁間隔"
+          }
         }
       }
     },
@@ -4320,6 +5220,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切换导航可以取消自动翻页"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換導航可以取消自動翻頁"
           }
         }
       }
@@ -4350,6 +5256,12 @@
             "state" : "translated",
             "value" : "阅读顺序"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閱讀順序"
+          }
         }
       }
     },
@@ -4378,6 +5290,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "从左向右"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從左向右"
           }
         }
       }
@@ -4408,6 +5326,12 @@
             "state" : "translated",
             "value" : "从右向左"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從右向左"
+          }
         }
       }
     },
@@ -4436,6 +5360,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "纵向"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "縱向"
           }
         }
       }
@@ -4466,6 +5396,12 @@
             "state" : "translated",
             "value" : "双页模式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "雙頁模式"
+          }
         }
       }
     },
@@ -4494,6 +5430,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用备选阅读器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用備選閱讀器"
           }
         }
       }
@@ -4524,6 +5466,12 @@
             "state" : "translated",
             "value" : "如当前阅读器有性能问题，请尝试使用备选阅读器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如當前閱讀器有性能問題，請嘗試使用備選閱讀器"
+          }
         }
       }
     },
@@ -4552,6 +5500,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示原图"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示原圖"
           }
         }
       }
@@ -4582,6 +5536,12 @@
             "state" : "translated",
             "value" : "自动分页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動分頁"
+          }
         }
       }
     },
@@ -4610,6 +5570,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "优先显示左侧分割页面"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "優先顯示左側分割頁面"
           }
         }
       }
@@ -4640,6 +5606,12 @@
             "state" : "translated",
             "value" : "点击屏幕左侧"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "點擊屏幕左側"
+          }
         }
       }
     },
@@ -4668,6 +5640,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "点击屏幕中间"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "點擊屏幕中間"
           }
         }
       }
@@ -4698,6 +5676,12 @@
             "state" : "translated",
             "value" : "点击片屏幕右侧"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "點擊片屏幕右側"
+          }
         }
       }
     },
@@ -4723,6 +5707,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "支持"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "支持"
@@ -4756,6 +5746,12 @@
             "state" : "translated",
             "value" : "在 GitHub 上反馈问题"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 GitHub 上反饋問題"
+          }
         }
       }
     },
@@ -4784,6 +5780,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "💰 支持开发者"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "💰 支持開發者"
           }
         }
       }
@@ -4814,6 +5816,12 @@
             "state" : "translated",
             "value" : "视图设定"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "視圖設定"
+          }
         }
       }
     },
@@ -4842,6 +5850,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "后台运行时模糊界面显示"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "後臺運行時模糊界面顯示"
           }
         }
       }
@@ -4872,6 +5886,12 @@
             "state" : "translated",
             "value" : "隐藏已读"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱藏已讀"
+          }
         }
       }
     },
@@ -4901,6 +5921,12 @@
             "state" : "translated",
             "value" : "使用密码锁定此App"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用密碼鎖定此App"
+          }
         }
       }
     },
@@ -4926,6 +5952,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "成功"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "成功"
@@ -4959,6 +5991,12 @@
             "state" : "translated",
             "value" : "和"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "和"
+          }
         }
       }
     },
@@ -4987,6 +6025,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "你好，我是这个App的开发者。非常感谢您使用这个阅读器。成为支持者不会解锁更多的功能，但是如果您有意愿和能力，十分欢迎您支持我的工作，谢谢。 ❤️"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你好，我是這個App的開發者。非常感謝您使用這個閱讀器。成爲支持者不會解鎖更多的功能，但是如果您有意願和能力，十分歡迎您支持我的工作，謝謝。 ❤️"
           }
         }
       }
@@ -5017,6 +6061,12 @@
             "state" : "translated",
             "value" : "成为支持者"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "成爲支持者"
+          }
         }
       }
     },
@@ -5045,6 +6095,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "单次"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "單次"
           }
         }
       }
@@ -5075,6 +6131,12 @@
             "state" : "translated",
             "value" : "隐私政策"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱私政策"
+          }
         }
       }
     },
@@ -5104,6 +6166,12 @@
             "state" : "translated",
             "value" : "很棒的糖果，谢谢 ☺️"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "很棒的糖果，謝謝 ☺️"
+          }
         }
       }
     },
@@ -5131,6 +6199,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "感激不尽 ❤️"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "感激不盡 ❤️"
           }
         }
       }
@@ -5161,6 +6235,12 @@
             "state" : "translated",
             "value" : "服务条款"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服務條款"
+          }
         }
       }
     },
@@ -5189,6 +6269,12 @@
             "state" : "translated",
             "value" : "类别"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "類別"
+          }
         }
       }
     },
@@ -5214,6 +6300,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每年"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "每年"
@@ -5247,6 +6339,12 @@
             "state" : "translated",
             "value" : "年度订阅将自动续订，除非手动提前一天取消。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "年度訂閱將自動續訂，除非手動提前一天取消。"
+          }
         }
       }
     },
@@ -5276,6 +6374,12 @@
             "state" : "translated",
             "value" : "每年赞助"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每年贊助"
+          }
         }
       }
     },
@@ -5303,6 +6407,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "翻译中…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻譯中…"
           }
         }
       }
@@ -5332,6 +6442,12 @@
             "state" : "translated",
             "value" : "检测文字"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檢測文字"
+          }
         }
       }
     },
@@ -5359,6 +6475,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "翻译服务未返回任何文字"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻譯服務未返回任何文字"
           }
         }
       }
@@ -5388,6 +6510,12 @@
             "state" : "translated",
             "value" : "下载图片"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下載圖片"
+          }
         }
       }
     },
@@ -5416,6 +6544,12 @@
             "state" : "translated",
             "value" : "修复图片"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "修復圖片"
+          }
         }
       }
     },
@@ -5440,6 +6574,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生成文字遮罩"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "生成文字遮罩"
@@ -5472,6 +6612,12 @@
             "state" : "translated",
             "value" : "运行光学字符识别"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "運行光學字符識別"
+          }
         }
       }
     },
@@ -5499,6 +6645,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "处理中"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "處理中"
           }
         }
       }
@@ -5528,6 +6680,12 @@
             "state" : "translated",
             "value" : "渲染已翻译的文字"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "渲染已翻譯的文字"
+          }
         }
       }
     },
@@ -5555,6 +6713,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "合并文字"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "合併文字"
           }
         }
       }
@@ -5584,6 +6748,12 @@
             "state" : "translated",
             "value" : "渲染已翻译的文字"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "渲染已翻譯的文字"
+          }
         }
       }
     },
@@ -5611,6 +6781,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "上传中"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上傳中"
           }
         }
       }
@@ -5640,6 +6816,12 @@
             "state" : "translated",
             "value" : "运行放大"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "運行放大"
+          }
         }
       }
     },
@@ -5665,6 +6847,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "版本"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "版本"
@@ -5698,6 +6886,12 @@
             "state" : "translated",
             "value" : "警告"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "警告"
+          }
         }
       }
     },
@@ -5726,6 +6920,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "这个文档似乎是RAR格式的。部分RAR格式与LANraragi存在兼容性问题，如果无法正常阅读，请将其转换为ZIP格式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這個文檔似乎是RAR格式的。部分RAR格式與LANraragi存在兼容性問題，如果無法正常閱讀，請將其轉換爲ZIP格式"
           }
         }
       }

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -3,6 +3,18 @@
   "strings" : {
     "" : {
       "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19,6 +31,18 @@
             "value" : "%.0fs"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%.0fs"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%.0fs"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29,6 +53,18 @@
     },
     "%lld" : {
       "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -39,6 +75,18 @@
     },
     "🍬" : {
       "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "🍬"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "🍬"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -49,6 +97,18 @@
     },
     "🍵" : {
       "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "🍵"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "🍵"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -59,6 +119,18 @@
     },
     "🤯" : {
       "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "🤯"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "🤯"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -74,6 +146,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Archive is being added to cache"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アーカイブをキャッシュに追加しています"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아카이브를 캐시에 추가하는 중입니다"
           }
         },
         "zh-Hans" : {
@@ -93,6 +177,18 @@
             "value" : "Failed to load archive from cache"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャッシュからアーカイブを読み込めませんでした"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캐시에서 아카이브를 불러오지 못했습니다"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -108,6 +204,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Failed to load page from cache"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャッシュからページを読み込めませんでした"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캐시에서 페이지를 불러오지 못했습니다"
           }
         },
         "zh-Hans" : {
@@ -127,6 +235,18 @@
             "value" : "Remove archive from cache"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アーカイブをキャッシュから削除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캐시에서 아카이브 제거"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -142,6 +262,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Failed to remove archive from cache, please retry"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アーカイブをキャッシュから削除できませんでした。もう一度お試しください"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캐시에서 아카이브를 제거하지 못했습니다. 다시 시도해 주세요"
           }
         },
         "zh-Hans" : {
@@ -161,6 +293,18 @@
             "value" : "Remove archive from cache?\nThis will not remove archive from server"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アーカイブをキャッシュから削除しますか？\nサーバー上のアーカイブは削除されません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캐시에서 아카이브를 제거할까요?\n서버의 아카이브는 삭제되지 않습니다"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -176,6 +320,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Failed to add archive to category"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アーカイブをカテゴリーに追加できませんでした"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아카이브를 카테고리에 추가하지 못했습니다"
           }
         },
         "zh-Hans" : {
@@ -195,6 +351,18 @@
             "value" : "Successfully added archive to category"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アーカイブをカテゴリーに追加しました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아카이브를 카테고리에 추가했습니다"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -210,6 +378,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Add/Remove archive from category"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アーカイブのカテゴリーを追加/削除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아카이브 카테고리 추가/제거"
           }
         },
         "zh-Hans" : {
@@ -229,6 +409,18 @@
             "value" : "Failed to remove archive from category"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アーカイブをカテゴリーから削除できませんでした"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "카테고리에서 아카이브를 제거하지 못했습니다"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -244,6 +436,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Successfully removed archive from category"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アーカイブをカテゴリーから削除しました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "카테고리에서 아카이브를 제거했습니다"
           }
         },
         "zh-Hans" : {
@@ -263,6 +467,18 @@
             "value" : "Delete archive"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アーカイブを削除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아카이브 삭제"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -278,6 +494,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Are you sure you want to delete this archive?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このアーカイブを削除してもよろしいですか？"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 아카이브를 삭제할까요?"
           }
         },
         "zh-Hans" : {
@@ -297,6 +525,18 @@
             "value" : "Tags"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タグ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "태그"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -312,6 +552,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Title"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タイトル"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제목"
           }
         },
         "zh-Hans" : {
@@ -331,6 +583,18 @@
             "value" : "Successfully updated archive metadata"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アーカイブのメタデータを更新しました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아카이브 메타데이터를 업데이트했습니다"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -345,6 +609,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Translation pending"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻訳待機中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "번역 대기 중"
           }
         },
         "zh-Hans" : {
@@ -363,6 +639,18 @@
             "value" : "Translation progress:"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻訳の進行状況:"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "번역 진행률:"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -379,6 +667,18 @@
             "value" : "Translation in queue position:"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻訳キューの位置:"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "번역 대기열 위치:"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -393,6 +693,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Failed to send translation request"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻訳リクエストを送信できませんでした"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "번역 요청을 보내지 못했습니다"
           }
         },
         "zh-Hans" : {
@@ -412,6 +724,18 @@
             "value" : "Already at the first archive"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すでに最初のアーカイブです"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이미 첫 번째 아카이브입니다"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -427,6 +751,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Read from beginning"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最初から読む"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "처음부터 읽기"
           }
         },
         "zh-Hans" : {
@@ -446,6 +782,18 @@
             "value" : "Already at the last archive"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すでに最後のアーカイブです"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이미 마지막 아카이브입니다"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -461,6 +809,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Release to load"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "離すと読み込みます"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "놓으면 불러옵니다"
           }
         },
         "zh-Hans" : {
@@ -480,6 +840,18 @@
             "value" : "Next archive"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "次のアーカイブ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다음 아카이브"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -497,10 +869,196 @@
             "value" : "Previous archive"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前のアーカイブ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이전 아카이브"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "上一个"
+          }
+        }
+      }
+    },
+    "archive.reader.autoPage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto page"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動ページ送り"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자동 페이지 넘김"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动翻页"
+          }
+        }
+      }
+    },
+    "archive.reader.cache.remove" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove cache"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャッシュを削除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캐시 제거"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除缓存"
+          }
+        }
+      }
+    },
+    "archive.reader.page.accessibility %lld %lld" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page %lld of %lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld / %lld ページ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld/%lld 페이지"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第 %lld 页，共 %lld 页"
+          }
+        }
+      }
+    },
+    "archive.reader.page.slider" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page slider"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ページスライダー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "페이지 슬라이더"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "页面滑块"
+          }
+        }
+      }
+    },
+    "archive.reader.pages.download" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download pages"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ページをダウンロード"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "페이지 다운로드"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载页面"
+          }
+        }
+      }
+    },
+    "archive.reader.reload.currentPage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reload current page"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在のページを再読み込み"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 페이지 다시 불러오기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新加载当前页"
           }
         }
       }
@@ -512,6 +1070,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reload thumbnail"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サムネイルを再読み込み"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "썸네일 다시 불러오기"
           }
         },
         "zh-Hans" : {
@@ -531,6 +1101,18 @@
             "value" : "%d Selected"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d 件選択済み"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d개 선택됨"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -546,6 +1128,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Add selected archive(s) to category"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択したアーカイブをカテゴリーに追加"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택한 아카이브를 카테고리에 추가"
           }
         },
         "zh-Hans" : {
@@ -565,6 +1159,18 @@
             "value" : "Failed to add some archive(s) to category"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一部のアーカイブをカテゴリーに追加できませんでした"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "일부 아카이브를 카테고리에 추가하지 못했습니다"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -580,6 +1186,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Successfully added archive(s) to category"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アーカイブをカテゴリーに追加しました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아카이브를 카테고리에 추가했습니다"
           }
         },
         "zh-Hans" : {
@@ -599,6 +1217,18 @@
             "value" : "Are you sure to remove selected archive(s) from category?"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択したアーカイブをカテゴリーから削除してもよろしいですか？"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택한 아카이브를 카테고리에서 제거할까요?"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -614,6 +1244,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Failed to remove some archive(s) from category"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一部のアーカイブをカテゴリーから削除できませんでした"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "일부 아카이브를 카테고리에서 제거하지 못했습니다"
           }
         },
         "zh-Hans" : {
@@ -633,6 +1275,18 @@
             "value" : "Successfully removed selected archive(s) from category"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択したアーカイブをカテゴリーから削除しました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택한 아카이브를 카테고리에서 제거했습니다"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -648,6 +1302,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Are you sure you want to delete all selected?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択したすべてを削除してもよろしいですか？"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택한 항목을 모두 삭제할까요?"
           }
         },
         "zh-Hans" : {
@@ -667,6 +1333,18 @@
             "value" : "Failed to delete some archive(s)"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一部のアーカイブを削除できませんでした"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "일부 아카이브를 삭제하지 못했습니다"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -682,6 +1360,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Successfully deleted selected archive(s)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択したアーカイブを削除しました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택한 아카이브를 삭제했습니다"
           }
         },
         "zh-Hans" : {
@@ -701,6 +1391,18 @@
             "value" : "No tags"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タグなし"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "태그 없음"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -716,6 +1418,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Date Added"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "追加日"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추가한 날짜"
           }
         },
         "zh-Hans" : {
@@ -735,6 +1449,18 @@
             "value" : "Other"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "その他"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기타"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -750,6 +1476,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Set current page as thumbnail"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在のページをサムネイルに設定"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 페이지를 썸네일로 설정"
           }
         },
         "zh-Hans" : {
@@ -769,6 +1507,18 @@
             "value" : "Successfully set current page as thumbnail"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在のページをサムネイルに設定しました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 페이지를 썸네일로 설정했습니다"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -784,6 +1534,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cached"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャッシュ済み"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캐시됨"
           }
         },
         "zh-Hans" : {
@@ -803,6 +1565,18 @@
             "value" : "Cancel"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "취소"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -818,6 +1592,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Category"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カテゴリー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "카테고리"
           }
         },
         "zh-Hans" : {
@@ -837,6 +1623,18 @@
             "value" : "Are you sure you want to delete this category?"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このカテゴリーを削除してもよろしいですか？"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 카테고리를 삭제할까요?"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -852,6 +1650,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Failed to edit category"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カテゴリーを編集できませんでした"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "카테고리를 편집하지 못했습니다"
           }
         },
         "zh-Hans" : {
@@ -871,6 +1681,18 @@
             "value" : "No Categories"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カテゴリーなし"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "카테고리 없음"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -886,6 +1708,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld archives"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 件のアーカイブ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld개 아카이브"
           }
         },
         "zh-Hans" : {
@@ -905,6 +1739,18 @@
             "value" : "Search: %@"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索: %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "검색: %@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -920,6 +1766,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pinned"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "固定済み"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "고정됨"
           }
         },
         "zh-Hans" : {
@@ -939,6 +1797,18 @@
             "value" : "Edit category"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カテゴリーを編集"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "카테고리 편집"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -954,6 +1824,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Failed to edit category"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カテゴリーを編集できませんでした"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "카테고리를 편집하지 못했습니다"
           }
         },
         "zh-Hans" : {
@@ -973,6 +1855,18 @@
             "value" : "Category name"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カテゴリー名"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "카테고리 이름"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -988,6 +1882,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Add"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "追加"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추가"
           }
         },
         "zh-Hans" : {
@@ -1007,6 +1913,18 @@
             "value" : "Failed to add category"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カテゴリーを追加できませんでした"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "카테고리를 추가하지 못했습니다"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1022,6 +1940,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dynamic category"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動的カテゴリー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "동적 카테고리"
           }
         },
         "zh-Hans" : {
@@ -1041,6 +1971,18 @@
             "value" : "Search keyword"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索キーワード"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "검색 키워드"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1056,6 +1998,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Copy"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コピー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "복사"
           }
         },
         "zh-Hans" : {
@@ -1075,6 +2029,18 @@
             "value" : "Delete"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "削除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "삭제"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1090,6 +2056,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Details"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "詳細"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "세부 정보"
           }
         },
         "zh-Hans" : {
@@ -1109,6 +2087,18 @@
             "value" : "Done"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完了"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "완료"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1123,6 +2113,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Job ID: %lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ジョブID: %lld"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작업 ID: %lld"
           }
         },
         "zh-Hans" : {
@@ -1142,6 +2144,18 @@
             "value" : "Download added, please go to Settings - Host - Upload Archives to view progress"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロードを追加しました。進行状況は 設定 - ホスト - アーカイブをアップロード で確認できます"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다운로드가 추가되었습니다. 진행 상황은 설정 - 호스트 - 아카이브 업로드에서 확인하세요"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1157,6 +2171,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Downsampling image.."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像をダウンサンプリング中..."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이미지를 다운샘플링하는 중..."
           }
         },
         "zh-Hans" : {
@@ -1176,6 +2202,18 @@
             "value" : "Edit"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編集"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "편집"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1191,6 +2229,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Error"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エラー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오류"
           }
         },
         "zh-Hans" : {
@@ -1210,6 +2260,18 @@
             "value" : "Failed to delete archives, please retry."
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アーカイブを削除できませんでした。もう一度お試しください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아카이브를 삭제하지 못했습니다. 다시 시도해 주세요."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1225,6 +2287,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Failed to queue the download job, please retry."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロードジョブをキューに追加できませんでした。もう一度お試しください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다운로드 작업을 대기열에 추가하지 못했습니다. 다시 시도해 주세요."
           }
         },
         "zh-Hans" : {
@@ -1244,6 +2318,18 @@
             "value" : "Server returned empty content for this archive."
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サーバーからこのアーカイブの内容が返されませんでした。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "서버가 이 아카이브의 콘텐츠를 반환하지 않았습니다."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1259,6 +2345,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Passcode incorrect, please try again"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パスコードが正しくありません。もう一度お試しください"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "암호가 올바르지 않습니다. 다시 시도해 주세요"
           }
         },
         "zh-Hans" : {
@@ -1278,6 +2376,18 @@
             "value" : "Passcode not match, please try again"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パスコードが一致しません。もう一度お試しください"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "암호가 일치하지 않습니다. 다시 시도해 주세요"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1293,6 +2403,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "History"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "履歴"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기록"
           }
         },
         "zh-Hans" : {
@@ -1312,6 +2434,18 @@
             "value" : "API Key, can be set in settings. This is NOT your password"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "APIキー。設定で指定できます。これはパスワードではありません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API 키입니다. 설정에서 지정할 수 있습니다. 비밀번호가 아닙니다"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1329,6 +2463,18 @@
             "value" : "Submit"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "送信"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제출"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1341,6 +2487,18 @@
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "http(s)://10.0.1.10:3000"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "http(s)://10.0.1.10:3000"
+          }
+        },
+        "ko" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "http(s)://10.0.1.10:3000"
@@ -1363,6 +2521,18 @@
             "value" : "Non local network must use https protocol"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ローカルネットワーク以外では https プロトコルを使用する必要があります"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "로컬 네트워크가 아닌 경우 https 프로토콜을 사용해야 합니다"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1378,6 +2548,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Library"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライブラリ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "라이브러리"
           }
         },
         "zh-Hans" : {
@@ -1397,6 +2579,18 @@
             "value" : "Loading..."
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読み込み中..."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "불러오는 중..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1412,6 +2606,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "We need to unlock your App"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アプリのロック解除が必要です"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "앱 잠금 해제가 필요합니다"
           }
         },
         "zh-Hans" : {
@@ -1431,6 +2637,18 @@
             "value" : "Enter New Passcode"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新しいパスコードを入力"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "새 암호 입력"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1446,6 +2664,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enter Passcode"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パスコードを入力"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "암호 입력"
           }
         },
         "zh-Hans" : {
@@ -1465,6 +2695,18 @@
             "value" : "Enter Current Passcode"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在のパスコードを入力"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 암호 입력"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1480,6 +2722,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Confirm Passcode"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パスコードを確認"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "암호 확인"
           }
         },
         "zh-Hans" : {
@@ -1499,6 +2753,18 @@
             "value" : "Start"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시작"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1514,6 +2780,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Random"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ランダム"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "무작위"
           }
         },
         "zh-Hans" : {
@@ -1533,6 +2811,18 @@
             "value" : "Remove"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "削除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제거"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1548,6 +2838,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Save"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "저장"
           }
         },
         "zh-Hans" : {
@@ -1567,6 +2869,18 @@
             "value" : "Search"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "검색"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1582,6 +2896,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Select"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택"
           }
         },
         "zh-Hans" : {
@@ -1601,6 +2927,18 @@
             "value" : "Settings"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "설정"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1615,6 +2953,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Advanced"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "詳細"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "고급"
           }
         },
         "zh-Hans" : {
@@ -1633,6 +2983,18 @@
             "value" : "Real-time Translation"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リアルタイム翻訳"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "실시간 번역"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1647,6 +3009,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "This function utilise [mange-image-translator](https://github.com/zyddnys/manga-image-translator) to translate image on the fly. You will need a working mange-image-translator instance to use this function"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この機能は [mange-image-translator](https://github.com/zyddnys/manga-image-translator) を使用して画像をリアルタイムに翻訳します。利用するには、動作中の mange-image-translator インスタンスが必要です"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 기능은 [mange-image-translator](https://github.com/zyddnys/manga-image-translator)를 사용해 이미지를 실시간으로 번역합니다. 사용하려면 작동 중인 mange-image-translator 인스턴스가 필요합니다"
           }
         },
         "zh-Hans" : {
@@ -1665,6 +3039,18 @@
             "value" : "Box threshold"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ボックスしきい値"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "박스 임계값"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1679,6 +3065,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Detection resolution"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検出解像度"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "감지 해상도"
           }
         },
         "zh-Hans" : {
@@ -1697,6 +3095,18 @@
             "value" : "Enable real-time translation"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リアルタイム翻訳を有効にする"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "실시간 번역 활성화"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1711,6 +3121,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Inpainter"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インペインター"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "인페인터"
           }
         },
         "zh-Hans" : {
@@ -1729,6 +3151,18 @@
             "value" : "Inpainter size"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インペイントサイズ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "인페인팅 크기"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1743,6 +3177,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Target language"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻訳先言語"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "대상 언어"
           }
         },
         "zh-Hans" : {
@@ -1761,6 +3207,18 @@
             "value" : "Mask dilation offset"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マスク拡張オフセット"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "마스크 확장 오프셋"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1775,6 +3233,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "render text direction"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキスト描画方向"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "텍스트 렌더링 방향"
           }
         },
         "zh-Hans" : {
@@ -1793,6 +3263,18 @@
             "value" : "Translation Service"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻訳サービス"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "번역 서비스"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1807,6 +3289,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Text detector"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキスト検出器"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "텍스트 감지기"
           }
         },
         "zh-Hans" : {
@@ -1825,6 +3319,18 @@
             "value" : "Unclip Ratio"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アンクリップ比率"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "언클립 비율"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1839,6 +3345,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Server url"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サーバーURL"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "서버 URL"
           }
         },
         "zh-Hans" : {
@@ -1858,6 +3376,18 @@
             "value" : "Artist"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アーティスト"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아티스트"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1873,6 +3403,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Character"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャラクター"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캐릭터"
           }
         },
         "zh-Hans" : {
@@ -1892,6 +3434,18 @@
             "value" : "Custom"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カスタム"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사용자 지정"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1907,6 +3461,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sort namespace could be any tag key"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "並び替え用の名前空間には任意のタグキーを指定できます"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "정렬 네임스페이스는 어떤 태그 키든 사용할 수 있습니다"
           }
         },
         "zh-Hans" : {
@@ -1926,6 +3492,18 @@
             "value" : "Custom sort namespace"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カスタム並び替え名前空間"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사용자 지정 정렬 네임스페이스"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1941,6 +3519,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Date"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日付"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "날짜"
           }
         },
         "zh-Hans" : {
@@ -1960,6 +3550,18 @@
             "value" : "Event"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "イベント"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이벤트"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1975,6 +3577,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Group"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "グループ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "그룹"
           }
         },
         "zh-Hans" : {
@@ -1994,6 +3608,18 @@
             "value" : "Last read"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最後に読んだ順"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "마지막으로 읽은 항목"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2009,6 +3635,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Title"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タイトル"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제목"
           }
         },
         "zh-Hans" : {
@@ -2028,6 +3666,18 @@
             "value" : "Parody"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パロディ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "패러디"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2043,6 +3693,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Random"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ランダム"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "무작위"
           }
         },
         "zh-Hans" : {
@@ -2062,6 +3724,18 @@
             "value" : "Series"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シリーズ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시리즈"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2077,6 +3751,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ascending"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "昇順"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오름차순"
           }
         },
         "zh-Hans" : {
@@ -2096,6 +3782,18 @@
             "value" : "Descending"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "降順"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "내림차순"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2111,6 +3809,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Database"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "データベース"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "데이터베이스"
           }
         },
         "zh-Hans" : {
@@ -2130,6 +3840,18 @@
             "value" : "Clear cache in database"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "データベース内のキャッシュを削除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "데이터베이스의 캐시 지우기"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2145,6 +3867,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cannot read database"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "データベースを読み込めません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "데이터베이스를 읽을 수 없습니다"
           }
         },
         "zh-Hans" : {
@@ -2164,6 +3898,18 @@
             "value" : "Debug"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デバッグ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "디버그"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2179,6 +3925,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Application log"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アプリケーションログ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "애플리케이션 로그"
           }
         },
         "zh-Hans" : {
@@ -2198,6 +3956,18 @@
             "value" : "Host"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホスト設定"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "호스트 설정"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2213,6 +3983,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Always load data from server when App start"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アプリ起動時に常にサーバーからデータを読み込む"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "앱 시작 시 항상 서버에서 데이터 불러오기"
           }
         },
         "zh-Hans" : {
@@ -2232,6 +4014,18 @@
             "value" : "Host"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホスト"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "호스트"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2247,6 +4041,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Upload Archives"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アーカイブをアップロード"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아카이브 업로드"
           }
         },
         "zh-Hans" : {
@@ -2266,6 +4072,18 @@
             "value" : "Upload"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アップロード"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "업로드"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2281,6 +4099,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Urls to upload, use newline to separate"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アップロードするURL。改行で区切ってください"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "업로드할 URL입니다. 줄바꿈으로 구분하세요"
           }
         },
         "zh-Hans" : {
@@ -2300,6 +4130,18 @@
             "value" : "Finished job will be removed after a while"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完了したジョブはしばらくすると削除されます"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "완료된 작업은 잠시 후 제거됩니다"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2315,6 +4157,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toggle navigation"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ナビゲーションを切り替え"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "내비게이션 전환"
           }
         },
         "zh-Hans" : {
@@ -2334,6 +4188,18 @@
             "value" : "Next page"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "次のページ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다음 페이지"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2349,6 +4215,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Previous page"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前のページ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이전 페이지"
           }
         },
         "zh-Hans" : {
@@ -2368,6 +4246,18 @@
             "value" : "Read Settings"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読書設定"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "읽기 설정"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2383,6 +4273,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Automatic paging interval"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動ページ送り間隔"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자동 페이지 넘김 간격"
           }
         },
         "zh-Hans" : {
@@ -2402,6 +4304,18 @@
             "value" : "Toggle navigation to stop automatic paging"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ナビゲーションを切り替えると自動ページ送りを停止します"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "내비게이션을 전환하면 자동 페이지 넘김이 중지됩니다"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2417,6 +4331,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Read direction"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読む方向"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "읽기 방향"
           }
         },
         "zh-Hans" : {
@@ -2436,6 +4362,18 @@
             "value" : "Left to right"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "左から右"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "왼쪽에서 오른쪽"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2451,6 +4389,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Right to left"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "右から左"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오른쪽에서 왼쪽"
           }
         },
         "zh-Hans" : {
@@ -2470,6 +4420,18 @@
             "value" : "Vertial"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "縦方向"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "세로"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2485,6 +4447,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Double page layout"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "見開きレイアウト"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "두 페이지 레이아웃"
           }
         },
         "zh-Hans" : {
@@ -2504,6 +4478,18 @@
             "value" : "Use fallback reader"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フォールバックリーダーを使用"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "대체 리더 사용"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2519,6 +4505,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Use fallback reader if current reader has performance issue"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在のリーダーでパフォーマンス問題がある場合はフォールバックリーダーを使用します"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 리더에 성능 문제가 있으면 대체 리더를 사용합니다"
           }
         },
         "zh-Hans" : {
@@ -2538,6 +4536,18 @@
             "value" : "Show original image"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "元の画像を表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "원본 이미지 표시"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2553,6 +4563,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Split wide page"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "横長ページを分割"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "넓은 페이지 분할"
           }
         },
         "zh-Hans" : {
@@ -2572,6 +4594,18 @@
             "value" : "Show left split page first"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "左側の分割ページを先に表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "왼쪽 분할 페이지 먼저 표시"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2587,6 +4621,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tap on left side of the screen"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画面左側をタップ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "화면 왼쪽 탭"
           }
         },
         "zh-Hans" : {
@@ -2606,6 +4652,18 @@
             "value" : "Tap on middle of the screen"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画面中央をタップ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "화면 가운데 탭"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2621,6 +4679,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tap on right side of the screen"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画面右側をタップ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "화면 오른쪽 탭"
           }
         },
         "zh-Hans" : {
@@ -2640,6 +4710,18 @@
             "value" : "Support"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サポート"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "지원"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2655,6 +4737,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Report an issue on GitHub"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHubで問題を報告"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub에 문제 신고"
           }
         },
         "zh-Hans" : {
@@ -2674,6 +4768,18 @@
             "value" : "💰 Support development"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "💰 開発をサポート"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "💰 개발 지원"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2689,6 +4795,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "View Settings"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表示設定"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "보기 설정"
           }
         },
         "zh-Hans" : {
@@ -2708,6 +4826,18 @@
             "value" : "Blur interface when app is not active"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アプリが非アクティブなときに画面をぼかす"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "앱이 비활성 상태일 때 인터페이스 흐리게 표시"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2723,6 +4853,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hide read"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "既読を非表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "읽은 항목 숨기기"
           }
         },
         "zh-Hans" : {
@@ -2742,6 +4884,18 @@
             "value" : "Require passcode to unlock app"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アプリのロック解除にパスコードを要求"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "앱 잠금 해제에 암호 요구"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2757,6 +4911,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Success"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "成功"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "성공"
           }
         },
         "zh-Hans" : {
@@ -2776,6 +4942,18 @@
             "value" : "and"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "および"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "및"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2791,6 +4969,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hi, I’m the solo developer behind this app. Thank you for using this app. There is no additional functionality if you become a supporter, but it will help me keep working on it.\nNo pressure, just pure gratitude. ❤️"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "こんにちは。このアプリを一人で開発しています。ご利用ありがとうございます。サポーターになっても追加機能はありませんが、開発を続ける助けになります。\n無理のない範囲で、感謝の気持ちだけです。❤️"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "안녕하세요, 이 앱을 혼자 개발하고 있습니다. 사용해 주셔서 감사합니다. 후원자가 되어도 추가 기능은 없지만, 계속 개발하는 데 큰 도움이 됩니다.\n부담 없이, 순수한 감사의 마음입니다. ❤️"
           }
         },
         "zh-Hans" : {
@@ -2810,6 +5000,18 @@
             "value" : "Become a Supporter"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サポーターになる"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "후원자 되기"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2825,6 +5027,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "One-time"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一回限り"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "일회성"
           }
         },
         "zh-Hans" : {
@@ -2844,6 +5058,18 @@
             "value" : "Privacy Policy"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プライバシーポリシー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "개인정보 처리방침"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2861,6 +5087,18 @@
             "value" : "Nice candy, thank you ☺️"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "素敵なキャンディーをありがとうございます ☺️"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "좋은 사탕 감사합니다 ☺️"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2875,6 +5113,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "THANK YOU ❤️"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ありがとうございます ❤️"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "감사합니다 ❤️"
           }
         },
         "zh-Hans" : {
@@ -2894,6 +5144,18 @@
             "value" : "Terms of Service"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "利用規約"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "서비스 약관"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2908,6 +5170,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Type"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "種類"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "유형"
           }
         },
         "zh-Hans" : {
@@ -2927,6 +5201,18 @@
             "value" : "Yearly"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "年額"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "연간"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2942,6 +5228,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Yearly subscription will automatically renew unless cancelled manually one day before"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "年額サブスクリプションは、前日までに手動でキャンセルしない限り自動更新されます"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "연간 구독은 하루 전에 직접 취소하지 않는 한 자동으로 갱신됩니다"
           }
         },
         "zh-Hans" : {
@@ -2961,6 +5259,18 @@
             "value" : "Yearly supporter"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "年額サポーター"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "연간 후원자"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2975,6 +5285,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Translating…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻訳中…"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "번역 중…"
           }
         },
         "zh-Hans" : {
@@ -2993,6 +5315,18 @@
             "value" : "Detecting texts"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキストを検出中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "텍스트 감지 중"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3007,6 +5341,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Did not get any text back from the text translation service"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキスト翻訳サービスからテキストが返されませんでした"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "텍스트 번역 서비스에서 텍스트가 반환되지 않았습니다"
           }
         },
         "zh-Hans" : {
@@ -3025,6 +5371,18 @@
             "value" : "Downloading image"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像をダウンロード中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이미지 다운로드 중"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3039,6 +5397,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Running inpainting"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インペイントを実行中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "인페인팅 실행 중"
           }
         },
         "zh-Hans" : {
@@ -3057,6 +5427,18 @@
             "value" : "Generating text mask"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキストマスクを生成中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "텍스트 마스크 생성 중"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3071,6 +5453,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Running OCR"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OCRを実行中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OCR 실행 중"
           }
         },
         "zh-Hans" : {
@@ -3089,6 +5483,18 @@
             "value" : "Processing"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "処理中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "처리 중"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3103,6 +5509,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rendering translated texts"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻訳済みテキストを描画中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "번역된 텍스트 렌더링 중"
           }
         },
         "zh-Hans" : {
@@ -3121,6 +5539,18 @@
             "value" : "Merge textline"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキスト行を結合中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "텍스트 줄 병합 중"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3135,6 +5565,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Translating"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻訳中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "번역 중"
           }
         },
         "zh-Hans" : {
@@ -3153,6 +5595,18 @@
             "value" : "Uploading"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アップロード中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "업로드 중"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3167,6 +5621,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Running upscaling"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アップスケーリングを実行中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "업스케일링 실행 중"
           }
         },
         "zh-Hans" : {
@@ -3186,6 +5652,18 @@
             "value" : "Version"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バージョン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "버전"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3203,6 +5681,18 @@
             "value" : "Warning"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "警告"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "경고"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3218,6 +5708,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "This archive seems to be in RAR format! RAR archives might not work properly in LANraragi depending on how they were made. If you encounter errors while reading, consider converting your archive to zip."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このアーカイブはRAR形式のようです。RARアーカイブは作成方法によってはLANraragiで正しく動作しない場合があります。読み込み中にエラーが発生する場合は、アーカイブをZIPに変換することを検討してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 아카이브는 RAR 형식인 것 같습니다. RAR 아카이브는 만들어진 방식에 따라 LANraragi에서 제대로 작동하지 않을 수 있습니다. 읽는 중 오류가 발생하면 아카이브를 ZIP으로 변환해 보세요."
           }
         },
         "zh-Hans" : {


### PR DESCRIPTION
## What changed
- Added Japanese (`ja`), Korean (`ko`), and Traditional Chinese (`zh-Hant`) translations to the main app string catalog.
- Derived `zh-Hant` from the existing Simplified Chinese (`zh-Hans`) strings.
- Localized Action extension InfoPlist strings and app InfoPlist permission text where localized source strings exist.
- Registered `ja`, `ko`, and `zh-Hant` as known project regions.
- Localized remaining reader accessibility labels that were hard-coded in English.
- Bumped version/build from `3.8.0 (173)` to `3.8.1 (174)`.

## Why
Japanese, Korean, and Traditional Chinese users should see localized app text, extension metadata, permission prompts, and reader accessibility labels.

## Verification
- `jq empty Localizable.xcstrings Action/InfoPlist.xcstrings LANreader/InfoPlist.xcstrings`
- Format placeholder consistency checks for localized strings
- Confirmed no `zh-HK` entries are present
- `xcodebuild -list -project LANreader.xcodeproj`
- `./scripts/lint`
- `./scripts/test-ios` passed earlier on this PR branch: 94 tests, 0 failures

## Not run
- Re-ran catalog/project/lint checks after adding `zh-Hant`; did not rerun `./scripts/test-ios` because this latest change only adds string-catalog entries and a known region.