### PR TITLE
Add support information page

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,22 @@
+# LANreader Support
+
+LANreader is a reader client for self-hosted LANraragi servers. If you need help, have a question, or want to report a problem, use the support options below.
+
+## Get Help
+
+- Open a GitHub issue: https://github.com/Doraemoe/LANreader/issues
+- Include your device model, iOS or iPadOS version, LANreader version, LANraragi server version, and a short description of what happened.
+- If the problem involves connecting to a server, include whether the server is reachable from Safari on the same device. Do not share private API keys, passwords, or private library content.
+
+## Common Checks
+
+- Confirm the LANraragi server URL is correct and reachable from the device.
+- Confirm the API key is valid if your server requires one.
+- Check that your device and LANraragi server are on networks that can reach each other.
+- Try refreshing the library after changing server settings.
+
+## Privacy and Terms
+
+- Privacy Policy: https://github.com/Doraemoe/LANreader/blob/master/PRIVACY.md
+- Terms of Use (EULA): https://www.apple.com/legal/internet-services/itunes/dev/stdeula/
+


### PR DESCRIPTION
## What changed
- Added `SUPPORT.md` with support contact instructions, troubleshooting checks, privacy policy, and EULA links.

## Why
- App Review rejected the current submission because the Support URL did not point to a page with support information.

## Verification
- Verified the pushed GitHub support page returns HTTP 200.
- Updated App Store Connect support URLs for all 3.8.2 localizations to the new support page.
- Re-ran `asc validate` for version 3.8.2; no blocking errors remain.