### PR TITLE
Add App Store rating support and bump 3.8.4

### DIFF
--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -939,7 +939,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreader.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 182;
+				CURRENT_PROJECT_VERSION = 183;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -950,7 +950,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.8.3;
+				MARKETING_VERSION = 3.8.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -967,7 +967,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreaderRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 182;
+				CURRENT_PROJECT_VERSION = 183;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -978,7 +978,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.8.3;
+				MARKETING_VERSION = 3.8.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1041,7 +1041,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 182;
+				CURRENT_PROJECT_VERSION = 183;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1053,7 +1053,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.3;
+				MARKETING_VERSION = 3.8.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1071,7 +1071,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 182;
+				CURRENT_PROJECT_VERSION = 183;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1083,7 +1083,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.3;
+				MARKETING_VERSION = 3.8.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/LANreader.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/LANreader.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift",
       "state" : {
-        "revision" : "9ed8c8457e00ff9c7aedb3bf213f20a2cfdf509e",
-        "version" : "7.11.0"
+        "revision" : "b83108d10f42680d78f23fe4d4d80fc88dab3212",
+        "version" : "7.11.1"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "206cbce3882b4de9aee19ce62ac5b7306cadd45b",
-        "version" : "1.7.3"
+        "revision" : "1197e80bc7e4b177051b6869ef93d8ac3ad677da",
+        "version" : "1.8.0"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
-        "version" : "1.0.6"
+        "revision" : "72d749bf341b78851203066ab421869b783ec42a",
+        "version" : "1.1.0"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "fea17c02d767f46b23070fdfdacc28a03a39232a",
-        "version" : "1.5.1"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "revision" : "1eaa6fa2ee57ac42843283b9fd3457af408c858d",
-        "version" : "1.25.5"
+        "revision" : "e2fa1df6cd9eec6fa6314aa20513e47da576f24e",
+        "version" : "1.26.0"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "b9b59eb58c946236d6f16305c576ad194c36444e",
-        "version" : "1.6.0"
+        "revision" : "a8cd6c976f335ed361dcecddb0dc39ebda51bc3e",
+        "version" : "1.6.1"
       }
     },
     {
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "f80552807ec92f72fe3fe4543d71879182b0bfd5",
-        "version" : "1.13.0"
+        "revision" : "8dc1fbf2f6255a73dec53b4648164884898db4c5",
+        "version" : "1.14.1"
       }
     },
     {
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-navigation",
       "state" : {
-        "revision" : "32f35241b8be0719c4c7f00eb27713b1cadb6248",
-        "version" : "2.8.0"
+        "revision" : "6cff006b3607b700029dc44f06b41a6cc7384ac7",
+        "version" : "2.10.2"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-sharing",
       "state" : {
-        "revision" : "bc27f8322bc30f6ce7d864d137dc77a6de8b57eb",
-        "version" : "2.8.0"
+        "revision" : "c8dd3627eb92cef1bcb44ac5a93d558ab32b82ce",
+        "version" : "2.9.0"
       }
     },
     {
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "9de99a78f099e59caf2b2beec65a4c45d54b2081",
-        "version" : "603.0.1"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     },
     {
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
-        "version" : "1.9.0"
+        "revision" : "401bf70d95bfe8db2a1dc619f9e175a85c089321",
+        "version" : "1.10.1"
       }
     }
   ],

--- a/LANreader/Category/UICategoryArchiveGrid.swift
+++ b/LANreader/Category/UICategoryArchiveGrid.swift
@@ -23,7 +23,7 @@ import UIKit
     public var body: some ReducerOf<Self> {
         BindingReducer()
 
-        Scope(state: \.archiveList, action: \.archiveList) {
+        Scope(\.archiveList, action: \.archiveList) {
             ArchiveListFeature()
         }
 
@@ -64,7 +64,7 @@ class UICategoryArchiveGridController: UIViewController {
         navigationItem.largeTitleDisplayMode = .never
 
         let archiveListView = UIArchiveListViewController(
-            store: store.scope(state: \.archiveList, action: \.archiveList)
+            store: store.scope(\.archiveList, action: \.archiveList)
         )
         add(archiveListView)
         NSLayoutConstraint.activate([

--- a/LANreader/Common/UIArchiveList.swift
+++ b/LANreader/Common/UIArchiveList.swift
@@ -761,7 +761,7 @@ class UIArchiveListViewController: UIViewController {
             >()
             snapshot.appendSections([.main])
             snapshot.appendItems(
-                Array(store.scope(state: \.archivesToDisplay, action: \.grid)))
+                Array(store.scope(\.archivesToDisplay, action: \.grid)))
             dataSource.apply(snapshot, animatingDifferences: false)
         }
 

--- a/LANreader/ContentView.swift
+++ b/LANreader/ContentView.swift
@@ -48,16 +48,16 @@ import Logging
     public var body: some Reducer<State, Action> {
         BindingReducer()
 
-        Scope(state: \.library, action: \.library) {
+        Scope(\.library, action: \.library) {
             LibraryFeature()
         }
-        Scope(state: \.category, action: \.category) {
+        Scope(\.category, action: \.category) {
             CategoryFeature()
         }
-        Scope(state: \.search, action: \.search) {
+        Scope(\.search, action: \.search) {
             SearchFeature()
         }
-        Scope(state: \.settings, action: \.settings) {
+        Scope(\.settings, action: \.settings) {
             SettingsFeature()
         }
 
@@ -190,12 +190,12 @@ struct Covers: ViewModifier {
     func body(content: Content) -> some View {
         content
             .fullScreenCover(
-                item: $store.scope(state: \.$destination, action: \.destination).login
+                item: $store.scope(\.$destination, action: \.destination).login
             ) { store in
                 LANraragiConfigView(store: store)
             }
             .fullScreenCover(
-                item: $store.scope(state: \.$destination, action: \.destination).lockScreen
+                item: $store.scope(\.$destination, action: \.destination).lockScreen
             ) { store in
                 LockScreen(store: store)
             }

--- a/LANreader/Library/CacheView.swift
+++ b/LANreader/Library/CacheView.swift
@@ -129,7 +129,7 @@ struct CacheView: View {
         ScrollView {
             LazyVGrid(columns: columns) {
                 ForEach(
-                    store.scope(state: \.archives, action: \.grid),
+                    store.scope(\.archives, action: \.grid),
                     id: \.state.id
                 ) { gridStore in
                     let inProgress = store.downloading.contains { (key, _) in

--- a/LANreader/Library/UILibraryList.swift
+++ b/LANreader/Library/UILibraryList.swift
@@ -24,7 +24,7 @@ import UIKit
     public var body: some ReducerOf<Self> {
         BindingReducer()
 
-        Scope(state: \.archiveList, action: \.archiveList) {
+        Scope(\.archiveList, action: \.archiveList) {
             ArchiveListFeature()
         }
 
@@ -77,7 +77,7 @@ class UILibraryListViewController: UIViewController {
         setupNavigationBar()
 
         let archiveListView = UIArchiveListViewController(
-            store: store.scope(state: \.archiveList, action: \.archiveList)
+            store: store.scope(\.archiveList, action: \.archiveList)
         )
         add(archiveListView)
         NSLayoutConstraint.activate([

--- a/LANreader/Page/ArchiveReader.swift
+++ b/LANreader/Page/ArchiveReader.swift
@@ -152,7 +152,7 @@ import UIKit
     public var body: some ReducerOf<Self> {
         BindingReducer()
 
-        Scope(state: \.autoPage, action: \.autoPage) {
+        Scope(\.autoPage, action: \.autoPage) {
             AutomaticPageFeature()
         }
 
@@ -988,11 +988,11 @@ struct ArchiveReader: View {
             }
         }
         .alert(
-            $store.scope(state: \.$alert, action: \.alert)
+            $store.scope(\.$alert, action: \.alert)
         )
         .overlay(content: {
             store.showAutoPageConfig ? AutomaticPageConfig(
-                store: store.scope(state: \.autoPage, action: \.autoPage)
+                store: store.scope(\.autoPage, action: \.autoPage)
             ) : nil
         })
         .task {

--- a/LANreader/Page/UIPageCollection.swift
+++ b/LANreader/Page/UIPageCollection.swift
@@ -152,7 +152,7 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
     }
 
     private func pageStore(id pageId: String) -> StoreOf<PageFeature>? {
-        Array(store.scope(state: \.pages, action: \.page)).first { $0.id == pageId }
+        Array(store.scope(\.pages, action: \.page)).first { $0.id == pageId }
     }
 
     private func pageStore(at indexPath: IndexPath) -> StoreOf<PageFeature>? {

--- a/LANreader/Search/UISearchViewV2.swift
+++ b/LANreader/Search/UISearchViewV2.swift
@@ -31,7 +31,7 @@ import UIKit
 
     public var body: some ReducerOf<Self> {
 
-        Scope(state: \.archiveList, action: \.archiveList) {
+        Scope(\.archiveList, action: \.archiveList) {
             ArchiveListFeature()
         }
 
@@ -145,7 +145,7 @@ class UISearchViewV2Controller: UIViewController {
     // Archive list child (same as original UISearchView)
     private lazy var archiveListViewController: UIArchiveListViewController = {
         UIArchiveListViewController(
-            store: store.scope(state: \.archiveList, action: \.archiveList)
+            store: store.scope(\.archiveList, action: \.archiveList)
         )
     }()
 

--- a/LANreader/Setting/SupportSettings.swift
+++ b/LANreader/Setting/SupportSettings.swift
@@ -23,6 +23,24 @@ struct SupportSettings: View {
         .foregroundStyle(.primary)
         .padding()
         Button {
+            openURL(AppStoreReviewURL.native) { accepted in
+                if !accepted {
+                    openURL(AppStoreReviewURL.web)
+                }
+            }
+        } label: {
+            HStack {
+                Text("settings.support.rateApp")
+                Spacer()
+                Image(systemName: "star.fill")
+                    .foregroundStyle(.secondary)
+                    .font(.footnote)
+                    .accessibilityHidden(true)
+            }
+        }
+        .foregroundStyle(.primary)
+        .padding()
+        Button {
             let issueURL = URL(string: "https://github.com/Doraemoe/LANreader/issues/new")!
             openURL(issueURL)
         } label: {
@@ -59,4 +77,9 @@ struct SupportSettings: View {
         LabeledContent("version", value: "\(version)-\(build)")
             .padding()
     }
+}
+
+private enum AppStoreReviewURL {
+    static let native = URL(string: "itms-apps://itunes.apple.com/app/id6743684988?action=write-review")!
+    static let web = URL(string: "https://apps.apple.com/app/id6743684988?action=write-review")!
 }

--- a/LANreader/SettingsView.swift
+++ b/LANreader/SettingsView.swift
@@ -16,15 +16,15 @@ import SwiftUI
     }
 
     public var body: some ReducerOf<Self> {
-        Scope(state: \.read, action: \.read) {
+        Scope(\.read, action: \.read) {
             ReadSettingsFeature()
         }
 
-        Scope(state: \.view, action: \.view) {
+        Scope(\.view, action: \.view) {
             ViewSettingsFeature()
         }
 
-        Scope(state: \.database, action: \.database) {
+        Scope(\.database, action: \.database) {
             DatabaseSettingsFeature()
         }
 
@@ -47,7 +47,7 @@ struct SettingsView: View {
             Section(
                 header: Text("settings.read")
             ) {
-                ReadSettings(store: self.store.scope(state: \.read, action: \.read))
+                ReadSettings(store: self.store.scope(\.read, action: \.read))
             }
             Section(header: Text("settings.host")) {
                 ServerSettings()
@@ -56,7 +56,7 @@ struct SettingsView: View {
                 header: Text("settings.view"),
                 footer: Text("settings.archive.list.order.custom.explain")
             ) {
-                ViewSettings(store: self.store.scope(state: \.view, action: \.view))
+                ViewSettings(store: self.store.scope(\.view, action: \.view))
             }
             Section(
                 header: Text("settings.advanced"),
@@ -64,7 +64,7 @@ struct SettingsView: View {
                 AdvancedSettings()
             }
             Section(header: Text("settings.database")) {
-                DatabaseSettings(store: self.store.scope(state: \.database, action: \.database))
+                DatabaseSettings(store: self.store.scope(\.database, action: \.database))
             }
             Section(header: Text("settings.support")) {
                 SupportSettings()

--- a/LANreader/UIAppTabView.swift
+++ b/LANreader/UIAppTabView.swift
@@ -41,7 +41,7 @@ class UITabViewController: UITabBarController {
         let libraryNavHelper = NavigationHelper()
         libraryNavHelper.navigationController = libraryNav
         let libraryView = UILibraryListViewController(
-            store: store.scope(state: \.library, action: \.library),
+            store: store.scope(\.library, action: \.library),
             navigationHelper: libraryNavHelper
         )
         libraryNav.viewControllers = [libraryView]
@@ -51,7 +51,7 @@ class UITabViewController: UITabBarController {
             tag: 0
         )
 
-        let categoryView = UICategoryListViewController(store: store.scope(state: \.category, action: \.category))
+        let categoryView = UICategoryListViewController(store: store.scope(\.category, action: \.category))
         let categoryNav = UINavigationController(rootViewController: categoryView)
         categoryNav.tabBarItem = UITabBarItem(
             title: String(localized: "category"),
@@ -59,7 +59,7 @@ class UITabViewController: UITabBarController {
             tag: 1
         )
 
-        let searchView = UISearchViewV2Controller(store: store.scope(state: \.search, action: \.search))
+        let searchView = UISearchViewV2Controller(store: store.scope(\.search, action: \.search))
         let searchNav = UINavigationController(rootViewController: searchView)
         searchNav.tabBarItem = UITabBarItem(
             tabBarSystemItem: .search,
@@ -70,7 +70,7 @@ class UITabViewController: UITabBarController {
         let settingsNavHelper = NavigationHelper()
         settingsNavHelper.navigationController = settingsNav
         let settingsView = UISettingsViewController(
-            store: store.scope(state: \.settings, action: \.settings),
+            store: store.scope(\.settings, action: \.settings),
             navigationHelper: settingsNavHelper
         )
         settingsNav.viewControllers = [settingsView]

--- a/LANreader/ViewSettings.swift
+++ b/LANreader/ViewSettings.swift
@@ -89,7 +89,7 @@ struct ViewSettings: View {
             }
         }
         .fullScreenCover(
-            item: $store.scope(state: \.$destination, action: \.destination).lockScreen
+            item: $store.scope(\.$destination, action: \.destination).lockScreen
         ) { store in
             LockScreen(store: store)
         }

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -5300,6 +5300,41 @@
         }
       }
     },
+    "settings.support.rateApp" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rate LANreader"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LANreaderを評価"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LANreader 평가하기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "给 LANreader 评分"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "為 LANreader 評分"
+          }
+        }
+      }
+    },
     "settings.support.title" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/ci_scripts/macros.json
+++ b/ci_scripts/macros.json
@@ -1,16 +1,16 @@
 [
   {
-    "fingerprint" : "206cbce3882b4de9aee19ce62ac5b7306cadd45b",
+    "fingerprint" : "1197e80bc7e4b177051b6869ef93d8ac3ad677da",
     "packageIdentity" : "swift-case-paths",
     "targetName" : "CasePathsMacros"
   },
   {
-    "fingerprint" : "1eaa6fa2ee57ac42843283b9fd3457af408c858d",
+    "fingerprint" : "e2fa1df6cd9eec6fa6314aa20513e47da576f24e",
     "packageIdentity" : "swift-composable-architecture",
     "targetName" : "ComposableArchitectureMacros"
   },
   {
-    "fingerprint" : "f80552807ec92f72fe3fe4543d71879182b0bfd5",
+    "fingerprint" : "8dc1fbf2f6255a73dec53b4648164884898db4c5",
     "packageIdentity" : "swift-dependencies",
     "targetName" : "DependenciesMacrosPlugin"
   },
@@ -18,5 +18,10 @@
     "fingerprint" : "25ac73741c3436605d61eceb5207e896973918e7",
     "packageIdentity" : "swift-perception",
     "targetName" : "PerceptionMacros"
+  },
+  {
+    "fingerprint" : "6cff006b3607b700029dc44f06b41a6cc7384ac7",
+    "packageIdentity" : "swift-navigation",
+    "targetName" : "SwiftNavigationMacros"
   }
 ]


### PR DESCRIPTION
## What changed
- Added a Settings > Support row that opens LANreader's App Store write-review page, with a web fallback.
- Bumped LANreader and Action from 3.8.3 (182) to 3.8.4 (183).
- Updated SwiftPM dependency pins and matching macro trust fingerprints.
- Updated Composable Architecture scoping calls to the current API style used by the refreshed dependencies.

## Why
- Gives users a direct rating entry point from the support section.
- Prepares the next App Store release with updated dependencies and version metadata.

## Verification
- `jq empty Localizable.xcstrings`
- `git diff --check`
- `./scripts/lint`
- `./scripts/test-ios` (94 tests passed)