### PR TITLE
Add Tankoubon API support

### DIFF
--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -939,7 +939,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreader.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 183;
+				CURRENT_PROJECT_VERSION = 184;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -950,7 +950,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.8.4;
+				MARKETING_VERSION = 3.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -967,7 +967,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreaderRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 183;
+				CURRENT_PROJECT_VERSION = 184;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -978,7 +978,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.8.4;
+				MARKETING_VERSION = 3.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1041,7 +1041,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 183;
+				CURRENT_PROJECT_VERSION = 184;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1053,7 +1053,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.4;
+				MARKETING_VERSION = 3.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1071,7 +1071,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 183;
+				CURRENT_PROJECT_VERSION = 184;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1083,7 +1083,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.4;
+				MARKETING_VERSION = 3.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/LANreader/Models/LANraragiResponse.swift
+++ b/LANreader/Models/LANraragiResponse.swift
@@ -10,6 +10,7 @@ struct ArchiveIndexResponse: Decodable, Equatable {
     let title: String
     let pagecount: Int
     let progress: Int
+    let archiveCount: Int?
 
     private enum CodingKeys: String, CodingKey {
         case arcid
@@ -19,6 +20,7 @@ struct ArchiveIndexResponse: Decodable, Equatable {
         case title
         case pagecount
         case progress
+        case archiveCount = "archive_count"
     }
 
     init(from decoder: Decoder) throws {
@@ -30,6 +32,7 @@ struct ArchiveIndexResponse: Decodable, Equatable {
         self.title = try container.decode(String.self, forKey: .title)
         self.pagecount = try container.decode(Int.self, forKey: .pagecount)
         self.progress = try container.decode(Int.self, forKey: .progress)
+        self.archiveCount = try container.decodeIfPresent(Int.self, forKey: .archiveCount)
     }
 }
 
@@ -78,6 +81,87 @@ struct ArchiveSearchResponse: Decodable {
 
 struct ArchiveRandomResponse: Decodable {
     let data: [ArchiveIndexResponse]
+}
+
+struct TankoubonMetadataResponse: Decodable, Equatable {
+    let id: String
+    let name: String?
+    let summary: String?
+    let tags: String?
+    let archives: [String]?
+    let progress: Int?
+}
+
+struct TankoubonFullResponse: Decodable, Equatable {
+    let result: TankoubonFullMetadataResponse
+    let total: Int
+    let filtered: Int
+}
+
+struct TankoubonFullMetadataResponse: Decodable, Equatable {
+    let id: String
+    let name: String?
+    let summary: String?
+    let tags: String?
+    let progress: Int?
+    let archives: [String]?
+    let fullData: [ArchiveIndexResponse]?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case summary
+        case tags
+        case progress
+        case archives
+        case fullData = "full_data"
+    }
+}
+
+struct TankoubonThumbnailUpdateResponse: Decodable, Equatable {
+    let operation: String
+    let success: Int
+    let newThumbnail: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case operation
+        case success
+        case newThumbnail = "new_thumbnail"
+    }
+}
+
+struct TankoubonProgressResponse: Decodable, Equatable {
+    let id: String
+    let operation: String
+    let page: Int
+    let lastReadTime: Int
+    let success: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case operation
+        case page
+        case lastReadTime = "lastreadtime"
+        case success
+    }
+}
+
+struct TankoubonUpdateRequest: Encodable {
+    let metadata: TankoubonMetadataUpdateRequest?
+}
+
+struct TankoubonMetadataUpdateRequest: Encodable {
+    let name: String?
+    let summary: String?
+    let tags: String?
+    let appendTags: Bool?
+
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case summary
+        case tags
+        case appendTags = "append"
+    }
 }
 
 struct StatsResponse: Decodable {

--- a/LANreader/Service/LANraragiService.swift
+++ b/LANreader/Service/LANraragiService.swift
@@ -157,7 +157,24 @@ actor LANraragiService {
         ]
         .merging(cacheBust.map { ["cachebust": String($0)] } ?? [:]) { _, new in new }
 
-        var components = URLComponents(string: "\(url)/api/archives/\(id)/thumbnail")!
+        return try await fetchThumbnail(
+            path: "/api/archives/\(id)/thumbnail",
+            query: query,
+            disableResponseCache: disableResponseCache
+        )
+    }
+
+    func retrieveTankoubonThumbnail(id: String) async throws -> Data? {
+        let query = ["no_fallback": "true"]
+        return try await fetchThumbnail(path: "/api/tankoubons/\(id)/thumbnail", query: query)
+    }
+
+    private func fetchThumbnail(
+        path: String,
+        query: [String: String],
+        disableResponseCache: Bool = false
+    ) async throws -> Data? {
+        var components = URLComponents(string: "\(url)\(path)")!
         components.queryItems = query.map { URLQueryItem(name: $0.key, value: $0.value) }
 
         let request = session.request(components.url!)
@@ -205,7 +222,8 @@ actor LANraragiService {
                        filter: String? = nil,
                        start: String = "-1",
                        sortby: String = "title",
-                       order: String = "asc") async -> DataTask<ArchiveSearchResponse> {
+                       order: String = "asc",
+                       groupByTanks: Bool? = nil) async -> DataTask<ArchiveSearchResponse> {
         var query = [String: String]()
         if category != nil {
             query["category"] = category
@@ -216,6 +234,9 @@ actor LANraragiService {
         query["start"] = start
         query["sortby"] = sortby
         query["order"] = order
+        if let groupByTanks {
+            query["groupby_tanks"] = String(groupByTanks)
+        }
 
         return session.request("\(url)/api/search", parameters: query)
             .validate()
@@ -224,7 +245,8 @@ actor LANraragiService {
 
     func randomArchives(
         category: String? = nil,
-        filter: String? = nil
+        filter: String? = nil,
+        groupByTanks: Bool? = nil
     ) async -> DataTask<ArchiveRandomResponse> {
         var query = [String: String]()
         query["count"] = "100"
@@ -234,9 +256,77 @@ actor LANraragiService {
         if let filter = filter {
             query["filter"] = filter
         }
+        if let groupByTanks {
+            query["groupby_tanks"] = String(groupByTanks)
+        }
         return session.request("\(url)/api/search/random", method: .get, parameters: query)
             .validate(statusCode: 200...200)
             .serializingDecodable(ArchiveRandomResponse.self)
+    }
+
+    func retrieveTankoubon(id: String) async -> DataTask<TankoubonMetadataResponse> {
+        session.request("\(url)/api/tankoubons/\(id)")
+            .validate(statusCode: 200...200)
+            .serializingDecodable(TankoubonMetadataResponse.self)
+    }
+
+    func retrieveFullTankoubon(id: String, page: Int = -1) async -> DataTask<TankoubonFullResponse> {
+        session.request("\(url)/api/tankoubons/\(id)/full", parameters: ["page": page])
+            .validate(statusCode: 200...200)
+            .serializingDecodable(TankoubonFullResponse.self)
+    }
+
+    func updateTankoubon(
+        id: String,
+        name: String? = nil,
+        summary: String? = nil,
+        tags: String? = nil,
+        appendTags: Bool? = nil
+    ) async -> DataTask<GenericSuccessResponse> {
+        let metadata: TankoubonMetadataUpdateRequest?
+        if name != nil || summary != nil || tags != nil || appendTags != nil {
+            metadata = TankoubonMetadataUpdateRequest(
+                name: name,
+                summary: summary,
+                tags: tags,
+                appendTags: appendTags
+            )
+        } else {
+            metadata = nil
+        }
+
+        let request = TankoubonUpdateRequest(metadata: metadata)
+        return session.request(
+            "\(url)/api/tankoubons/\(id)",
+            method: .put,
+            parameters: request,
+            encoder: JSONParameterEncoder.default
+        )
+        .validate(statusCode: 200...200)
+        .serializingDecodable(GenericSuccessResponse.self)
+    }
+
+    func deleteTankoubon(id: String) async -> DataTask<GenericSuccessResponse> {
+        session.request("\(url)/api/tankoubons/\(id)", method: .delete)
+            .validate(statusCode: 200...200)
+            .serializingDecodable(GenericSuccessResponse.self)
+    }
+
+    func updateTankoubonThumbnail(id: String, page: Int) async -> DataTask<TankoubonThumbnailUpdateResponse> {
+        session.request(
+            "\(url)/api/tankoubons/\(id)/thumbnail",
+            method: .put,
+            parameters: ["page": page],
+            encoding: URLEncoding(destination: .queryString)
+        )
+            .validate(statusCode: 200...200)
+            .serializingDecodable(TankoubonThumbnailUpdateResponse.self)
+    }
+
+    func updateTankoubonReadProgress(id: String, progress: Int) async -> DataTask<TankoubonProgressResponse> {
+        session.request("\(url)/api/tankoubons/\(id)/progress/\(progress)", method: .put)
+            .validate(statusCode: 200...200)
+            .serializingDecodable(TankoubonProgressResponse.self)
     }
 
     func retrieveCategories() async -> DataTask<[ArchiveCategoriesResponse]> {

--- a/LANreaderTests/Service/LANraragiServiceTest.swift
+++ b/LANreaderTests/Service/LANraragiServiceTest.swift
@@ -8,11 +8,13 @@ import OHHTTPStubsSwift
 import SwiftUI
 @testable import LANreader
 
-// swiftlint:disable type_body_length
+// swiftlint:disable type_body_length file_length
 class LANraragiServiceTest: XCTestCase {
 
     private let url = "https://localhost"
     private let apiKey = "apiKey"
+    private let tankId = "TANK_1783084742"
+    private let archiveId = "0123456789012345678901234567890123456789"
 
     private var service: LANraragiService!
 
@@ -277,6 +279,46 @@ class LANraragiServiceTest: XCTestCase {
         XCTAssertEqual(actual.recordsTotal, 1234)
     }
 
+    func testSearchArchiveDecodesTankResultAndCanDisableGrouping() async throws {
+        try await configureVerifiedClient()
+
+        let tankId = self.tankId
+        let body = Data("""
+        {
+          "data": [{
+            "archive_count": 2,
+            "arcid": "\(tankId)",
+            "extension": ".tank",
+            "filename": "",
+            "isnew": "false",
+            "lastreadtime": 1783084725,
+            "pagecount": 47,
+            "progress": 1,
+            "size": 77747883,
+            "summary": "summary",
+            "tags": "artist:test",
+            "title": "test"
+          }],
+          "draw": 0,
+          "recordsFiltered": 1,
+          "recordsTotal": 1
+        }
+        """.utf8)
+
+        stub(condition: isHost("localhost")
+                && isPath("/api/search")
+                && containsQueryParams(["category": "SET_12345678", "groupby_tanks": "false"])
+                && isMethodGET()
+                && hasHeaderNamed("Authorization", value: "Bearer YXBpS2V5")) { _ in
+            HTTPStubsResponse(data: body, statusCode: 200, headers: ["Content-Type": "application/json"])
+        }
+
+        let actual = try await service.searchArchive(category: "SET_12345678", groupByTanks: false).value
+        XCTAssertEqual(actual.data[0].arcid, tankId)
+        XCTAssertEqual(actual.data[0].archiveCount, 2)
+        XCTAssertEqual(actual.data[0].extension, ".tank")
+    }
+
     func testSearchArchiveIndexUnauthorized() async throws {
         try await configureVerifiedClient()
 
@@ -292,6 +334,139 @@ class LANraragiServiceTest: XCTestCase {
 
         let actual = try? await service.searchArchive(category: "SET_12345678").value
         XCTAssertNil(actual)
+    }
+
+    func testRetrieveTankoubonMetadata() async throws {
+        try await configureVerifiedClient()
+
+        let tankId = self.tankId
+        let archiveId = self.archiveId
+        let tankBody = Data("""
+        {
+          "id": "\(tankId)",
+          "name": "Tank",
+          "summary": "Summary",
+          "tags": "artist:test",
+          "archives": ["\(archiveId)"],
+          "progress": 3
+        }
+        """.utf8)
+        stub(condition: isHost("localhost") && isPath("/api/tankoubons/\(tankId)")) { _ in
+            HTTPStubsResponse(data: tankBody, statusCode: 200, headers: nil)
+        }
+
+        let tank = try await service.retrieveTankoubon(id: tankId).value
+
+        XCTAssertEqual(tank.id, tankId)
+        XCTAssertEqual(tank.archives, [archiveId])
+    }
+
+    func testRetrieveFullTankoubonAndThumbnail() async throws {
+        try await configureVerifiedClient()
+
+        let tankId = self.tankId
+        let archiveId = self.archiveId
+        let fullBody = Data("""
+        {
+          "result": {
+            "id": "\(tankId)",
+            "name": "Tank",
+            "summary": "Summary",
+            "tags": "artist:test",
+            "progress": 3,
+            "archives": ["\(archiveId)"],
+            "full_data": [{
+              "arcid": "\(archiveId)",
+              "extension": "zip",
+              "filename": "archive.zip",
+              "isnew": false,
+              "lastreadtime": 1,
+              "pagecount": 10,
+              "progress": 0,
+              "size": 100,
+              "tags": "artist:test",
+              "title": "Archive"
+            }]
+          },
+          "total": 1,
+          "filtered": 1
+        }
+        """.utf8)
+        let imageData = Data([0xFF, 0xD8, 0xFF, 0xDB])
+
+        stub(condition: isHost("localhost")
+                && isPath("/api/tankoubons/\(tankId)/full")
+                && containsQueryParams(["page": "-1"])) { _ in
+            HTTPStubsResponse(data: fullBody, statusCode: 200, headers: nil)
+        }
+        stub(condition: isHost("localhost")
+                && isPath("/api/tankoubons/\(tankId)/thumbnail")
+                && containsQueryParams(["no_fallback": "true"])) { _ in
+            HTTPStubsResponse(data: imageData, statusCode: 200, headers: ["Content-Type": "image/jpeg"])
+        }
+
+        let full = try await service.retrieveFullTankoubon(id: tankId).value
+        let thumbnail = try await service.retrieveTankoubonThumbnail(id: tankId)
+
+        XCTAssertEqual(full.result.fullData?.first?.arcid, archiveId)
+        XCTAssertEqual(thumbnail, imageData)
+    }
+
+    func testUpdateAndDeleteTankoubon() async throws {
+        try await configureVerifiedClient()
+
+        let tankId = self.tankId
+        let successBody = Data("{ \"success\": 1 }".utf8)
+
+        stub(condition: isHost("localhost")
+                && isPath("/api/tankoubons/\(tankId)")
+                && isMethodPUT()
+                && hasHeaderNamed("Content-Type", value: "application/json")) { _ in
+            HTTPStubsResponse(data: successBody, statusCode: 200, headers: nil)
+        }
+        stub(condition: isHost("localhost")
+                && isPath("/api/tankoubons/\(tankId)")
+                && isMethodDELETE()) { _ in
+            HTTPStubsResponse(data: successBody, statusCode: 200, headers: nil)
+        }
+
+        let update = try await service.updateTankoubon(
+            id: tankId,
+            name: "Tank",
+            summary: "Summary",
+            tags: "artist:test",
+            appendTags: false
+        ).value
+        let delete = try await service.deleteTankoubon(id: tankId).value
+
+        XCTAssertEqual(update.success, 1)
+        XCTAssertEqual(delete.success, 1)
+    }
+
+    func testUpdateThumbnailAndProgress() async throws {
+        try await configureVerifiedClient()
+
+        let tankId = self.tankId
+        stub(condition: isHost("localhost")
+                && isPath("/api/tankoubons/\(tankId)/thumbnail")
+                && containsQueryParams(["page": "4"])
+                && isMethodPUT()) { _ in
+            let body = Data("{ \"operation\": \"update_tankoubon_thumbnail\", \"success\": 1 }".utf8)
+            return HTTPStubsResponse(data: body, statusCode: 200, headers: nil)
+        }
+        stub(condition: isHost("localhost") && isPath("/api/tankoubons/\(tankId)/progress/5")) { _ in
+            let body = Data("""
+            { "id": "\(tankId)", "operation": "update_tank_progress",
+              "page": 5, "lastreadtime": 123943543, "success": 1 }
+            """.utf8)
+            return HTTPStubsResponse(data: body, statusCode: 200, headers: nil)
+        }
+
+        let thumbnail = try await service.updateTankoubonThumbnail(id: tankId, page: 4).value
+        let progress = try await service.updateTankoubonReadProgress(id: tankId, progress: 5).value
+
+        XCTAssertEqual(thumbnail.success, 1)
+        XCTAssertEqual(progress.page, 5)
     }
 
     func testRetrieveCategories() async throws {
@@ -638,4 +813,4 @@ class LANraragiServiceTest: XCTestCase {
     }
 
 }
-// swiftlint:enable type_body_length
+// swiftlint:enable type_body_length file_length


### PR DESCRIPTION
## What changed
- Added LANraragi Tankoubon response/request models and service endpoints for metadata, full contents, thumbnails, delete, metadata update, and read progress.
- Added `groupby_tanks` support for search/random archive requests and `archive_count` decoding for tank search results.
- Covered Tankoubon service behavior in the existing `LANraragiServiceTest` suite.
- Bumped app version to 3.9.0 and build number to 184 for LANreader and Action targets.

## Why
LANraragi now returns virtual `.tank` archives with `TANK_` ids and exposes dedicated Tankoubon endpoints for reading and metadata operations.

## Verification
- `./scripts/lint` passed.
- `git diff --check` passed.
- `./scripts/test-ios -only-testing:LANreaderTests/LANraragiServiceTest` was attempted twice. First attempt failed before tests because the Xcode build system crashed with `Build again to continue`; retry was blocked by local CoreSimulator mismatch: current CoreSimulator 1051.54.0 is older than build version 1051.55.0 and the configured iPad simulator destination was unavailable.
