### PR TITLE
Use Xcode 26.6 in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Select Xcode version
         run: |
-          sudo xcode-select -switch /Applications/Xcode_26.5.app
+          sudo xcode-select -switch /Applications/Xcode_26.6.app
           xcodebuild -version
 
       - name: Build and test

--- a/.github/workflows/manual-ipa-release.yml
+++ b/.github/workflows/manual-ipa-release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Select Xcode version
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.5.app
+          sudo xcode-select -s /Applications/Xcode_26.6.app
           xcodebuild -version
 
       - name: Resolve app versions

--- a/LANreader.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/LANreader.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/noppefoxwolf/AnimatedImage",
       "state" : {
-        "revision" : "1aab1442149b76acf786b3c1e9cd6837638c954b",
-        "version" : "0.2.3"
+        "revision" : "d64237a33ce91b0513dd850589fea32fa28f4f80",
+        "version" : "0.2.4"
       }
     },
     {
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-navigation",
       "state" : {
-        "revision" : "6cff006b3607b700029dc44f06b41a6cc7384ac7",
-        "version" : "2.10.2"
+        "revision" : "fad75807c596fecd724b0fc81cd61c94008faad4",
+        "version" : "2.10.3"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-sharing",
       "state" : {
-        "revision" : "c8dd3627eb92cef1bcb44ac5a93d558ab32b82ce",
-        "version" : "2.9.0"
+        "revision" : "8244fe63bf43e58188ab13851ad693eecf6a9e90",
+        "version" : "2.9.1"
       }
     },
     {

--- a/ci_scripts/macros.json
+++ b/ci_scripts/macros.json
@@ -20,7 +20,7 @@
     "targetName" : "PerceptionMacros"
   },
   {
-    "fingerprint" : "6cff006b3607b700029dc44f06b41a6cc7384ac7",
+    "fingerprint" : "fad75807c596fecd724b0fc81cd61c94008faad4",
     "packageIdentity" : "swift-navigation",
     "targetName" : "SwiftNavigationMacros"
   }


### PR DESCRIPTION
## What changed
- Select Xcode 26.6 in CI and manual IPA release workflows.
- Include the refreshed SwiftPM pins for AnimatedImage 0.2.4, swift-navigation 2.10.3, and swift-sharing 2.9.1.
- Update the trusted SwiftNavigationMacros fingerprint for the new swift-navigation revision.

## Why
The macos-26-arm64 runner image exposes /Applications/Xcode_26.6.app. The simulator destination remains iOS 26.5 because the same runner image lists iOS Simulator 26.5 devices for Xcode 26.6.

## Verification
- git diff --check
- ./scripts/lint
- xcodebuild -version -> Xcode 26.6, Build version 17F113
- ./scripts/test-ios -> 99 tests passed