### PR TITLE
Align archive update requests with OpenAPI

### DIFF
--- a/LANreader/Service/LANraragiService.swift
+++ b/LANreader/Service/LANraragiService.swift
@@ -213,7 +213,12 @@ actor LANraragiService {
 
     func updateArchiveThumbnail(id: String, page: Int) -> DataTask<String> {
         let query = ["page": page]
-        return session.request("\(url)/api/archives/\(id)/thumbnail", method: .put, parameters: query)
+        return session.request(
+            "\(url)/api/archives/\(id)/thumbnail",
+            method: .put,
+            parameters: query,
+            encoding: URLEncoding.queryString
+        )
             .validate(statusCode: 200...200)
             .serializingString()
     }
@@ -417,8 +422,12 @@ actor LANraragiService {
         query["title"] = archive.name
         query["tags"] = archive.tags
 
-        return session.request("\(url)/api/archives/\(archive.id)/metadata",
-                               method: .put, parameters: query)
+        return session.request(
+            "\(url)/api/archives/\(archive.id)/metadata",
+            method: .put,
+            parameters: query,
+            encoding: URLEncoding.queryString
+        )
         .validate(statusCode: 200...200)
         .serializingString()
     }

--- a/LANreaderTests/Service/LANraragiServiceTest.swift
+++ b/LANreaderTests/Service/LANraragiServiceTest.swift
@@ -202,6 +202,22 @@ class LANraragiServiceTest: XCTestCase {
         XCTAssertNil(actual)
     }
 
+    func testUpdateArchiveThumbnailSendsPageAsQueryParameter() async throws {
+        try await configureVerifiedClient()
+
+        let body = "{ \"operation\": \"update_thumbnail\", \"success\": 1 }"
+        stub(condition: isHost("localhost")
+                && isPath("/api/archives/id/thumbnail")
+                && containsQueryParams(["page": "4"])
+                && isMethodPUT()
+                && hasHeaderNamed("Authorization", value: "Bearer YXBpS2V5")) { _ in
+            HTTPStubsResponse(data: Data(body.utf8), statusCode: 200, headers: ["Content-Type": "application/json"])
+        }
+
+        let actual = try await service.updateArchiveThumbnail(id: "id", page: 4).value
+        XCTAssertEqual(actual, body)
+    }
+
     func testQueuePageThumbnailsReturnsQueuedJob() async throws {
         try await configureVerifiedClient()
 
@@ -657,8 +673,8 @@ class LANraragiServiceTest: XCTestCase {
 
         stub(condition: isHost("localhost")
                 && isPath("/api/archives/id/metadata")
+                && containsQueryParams(["tags": "tags", "title": "name"])
                 && isMethodPUT()
-                && hasBody(Data("tags=tags&title=name".utf8))
                 && hasHeaderNamed("Authorization", value: "Bearer YXBpS2V5")) { _ in
             HTTPStubsResponse(
                     fileAtPath: OHPathForFile("SetArchiveMetadataResponse.json", type(of: self))!,
@@ -678,8 +694,8 @@ class LANraragiServiceTest: XCTestCase {
 
         stub(condition: isHost("localhost")
                 && isPath("/api/archives/id/metadata")
+                && containsQueryParams(["tags": "tags", "title": "name"])
                 && isMethodPUT()
-                && hasBody(Data("tags=tags&title=name".utf8))
                 && hasHeaderNamed("Authorization", value: "Bearer YXBpS2V5")) { _ in
             HTTPStubsResponse(
                     fileAtPath: OHPathForFile("UnauthorizedResponse.json", type(of: self))!,


### PR DESCRIPTION
## Summary
- Send archive thumbnail and archive metadata update parameters as query strings to match LANraragi OpenAPI
- Add service test coverage for archive thumbnail and metadata update query parameters

## Verification
- git diff --check
- ./scripts/lint
- ./scripts/test-ios -only-testing:LANreaderTests/LANraragiServiceTest/testUpdateArchiveThumbnailSendsPageAsQueryParameter -only-testing:LANreaderTests/LANraragiServiceTest/testUpdateArchiveMetadata -only-testing:LANreaderTests/LANraragiServiceTest/testUpdateArchiveMetadataUnauthorized