### PR TITLE
Add reader chapter navigation

### DIFF
--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -939,7 +939,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreader.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 187;
+				CURRENT_PROJECT_VERSION = 188;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -950,7 +950,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.9.1;
+				MARKETING_VERSION = 3.9.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -967,7 +967,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreaderRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 187;
+				CURRENT_PROJECT_VERSION = 188;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -978,7 +978,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.9.1;
+				MARKETING_VERSION = 3.9.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1041,7 +1041,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 187;
+				CURRENT_PROJECT_VERSION = 188;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1053,7 +1053,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.9.1;
+				MARKETING_VERSION = 3.9.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1071,7 +1071,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 187;
+				CURRENT_PROJECT_VERSION = 188;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1083,7 +1083,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.9.1;
+				MARKETING_VERSION = 3.9.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/LANreader/Models/LANraragiResponse.swift
+++ b/LANreader/Models/LANraragiResponse.swift
@@ -11,6 +11,7 @@ struct ArchiveIndexResponse: Decodable, Equatable {
     let pagecount: Int
     let progress: Int
     let archiveCount: Int?
+    let toc: [ArchiveChapter]?
 
     private enum CodingKeys: String, CodingKey {
         case arcid
@@ -21,6 +22,7 @@ struct ArchiveIndexResponse: Decodable, Equatable {
         case pagecount
         case progress
         case archiveCount = "archive_count"
+        case toc
     }
 
     init(from decoder: Decoder) throws {
@@ -33,6 +35,7 @@ struct ArchiveIndexResponse: Decodable, Equatable {
         self.pagecount = try container.decode(Int.self, forKey: .pagecount)
         self.progress = try container.decode(Int.self, forKey: .progress)
         self.archiveCount = try container.decodeIfPresent(Int.self, forKey: .archiveCount)
+        self.toc = try container.decodeIfPresent([ArchiveChapter].self, forKey: .toc)
     }
 }
 
@@ -348,7 +351,8 @@ extension ArchiveIndexResponse {
                 isNew: isnew == "true",
                 progress: progress,
                 pagecount: pagecount,
-                dateAdded: extractDateAdded(tags: tags ?? ""))
+                dateAdded: extractDateAdded(tags: tags ?? ""),
+                toc: toc)
     }
 
     func toArchive() -> Archive {

--- a/LANreader/Models/ViewModels.swift
+++ b/LANreader/Models/ViewModels.swift
@@ -3,6 +3,12 @@
 import Foundation
 import SwiftUI
 
+public struct ArchiveChapter: Decodable, Equatable, Hashable, Identifiable, Sendable {
+    public var id: Int { page }
+    public let name: String
+    public let page: Int
+}
+
 public struct ArchiveItem: Identifiable, Equatable, Hashable, Sendable {
     public let id: String
     var name: String
@@ -12,6 +18,7 @@ public struct ArchiveItem: Identifiable, Equatable, Hashable, Sendable {
     var progress: Int
     let pagecount: Int
     let dateAdded: Int?
+    var toc: [ArchiveChapter]?
     var refresh: Bool = false
 }
 

--- a/LANreader/Page/ArchiveReader.swift
+++ b/LANreader/Page/ArchiveReader.swift
@@ -109,6 +109,14 @@ public struct SliderPreviewThumbnailQueueResult: Equatable, Sendable {
             archivePageNumbers.count
         }
 
+        var chapters: [ArchiveChapter] {
+            guard !cached,
+                  let currentArchive = allArchives[id: currentArchiveId] else {
+                return []
+            }
+            return currentArchive.wrappedValue.toc ?? []
+        }
+
         var canOpenDetails: Bool {
             guard !extracting else { return false }
             guard currentArchiveId.isTankoubonArchiveId else { return true }
@@ -130,6 +138,7 @@ public struct SliderPreviewThumbnailQueueResult: Equatable, Sendable {
         case finishExtracting([ReaderExtractedPage], TankoubonDetailsMetadata?)
         case toggleControlUi(Bool?)
         case visiblePageChanged(Int)
+        case chapterSelected(Int)
         case requestJump(Int, source: ReaderNavigationSource)
         case navigate(ReaderNavigationDirection, source: ReaderNavigationSource)
         case scrollRequestHandled(UUID)
@@ -351,6 +360,12 @@ public struct SliderPreviewThumbnailQueueResult: Equatable, Sendable {
                     logger.error("failed to update archive progress. id=\(state.currentArchiveId) \(error)")
                 }
                 .cancellable(id: CancelId.updateProgress, cancelInFlight: true)
+            case let .chapterSelected(pageNumber):
+                guard state.chapters.contains(where: { $0.page == pageNumber }),
+                      let pageIndex = state.pages.firstIndex(where: { $0.pageNumber == pageNumber }) else {
+                    return .none
+                }
+                return .send(.requestJump(pageIndex, source: .chapter))
             case let .requestJump(index, source):
                 guard !state.pages.isEmpty else { return .none }
                 let clampedIndex = ReaderPositioning.clampedPageIndex(index, pageCount: state.pages.count)
@@ -1214,9 +1229,9 @@ struct ArchiveReader: View {
                     sliderPreviewRow(
                         store: store,
                         displayIndex: displayIndex,
-                        isRightToLeft: isRightToLeft,
+                        sliderContext: sliderContext,
                         bubbleLayout: bubbleLayout,
-                        sliderHorizontalPadding: sliderHorizontalPadding
+                        showsChapterMenu: !store.chapters.isEmpty
                     )
                 }
 
@@ -1235,20 +1250,23 @@ struct ArchiveReader: View {
     private func sliderPreviewRow(
         store: StoreOf<ArchiveReaderFeature>,
         displayIndex: Int,
-        isRightToLeft: Bool,
+        sliderContext: ReaderSliderContext,
         bubbleLayout: SliderPreviewBubbleLayout,
-        sliderHorizontalPadding: CGFloat
+        showsChapterMenu: Bool
     ) -> some View {
         GeometryReader { geometry in
+            let chapterMenuInset = showsChapterMenu ? ReaderToolbarMetrics.chapterMenuInset : 0
             let bubbleLeadingX = SliderPreviewPositioning.bubbleLeadingX(
                 pageIndex: displayIndex,
                 pageCount: store.pages.count,
                 track: SliderPreviewTrackGeometry(
                     rowWidth: geometry.size.width,
-                    sliderHorizontalPadding: sliderHorizontalPadding,
-                    bubbleWidth: bubbleLayout.width
+                    sliderHorizontalPadding: sliderContext.horizontalPadding,
+                    bubbleWidth: bubbleLayout.width,
+                    leadingInset: sliderContext.isRightToLeft ? 0 : chapterMenuInset,
+                    trailingInset: sliderContext.isRightToLeft ? chapterMenuInset : 0
                 ),
-                isRightToLeft: isRightToLeft
+                isRightToLeft: sliderContext.isRightToLeft
             )
 
             SliderPreviewBubble(
@@ -1407,51 +1425,82 @@ struct ArchiveReader: View {
         store: StoreOf<ArchiveReaderFeature>,
         context: ReaderSliderContext
     ) -> some View {
-        GeometryReader { geometry in
-            let sliderWidth = max(geometry.size.width - context.horizontalPadding * 2, 1)
-
-            ZStack {
-                Slider(
-                    value: .constant(context.displayValue),
-                    in: 0...Double(context.maxIndex),
-                    step: 1
-                )
-                .tint(Color(uiColor: .systemBlue))
-                .padding(.horizontal, context.horizontalPadding)
-                .scaleEffect(x: context.isRightToLeft ? -1 : 1, y: 1)
-                .allowsHitTesting(false)
-
-                Rectangle()
-                    .fill(Color.clear)
-                    .contentShape(Rectangle())
-                    .gesture(
-                        DragGesture(minimumDistance: 0)
-                            .onChanged { value in
-                                if !store.sliderDragging {
-                                    store.send(.sliderDragStarted)
-                                }
-                                sendSliderDragChanged(
-                                    store: store,
-                                    locationX: value.location.x,
-                                    sliderWidth: sliderWidth,
-                                    context: context
-                                )
-                            }
-                            .onEnded { value in
-                                sendSliderDragChanged(
-                                    store: store,
-                                    locationX: value.location.x,
-                                    sliderWidth: sliderWidth,
-                                    context: context
-                                )
-                                store.send(.sliderDragEnded)
-                            }
-                    )
+        HStack(spacing: ReaderToolbarMetrics.chapterMenuSpacing) {
+            if !store.chapters.isEmpty {
+                readerChapterMenu(store: store)
             }
+
+            GeometryReader { geometry in
+                let sliderWidth = max(geometry.size.width - context.horizontalPadding * 2, 1)
+
+                ZStack {
+                    Slider(
+                        value: .constant(context.displayValue),
+                        in: 0...Double(context.maxIndex),
+                        step: 1
+                    )
+                    .tint(Color(uiColor: .systemBlue))
+                    .padding(.horizontal, context.horizontalPadding)
+                    .scaleEffect(x: context.isRightToLeft ? -1 : 1, y: 1)
+                    .allowsHitTesting(false)
+
+                    Rectangle()
+                        .fill(Color.clear)
+                        .contentShape(Rectangle())
+                        .gesture(
+                            DragGesture(minimumDistance: 0)
+                                .onChanged { value in
+                                    if !store.sliderDragging {
+                                        store.send(.sliderDragStarted)
+                                    }
+                                    sendSliderDragChanged(
+                                        store: store,
+                                        locationX: value.location.x,
+                                        sliderWidth: sliderWidth,
+                                        context: context
+                                    )
+                                }
+                                .onEnded { value in
+                                    sendSliderDragChanged(
+                                        store: store,
+                                        locationX: value.location.x,
+                                        sliderWidth: sliderWidth,
+                                        context: context
+                                    )
+                                    store.send(.sliderDragEnded)
+                                }
+                        )
+                }
+            }
+            .frame(height: 34)
+            .environment(\.layoutDirection, .leftToRight)
+            .accessibilityLabel(Text("archive.reader.page.slider"))
         }
-        .frame(height: 34)
-        .environment(\.layoutDirection, .leftToRight)
-        .accessibilityLabel(Text("archive.reader.page.slider"))
+        .frame(height: store.chapters.isEmpty ? 34 : ReaderToolbarMetrics.buttonSize)
+    }
+
+    private func readerChapterMenu(
+        store: StoreOf<ArchiveReaderFeature>
+    ) -> some View {
+        Menu {
+            ForEach(store.chapters) { chapter in
+                Button(chapter.name) {
+                    store.send(.chapterSelected(chapter.page))
+                }
+            }
+        } label: {
+            Label("archive.reader.chapters", systemImage: "list.bullet.rectangle")
+                .labelStyle(.iconOnly)
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(Color.indigo)
+                .frame(width: ReaderToolbarMetrics.buttonSize, height: ReaderToolbarMetrics.buttonSize)
+                .background(Color(uiColor: .secondarySystemBackground).opacity(0.82), in: Circle())
+                .overlay {
+                    Circle()
+                        .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
+                }
+        }
+        .menuOrder(.fixed)
     }
 
     private func sendSliderDragChanged(
@@ -1507,6 +1556,8 @@ private enum ReaderToolbarMetrics {
     static let previewBottomSpacing: CGFloat = 12
     static let sliderHorizontalPadding: CGFloat = 16
     static let buttonSize: CGFloat = 44
+    static let chapterMenuSpacing: CGFloat = 10
+    static let chapterMenuInset = buttonSize + chapterMenuSpacing
 }
 
 enum SliderPreviewPositioning {
@@ -1527,8 +1578,14 @@ enum SliderPreviewPositioning {
         track: SliderPreviewTrackGeometry,
         isRightToLeft: Bool
     ) -> CGFloat {
-        let sliderWidth = max(track.rowWidth - track.sliderHorizontalPadding * 2, 1)
-        let thumbCenterX = track.sliderHorizontalPadding + (
+        let sliderWidth = max(
+            track.rowWidth
+                - track.leadingInset
+                - track.trailingInset
+                - track.sliderHorizontalPadding * 2,
+            1
+        )
+        let thumbCenterX = track.leadingInset + track.sliderHorizontalPadding + (
             sliderWidth * visualNormalized(
                 pageIndex: pageIndex,
                 pageCount: pageCount,
@@ -1560,6 +1617,22 @@ struct SliderPreviewTrackGeometry {
     let rowWidth: CGFloat
     let sliderHorizontalPadding: CGFloat
     let bubbleWidth: CGFloat
+    let leadingInset: CGFloat
+    let trailingInset: CGFloat
+
+    init(
+        rowWidth: CGFloat,
+        sliderHorizontalPadding: CGFloat,
+        bubbleWidth: CGFloat,
+        leadingInset: CGFloat = 0,
+        trailingInset: CGFloat = 0
+    ) {
+        self.rowWidth = rowWidth
+        self.sliderHorizontalPadding = sliderHorizontalPadding
+        self.bubbleWidth = bubbleWidth
+        self.leadingInset = leadingInset
+        self.trailingInset = trailingInset
+    }
 }
 
 private struct SliderPreviewBubble: View {

--- a/LANreader/Page/ReaderPositioning.swift
+++ b/LANreader/Page/ReaderPositioning.swift
@@ -3,6 +3,7 @@ import Foundation
 public enum ReaderNavigationSource: Equatable, Sendable {
     case initialRestore
     case slider
+    case chapter
     case tap
     case keyboard
     case autoPage

--- a/LANreader/Page/UIPageCollection.swift
+++ b/LANreader/Page/UIPageCollection.swift
@@ -167,7 +167,7 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
         switch request.source {
         case .initialRestore, .slider:
             return .centeredHorizontally
-        case .tap, .keyboard, .autoPage:
+        case .chapter, .tap, .keyboard, .autoPage:
             return .left
         }
     }

--- a/LANreaderTests/ArchiveReaderFeatureTests.swift
+++ b/LANreaderTests/ArchiveReaderFeatureTests.swift
@@ -321,6 +321,39 @@ final class ArchiveReaderFeatureTests: XCTestCase {
         )
     }
 
+    func testSliderPreviewPositioningAccountsForChapterMenuInset() {
+        XCTAssertEqual(
+            SliderPreviewPositioning.bubbleLeadingX(
+                pageIndex: 2,
+                pageCount: 5,
+                track: SliderPreviewTrackGeometry(
+                    rowWidth: 320,
+                    sliderHorizontalPadding: 16,
+                    bubbleWidth: 100,
+                    leadingInset: 54
+                ),
+                isRightToLeft: false
+            ),
+            137,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            SliderPreviewPositioning.bubbleLeadingX(
+                pageIndex: 2,
+                pageCount: 5,
+                track: SliderPreviewTrackGeometry(
+                    rowWidth: 320,
+                    sliderHorizontalPadding: 16,
+                    bubbleWidth: 100,
+                    trailingInset: 54
+                ),
+                isRightToLeft: true
+            ),
+            83,
+            accuracy: 0.001
+        )
+    }
+
     func testSliderPreviewPositioningMapsRightEdgeToFirstPageInRTL() {
         XCTAssertEqual(
             SliderPreviewPositioning.pageIndex(
@@ -797,6 +830,48 @@ final class ArchiveReaderFeatureTests: XCTestCase {
                 animated: false
             )
         }
+    }
+
+    @MainActor
+    func testChapterSelectionJumpsToOneBasedPageAfterSplitInsertion() async {
+        configureReaderDefaults()
+        let chapters = [
+            ArchiveChapter(name: "Opening", page: 1),
+            ArchiveChapter(name: "Second chapter", page: 3)
+        ]
+        var initialState = makeState(
+            allArchives: [makeArchive(toc: chapters)]
+        )
+        initialState.pages = makeSplitPageStates()
+        let store = makeTestStore(initialState: initialState)
+
+        XCTAssertEqual(store.state.chapters, chapters)
+
+        await store.send(.chapterSelected(3))
+        await store.receive(.requestJump(3, source: .chapter)) {
+            $0.scrollRequest = makeScrollRequest(
+                id: 0,
+                targetPageIndex: 3,
+                source: .chapter,
+                animated: true
+            )
+        }
+    }
+
+    @MainActor
+    func testCachedReaderDoesNotExposeOrNavigateChapters() async {
+        configureReaderDefaults()
+        var initialState = makeState(
+            cached: true,
+            allArchives: [
+                makeArchive(toc: [ArchiveChapter(name: "Opening", page: 1)])
+            ]
+        )
+        initialState.pages = makePageStates(count: 3)
+        let store = makeTestStore(initialState: initialState)
+
+        XCTAssertTrue(store.state.chapters.isEmpty)
+        await store.send(.chapterSelected(1))
     }
 
     @MainActor
@@ -1985,7 +2060,8 @@ private func makeState(
 private func makeArchive(
     id: String = "archive",
     progress: Int = 0,
-    isNew: Bool = false
+    isNew: Bool = false,
+    toc: [ArchiveChapter]? = nil
 ) -> ArchiveItem {
     ArchiveItem(
         id: id,
@@ -1995,7 +2071,8 @@ private func makeArchive(
         isNew: isNew,
         progress: progress,
         pagecount: 10,
-        dateAdded: nil
+        dateAdded: nil,
+        toc: toc
     )
 }
 

--- a/LANreaderTests/Resources/ArchiveSearchResponse.json
+++ b/LANreaderTests/Resources/ArchiveSearchResponse.json
@@ -7,7 +7,17 @@
             "tags": "artist:abc, language:def, parody:ghi, category:jkl",
             "title": "title",
             "pagecount": 12,
-            "progress": 2
+            "progress": 2,
+            "toc": [
+                {
+                    "name": "Chapter 1",
+                    "page": 1
+                },
+                {
+                    "name": "Chapter 2",
+                    "page": 5
+                }
+            ]
         }
     ],
     "draw": 0,

--- a/LANreaderTests/Service/LANraragiServiceTest.swift
+++ b/LANreaderTests/Service/LANraragiServiceTest.swift
@@ -324,6 +324,14 @@ class LANraragiServiceTest: XCTestCase {
         XCTAssertEqual(actual.draw, 0)
         XCTAssertEqual(actual.recordsFiltered, 1)
         XCTAssertEqual(actual.recordsTotal, 1234)
+        XCTAssertEqual(
+            actual.data[0].toc,
+            [
+                ArchiveChapter(name: "Chapter 1", page: 1),
+                ArchiveChapter(name: "Chapter 2", page: 5)
+            ]
+        )
+        XCTAssertEqual(actual.data[0].toArchiveItem().toc, actual.data[0].toc)
     }
 
     func testSearchArchiveDecodesTankResultAndCanDisableGrouping() async throws {

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -1291,6 +1291,41 @@
         }
       }
     },
+    "archive.reader.chapters" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chapters"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャプター"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "챕터"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "章节"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "章節"
+          }
+        }
+      }
+    },
     "archive.reader.cache.remove" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
## What changed

- decode optional archive chapter metadata and expose a chapter menu in the non-cached reader
- jump to one-based chapter pages while preserving split-page and reading-direction behavior
- keep the chapter control hidden for cached archives and archives without chapters
- bump the app and Action targets to version 3.9.2, build 188

## Why

LANraragi archive results can now include a table of contents, so the reader should let users navigate directly to chapter start pages.

## Verification

- ./scripts/lint
- ./scripts/test-ios — 116 tests passed
- jq empty Localizable.xcstrings
- git diff --check