### PR TITLE
Hide status bar (Clock/Battery) in reader when UI controls are hidden

### DIFF
--- a/LANreader/Page/UIArchiveReader.swift
+++ b/LANreader/Page/UIArchiveReader.swift
@@ -7,6 +7,10 @@ class UIArchiveReaderController: UIViewController {
     private var hostingController: UIHostingController<ArchiveReader>!
     private var detailsButton: UIBarButtonItem?
 
+    override var prefersStatusBarHidden: Bool {
+        store.controlUiHidden
+    }
+
     init(
         store: StoreOf<ArchiveReaderFeature>,
         navigationHelper: NavigationHelper? = nil
@@ -74,6 +78,7 @@ class UIArchiveReaderController: UIViewController {
             let controlUiHidden = store.controlUiHidden
             guard self.navigationController?.topViewController === self else { return }
             self.navigationController?.setNavigationBarHidden(controlUiHidden, animated: false)
+            self.setNeedsStatusBarAppearanceUpdate()
         }
 
         observe { [weak self] in


### PR DESCRIPTION
This was the only thing that bothered me about the app. I don't know if it's intentional that it stays visible, but if not, I thought this might benefit everyone else too (:

(Only tested on iPadOS 17, but it should work everywhere i guess)