### PR TITLE
Fix CRLF log rendering

### DIFF
--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		F1A2B3C62F60000200AAA001 /* ArchiveDetailsTagParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C92F60000200AAA001 /* ArchiveDetailsTagParserTests.swift */; };
 		F1A2B3CA2F60000300AAA001 /* ArchiveDetailsTagParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3CB2F60000300AAA001 /* ArchiveDetailsTagParser.swift */; };
 		F1A2B3CC2F70000100AAA001 /* ArchiveListFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3CD2F70000100AAA001 /* ArchiveListFeatureTests.swift */; };
+		F1A2B3CE2F80000100AAA001 /* LogTextRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3CF2F80000100AAA001 /* LogTextRendererTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -224,6 +225,7 @@
 		F1A2B3C92F60000200AAA001 /* ArchiveDetailsTagParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailsTagParserTests.swift; sourceTree = "<group>"; };
 		F1A2B3CB2F60000300AAA001 /* ArchiveDetailsTagParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailsTagParser.swift; sourceTree = "<group>"; };
 		F1A2B3CD2F70000100AAA001 /* ArchiveListFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveListFeatureTests.swift; sourceTree = "<group>"; };
+		F1A2B3CF2F80000100AAA001 /* LogTextRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogTextRendererTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -433,6 +435,7 @@
 				F1A2B3C82F60000100AAA001 /* ArchiveReaderFeatureTests.swift */,
 				F1A2B3C92F60000200AAA001 /* ArchiveDetailsTagParserTests.swift */,
 				F1A2B3CD2F70000100AAA001 /* ArchiveListFeatureTests.swift */,
+				F1A2B3CF2F80000100AAA001 /* LogTextRendererTests.swift */,
 				7D354CB824F1316E00617F4A /* Info.plist */,
 				4BD820A697A4726B7B747BFD /* Service */,
 			);
@@ -764,6 +767,7 @@
 				F1A2B3C52F60000100AAA001 /* ArchiveReaderFeatureTests.swift in Sources */,
 				F1A2B3C62F60000200AAA001 /* ArchiveDetailsTagParserTests.swift in Sources */,
 				F1A2B3CC2F70000100AAA001 /* ArchiveListFeatureTests.swift in Sources */,
+				F1A2B3CE2F80000100AAA001 /* LogTextRendererTests.swift in Sources */,
 				4BD82555CE41A0467CCC6411 /* LANraragiServiceTest.swift in Sources */,
 				7DF6FFAA252DC3BB009280A5 /* FileUtils.swift in Sources */,
 			);
@@ -939,7 +943,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreader.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 196;
+				CURRENT_PROJECT_VERSION = 197;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -950,7 +954,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.9.3;
+				MARKETING_VERSION = 3.9.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -967,7 +971,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreaderRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 196;
+				CURRENT_PROJECT_VERSION = 197;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -978,7 +982,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.9.3;
+				MARKETING_VERSION = 3.9.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1041,7 +1045,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 196;
+				CURRENT_PROJECT_VERSION = 197;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1053,7 +1057,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.9.3;
+				MARKETING_VERSION = 3.9.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1071,7 +1075,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 196;
+				CURRENT_PROJECT_VERSION = 197;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1083,7 +1087,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.9.3;
+				MARKETING_VERSION = 3.9.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/LANreader.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/LANreader.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "revision" : "e2fa1df6cd9eec6fa6314aa20513e47da576f24e",
-        "version" : "1.26.0"
+        "revision" : "ead11e04e5011c437722c1990d22f80d87056978",
+        "version" : "1.26.1"
       }
     },
     {

--- a/LANreader/Setting/LogView.swift
+++ b/LANreader/Setting/LogView.swift
@@ -74,12 +74,14 @@ private struct SelectableLogTextView: UIViewRepresentable {
     }
 }
 
-private enum LogTextRenderer {
+enum LogTextRenderer {
     private static let messageMarker = " message="
 
     static func attributedLog(from log: String) -> NSAttributedString {
         let attributedLog = NSMutableAttributedString()
-        let lines = log.split(separator: "\n", omittingEmptySubsequences: false)
+        // Puppy writes CRLF line endings, and "\r\n" is a single Swift Character,
+        // so splitting on the literal "\n" would never match.
+        let lines = log.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
 
         for (index, line) in lines.enumerated() {
             attributedLog.append(attributedLine(from: String(line)))

--- a/LANreaderTests/LogTextRendererTests.swift
+++ b/LANreaderTests/LogTextRendererTests.swift
@@ -1,0 +1,62 @@
+import UIKit
+import XCTest
+@testable import LANreader
+
+final class LogTextRendererTests: XCTestCase {
+    // Puppy writes CRLF line endings and "\r\n" is a single Swift Character,
+    // so every entry must still be highlighted independently.
+    func testEachCarriageReturnSeparatedEntryIsHighlighted() {
+        let log = [
+            "timestamp=2026-07-29T11:00:00.000+10:00 level=info logger=a location=b#L.1 function=c() message=first",
+            "timestamp=2026-07-29T11:00:01.000+10:00 level=error logger=a location=b#L.2 function=c() message=second"
+        ].joined(separator: "\r\n") + "\r\n"
+
+        let attributed = LogTextRenderer.attributedLog(from: log)
+
+        XCTAssertEqual(levelValueColors(in: attributed), [.systemBlue, .systemRed])
+    }
+
+    func testLineFeedSeparatedEntriesAreHighlighted() {
+        let log = [
+            "timestamp=2026-07-29T11:00:00.000+10:00 level=warning logger=a location=b#L.1 function=c() message=first",
+            "timestamp=2026-07-29T11:00:01.000+10:00 level=info logger=a location=b#L.2 function=c() message=second"
+        ].joined(separator: "\n")
+
+        let attributed = LogTextRenderer.attributedLog(from: log)
+
+        XCTAssertEqual(levelValueColors(in: attributed), [.systemOrange, .systemBlue])
+    }
+
+    func testRenderedTextPreservesEveryEntry() {
+        let log = "level=info message=first\r\nlevel=info message=second\r\n"
+
+        let rendered = LogTextRenderer.attributedLog(from: log).string
+
+        XCTAssertEqual(
+            rendered.split(omittingEmptySubsequences: true, whereSeparator: \.isNewline),
+            ["level=info message=first", "level=info message=second"]
+        )
+    }
+
+    private func levelValueColors(in attributed: NSAttributedString) -> [UIColor] {
+        var colors: [UIColor] = []
+        let text = attributed.string as NSString
+
+        attributed.enumerateAttribute(
+            .foregroundColor,
+            in: NSRange(location: 0, length: attributed.length)
+        ) { value, range, _ in
+            guard let color = value as? UIColor else { return }
+            guard levelValues(in: text).contains(text.substring(with: range)) else { return }
+            colors.append(color)
+        }
+
+        return colors
+    }
+
+    private func levelValues(in text: NSString) -> Set<String> {
+        ["trace", "debug", "info", "notice", "warning", "warn", "error", "critical", "fatal"]
+            .filter { text.contains("level=\($0)") }
+            .reduce(into: Set<String>()) { $0.insert($1) }
+    }
+}

--- a/ci_scripts/macros.json
+++ b/ci_scripts/macros.json
@@ -5,7 +5,7 @@
     "targetName" : "CasePathsMacros"
   },
   {
-    "fingerprint" : "e2fa1df6cd9eec6fa6314aa20513e47da576f24e",
+    "fingerprint" : "ead11e04e5011c437722c1990d22f80d87056978",
     "packageIdentity" : "swift-composable-architecture",
     "targetName" : "ComposableArchitectureMacros"
   },


### PR DESCRIPTION
## What changed
- Handle CRLF and LF line endings when rendering Puppy logs.
- Add regression coverage for highlighting and text preservation.
- Update LANreader and Action to marketing version 3.9.4, build 197.

## Why
Puppy emits CRLF entries, and splitting only on `\n` treated the whole log as one line, preventing per-entry highlighting.

## Verification
- `./scripts/lint`
- `./scripts/test-ios` — 123 tests passed
- `git diff --check`