### PR TITLE
Improve search suggestions

### DIFF
--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -82,6 +82,8 @@
 		E9C354E42CA646D7004C10CD /* UILibraryList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C354E32CA646D3004C10CD /* UILibraryList.swift */; };
 		E9C3550F2CA65101004C10CD /* UIArchiveCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C3550E2CA650FE004C10CD /* UIArchiveCell.swift */; };
 		E9CA49D02F80000100A53A54 /* SearchSuggestionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9CA49D12F80000100A53A54 /* SearchSuggestionCell.swift */; };
+		F1A2B3D62F90000100AAA001 /* SearchKeyword.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3D72F90000100AAA001 /* SearchKeyword.swift */; };
+		F1A2B3D82F90000200AAA001 /* SearchFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3D92F90000200AAA001 /* SearchFeatureTests.swift */; };
 		E9CA49E62E81FF3000A53A54 /* UISearchViewV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9CA49E52E81FF2B00A53A54 /* UISearchViewV2.swift */; };
 		E9CBC0F02A3DD62F00CCD592 /* LogFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9CBC0EF2A3DD62F00CCD592 /* LogFormatter.swift */; };
 		E9DA93612C16960E003272B9 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = E9DA93602C16960E003272B9 /* Localizable.xcstrings */; };
@@ -228,6 +230,8 @@
 		F1A2B3CB2F60000300AAA001 /* ArchiveDetailsTagParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailsTagParser.swift; sourceTree = "<group>"; };
 		F1A2B3CD2F70000100AAA001 /* ArchiveListFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveListFeatureTests.swift; sourceTree = "<group>"; };
 		F1A2B3CF2F80000100AAA001 /* LogTextRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogTextRendererTests.swift; sourceTree = "<group>"; };
+		F1A2B3D72F90000100AAA001 /* SearchKeyword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKeyword.swift; sourceTree = "<group>"; };
+		F1A2B3D92F90000200AAA001 /* SearchFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFeatureTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -372,6 +376,7 @@
 			children = (
 				E9CA49E52E81FF2B00A53A54 /* UISearchViewV2.swift */,
 				E9CA49D12F80000100A53A54 /* SearchSuggestionCell.swift */,
+				F1A2B3D72F90000100AAA001 /* SearchKeyword.swift */,
 			);
 			path = Search;
 			sourceTree = "<group>";
@@ -439,6 +444,7 @@
 				F1A2B3C92F60000200AAA001 /* ArchiveDetailsTagParserTests.swift */,
 				F1A2B3CD2F70000100AAA001 /* ArchiveListFeatureTests.swift */,
 				F1A2B3CF2F80000100AAA001 /* LogTextRendererTests.swift */,
+				F1A2B3D92F90000200AAA001 /* SearchFeatureTests.swift */,
 				7D354CB824F1316E00617F4A /* Info.plist */,
 				4BD820A697A4726B7B747BFD /* Service */,
 			);
@@ -739,6 +745,7 @@
 				4BD82C7F9CB71CAF8F33C171 /* ViewSettings.swift in Sources */,
 				E9CA49E62E81FF3000A53A54 /* UISearchViewV2.swift in Sources */,
 				E9CA49D02F80000100A53A54 /* SearchSuggestionCell.swift in Sources */,
+				F1A2B3D62F90000100AAA001 /* SearchKeyword.swift in Sources */,
 				E9965AAA2D6830DB00114E32 /* UICacheView.swift in Sources */,
 				E9A452242D90F0D60010CEE3 /* SupportView.swift in Sources */,
 				4BD82CED54A4C9689B0E9E55 /* ContentView.swift in Sources */,
@@ -772,6 +779,7 @@
 				F1A2B3C62F60000200AAA001 /* ArchiveDetailsTagParserTests.swift in Sources */,
 				F1A2B3CC2F70000100AAA001 /* ArchiveListFeatureTests.swift in Sources */,
 				F1A2B3CE2F80000100AAA001 /* LogTextRendererTests.swift in Sources */,
+				F1A2B3D82F90000200AAA001 /* SearchFeatureTests.swift in Sources */,
 				4BD82555CE41A0467CCC6411 /* LANraragiServiceTest.swift in Sources */,
 				7DF6FFAA252DC3BB009280A5 /* FileUtils.swift in Sources */,
 			);
@@ -947,7 +955,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreader.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 199;
+				CURRENT_PROJECT_VERSION = 200;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -958,7 +966,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.9.4;
+				MARKETING_VERSION = 3.9.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -975,7 +983,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreaderRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 199;
+				CURRENT_PROJECT_VERSION = 200;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -986,7 +994,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.9.4;
+				MARKETING_VERSION = 3.9.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1049,7 +1057,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 199;
+				CURRENT_PROJECT_VERSION = 200;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1061,7 +1069,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.9.4;
+				MARKETING_VERSION = 3.9.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1079,7 +1087,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 199;
+				CURRENT_PROJECT_VERSION = 200;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1091,7 +1099,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.9.4;
+				MARKETING_VERSION = 3.9.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/LANreader/Database/AppDatabase.swift
+++ b/LANreader/Database/AppDatabase.swift
@@ -198,11 +198,37 @@ extension AppDatabase {
         }
     }
 
+    // `%` and `_` are LIKE wildcards, so a keyword containing them must be escaped or it matches
+    // every tag instead of the literal text the user typed.
+    private static let likeEscape = "\\"
+
+    private static func escapedForLike(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: likeEscape, with: likeEscape + likeEscape)
+            .replacingOccurrences(of: "%", with: likeEscape + "%")
+            .replacingOccurrences(of: "_", with: likeEscape + "_")
+    }
+
     func searchTag(keyword: String) throws -> [TagItem] {
+        // Every word must match somewhere in the tag, so `artist auo` still finds `artist:e auo`.
+        let words = keyword.split(separator: " ").map(String.init)
+        guard !words.isEmpty else {
+            return []
+        }
+        let escape = Self.likeEscape
+        let prefixPattern = "\(Self.escapedForLike(keyword))%"
         return try dbReader.read { database in
-            try TagItem
-                .filter(Column("tag").like("%\(keyword)%"))
-                .order(Column("count").desc)
+            var request = TagItem.all()
+            for word in words {
+                request = request.filter(
+                    Column("tag").like("%\(Self.escapedForLike(word))%", escape: escape)
+                )
+            }
+            return try request
+                .order(
+                    Column("tag").like(prefixPattern, escape: escape).desc,
+                    Column("count").desc
+                )
                 .limit(20)
                 .fetchAll(database)
         }

--- a/LANreader/Models/AppModels.swift
+++ b/LANreader/Models/AppModels.swift
@@ -11,12 +11,12 @@ public struct SearchFilter: Equatable, Sendable {
     let filter: String?
 }
 
-public struct TagWithType: Equatable {
+public struct TagWithType: Equatable, Sendable {
     let tag: String
     let type: TagType
 }
 
-enum TagType {
+enum TagType: Sendable {
     case suggested
     case popular
 }

--- a/LANreader/Search/SearchKeyword.swift
+++ b/LANreader/Search/SearchKeyword.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+// LANraragi separates search predicates with commas, not spaces, so a single predicate can contain
+// spaces (for example `artist:e auo`). Suggestion lookup and completion therefore operate on the
+// comma delimited predicate the user is currently typing.
+enum SearchKeyword {
+    static func currentPredicateRange(in keyword: String) -> Range<String.Index> {
+        guard let lastSeparator = keyword.lastIndex(of: ",") else {
+            return keyword.startIndex..<keyword.endIndex
+        }
+        return keyword.index(after: lastSeparator)..<keyword.endIndex
+    }
+
+    /// The text used to look up tag suggestions for the predicate being typed.
+    static func suggestionQuery(in keyword: String) -> String {
+        var predicate = String(keyword[currentPredicateRange(in: keyword)])
+            .trimmingCharacters(in: .whitespaces)
+        if predicate.hasPrefix("-") {
+            predicate.removeFirst()
+        }
+        return predicate
+            .replacingOccurrences(of: "\"", with: "")
+            .trimmingCharacters(in: .whitespaces)
+    }
+
+    /// Replaces the predicate being typed with the picked tag, keeping earlier predicates intact.
+    static func completing(_ keyword: String, with tag: String) -> String {
+        let range = currentPredicateRange(in: keyword)
+        let completedPredicates = String(keyword[keyword.startIndex..<range.lowerBound])
+        let predicate = String(keyword[range]).trimmingCharacters(in: .whitespaces)
+        let exclusion = predicate.hasPrefix("-") ? "-" : ""
+        let separator = completedPredicates.isEmpty ? "" : " "
+        return "\(completedPredicates)\(separator)\(exclusion)\(tag)$,"
+    }
+}

--- a/LANreader/Search/UISearchViewV2.swift
+++ b/LANreader/Search/UISearchViewV2.swift
@@ -1,8 +1,11 @@
 import ComposableArchitecture
+import Logging
 import SwiftUI
 import UIKit
 
-@Reducer public struct SearchFeature {
+@Reducer public struct SearchFeature: Sendable {
+    private let logger = Logger(label: "SearchFeature")
+
     @ObservableState
     public struct State: Equatable {
         var keyword = ""
@@ -18,6 +21,7 @@ import UIKit
     public enum Action: Equatable, BindableAction {
         case binding(BindingAction<State>)
         case generateSuggestion(String)
+        case suggestionsUpdated([TagWithType])
         case loadPopularTag
         case suggestionTapped(TagWithType)
         case searchSubmit(String)
@@ -26,6 +30,7 @@ import UIKit
 
     @Dependency(\.lanraragiService) var service
     @Dependency(\.appDatabase) var database
+    @Dependency(\.continuousClock) var clock
 
     enum CancelId { case search }
 
@@ -39,22 +44,27 @@ import UIKit
         Reduce { state, action in
             switch action {
             case let .generateSuggestion(searchText):
-                let lastToken = searchText.split(
-                    separator: " ",
-                    omittingEmptySubsequences: false
-                ).last.map(String.init) ?? ""
-                guard !lastToken.isEmpty else {
-                    state.suggestedTag = state.popularTag
-                    return .none
+                let query = SearchKeyword.suggestionQuery(in: searchText)
+                let popularTag = state.popularTag
+                guard !query.isEmpty else {
+                    state.suggestedTag = popularTag
+                    return .cancel(id: CancelId.search)
                 }
-                do {
-                    let result = try database.searchTag(keyword: lastToken)
-                    state.suggestedTag = result.map {
+                // Tag lookup is a full table scan, so keep it off the main thread and debounce it
+                // instead of running one scan per keystroke.
+                return .run(priority: .background) { send in
+                    try await clock.sleep(for: .milliseconds(150))
+                    let tags = try database.searchTag(keyword: query).map {
                         TagWithType(tag: $0.tag, type: .suggested)
                     }
-                } catch {
-                    state.suggestedTag = state.popularTag
+                    await send(.suggestionsUpdated(tags))
+                } catch: { error, send in
+                    logger.error("failed to generate search suggestion. \(error)")
+                    await send(.suggestionsUpdated(popularTag))
                 }
+                .cancellable(id: CancelId.search, cancelInFlight: true)
+            case let .suggestionsUpdated(tags):
+                state.suggestedTag = tags
                 return .none
             case .loadPopularTag:
                 if let result = try? database.popularTag() {
@@ -65,19 +75,14 @@ import UIKit
                 }
                 return .none
             case let .suggestionTapped(tagWithType):
-                let validKeyword = if tagWithType.type == .suggested {
-                    state.keyword.split(separator: " ").dropLast(1).joined(separator: " ")
-                } else {
-                    state.keyword.trimmingCharacters(in: .whitespaces)
-                }
-                state.keyword = "\(validKeyword) \(tagWithType.tag)$,"
-                return .none
+                state.keyword = SearchKeyword.completing(state.keyword, with: tagWithType.tag)
+                return .cancel(id: CancelId.search)
             case let .searchSubmit(keyword):
                 guard !keyword.isEmpty else {
                     return .none
                 }
                 state.archiveList.filter = SearchFilter(category: nil, filter: keyword)
-                return .none
+                return .cancel(id: CancelId.search)
             case .binding:
                 return .none
             case .archiveList:
@@ -151,6 +156,7 @@ class UISearchViewV2Controller: UIViewController {
 
     // Constraints for animated height changes
     private var suggestionsHeightConstraint: NSLayoutConstraint?
+    private var hasRenderedSuggestions = false
 
     // Constants
     private let maxSuggestionsHeight: CGFloat = {
@@ -293,21 +299,15 @@ class UISearchViewV2Controller: UIViewController {
     private func setupObserve() {
         observe { [weak self] in
             guard let self else { return }
-            var searchText: String?
-            if UIDevice.current.userInterfaceIdiom == .phone {
-                searchText = searchController.searchBar.text
-            } else {
-                searchText = searchBar.text
-            }
-            if searchText?.isEmpty == true && !store.popularTag.isEmpty {
-                suggestionsTableView.reloadData()
-                updateSuggestionsVisibility(for: searchText ?? "", animated: false)
-            }
+            _ = store.suggestedTag
+            suggestionsTableView.reloadData()
+            updateSuggestionsVisibility(animated: hasRenderedSuggestions)
+            hasRenderedSuggestions = true
         }
     }
 
     // MARK: - Suggestions Handling
-    private func updateSuggestionsVisibility(for _: String, animated: Bool = true) {
+    private func updateSuggestionsVisibility(animated: Bool = true) {
         if !store.suggestedTag.isEmpty {
             let contentHeight = CGFloat(store.suggestedTag.count) * suggestionsRowHeight + suggestionsVerticalPadding
             let newHeight = min(contentHeight, maxSuggestionsHeight)
@@ -351,14 +351,8 @@ class UISearchViewV2Controller: UIViewController {
 // MARK: - UISearchBarDelegate
 extension UISearchViewV2Controller: UISearchBarDelegate {
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        Task { [weak self] in
-            guard let self else { return }
-            // Bind keyword into store state
-            store.send(.binding(.set(\.keyword, searchText)))
-            await store.send(.generateSuggestion(searchText)).finish()
-            suggestionsTableView.reloadData()
-            updateSuggestionsVisibility(for: searchText)
-        }
+        store.send(.binding(.set(\.keyword, searchText)))
+        store.send(.generateSuggestion(searchText))
     }
 
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {

--- a/LANreaderTests/SearchFeatureTests.swift
+++ b/LANreaderTests/SearchFeatureTests.swift
@@ -1,0 +1,200 @@
+import XCTest
+import ComposableArchitecture
+import GRDB
+@testable import LANreader
+
+final class SearchFeatureTests: XCTestCase {
+    func testSuggestionQueryKeepsSpacesInsideAPredicate() {
+        XCTAssertEqual(SearchKeyword.suggestionQuery(in: "e auo"), "e auo")
+        XCTAssertEqual(SearchKeyword.suggestionQuery(in: "artist:e au"), "artist:e au")
+    }
+
+    func testSuggestionQueryOnlyUsesThePredicateBeingTyped() {
+        XCTAssertEqual(SearchKeyword.suggestionQuery(in: "language:english$, e au"), "e au")
+        XCTAssertEqual(SearchKeyword.suggestionQuery(in: "language:english$,e au"), "e au")
+    }
+
+    func testSuggestionQueryIsEmptyWhenPredicateIsComplete() {
+        XCTAssertEqual(SearchKeyword.suggestionQuery(in: ""), "")
+        XCTAssertEqual(SearchKeyword.suggestionQuery(in: "language:english$,"), "")
+        XCTAssertEqual(SearchKeyword.suggestionQuery(in: "language:english$, "), "")
+    }
+
+    func testSuggestionQueryStripsExclusionAndQuotes() {
+        XCTAssertEqual(SearchKeyword.suggestionQuery(in: "-e au"), "e au")
+        XCTAssertEqual(SearchKeyword.suggestionQuery(in: "\"e au"), "e au")
+        XCTAssertEqual(SearchKeyword.suggestionQuery(in: "language:english$, -\"e au"), "e au")
+    }
+
+    func testCompletingReplacesOnlyThePredicateBeingTyped() {
+        XCTAssertEqual(SearchKeyword.completing("e au", with: "artist:e auo"), "artist:e auo$,")
+        XCTAssertEqual(
+            SearchKeyword.completing("language:english$, e au", with: "artist:e auo"),
+            "language:english$, artist:e auo$,"
+        )
+    }
+
+    func testCompletingAppendsWhenPreviousPredicateIsComplete() {
+        XCTAssertEqual(SearchKeyword.completing("", with: "artist:e auo"), "artist:e auo$,")
+        XCTAssertEqual(
+            SearchKeyword.completing("language:english$,", with: "artist:e auo"),
+            "language:english$, artist:e auo$,"
+        )
+    }
+
+    func testCompletingKeepsExclusionPrefix() {
+        XCTAssertEqual(SearchKeyword.completing("-e au", with: "artist:e auo"), "-artist:e auo$,")
+    }
+
+    func testSearchTagMatchesEveryWordInAnyOrder() throws {
+        let database = try makeInMemoryDatabase(tags: [("artist:e auo", 5), ("artist:someone", 10)])
+
+        XCTAssertEqual(try database.searchTag(keyword: "e auo").map(\.tag), ["artist:e auo"])
+        XCTAssertEqual(try database.searchTag(keyword: "artist auo").map(\.tag), ["artist:e auo"])
+    }
+
+    func testSearchTagRanksPrefixMatchesFirst() throws {
+        let database = try makeInMemoryDatabase(tags: [("e auo", 1), ("artist:e auo", 100)])
+
+        XCTAssertEqual(
+            try database.searchTag(keyword: "e auo").map(\.tag),
+            ["e auo", "artist:e auo"]
+        )
+    }
+
+    func testSearchTagTreatsPercentAsLiteralText() throws {
+        let database = try makeInMemoryDatabase(tags: [("tag:100% cotton", 1), ("artist:e auo", 100)])
+
+        XCTAssertEqual(try database.searchTag(keyword: "100%").map(\.tag), ["tag:100% cotton"])
+        XCTAssertEqual(try database.searchTag(keyword: "%").map(\.tag), ["tag:100% cotton"])
+    }
+
+    func testSearchTagTreatsUnderscoreAsLiteralText() throws {
+        let database = try makeInMemoryDatabase(tags: [("tag:date_added", 1), ("artist:e auo", 100)])
+
+        XCTAssertEqual(try database.searchTag(keyword: "date_added").map(\.tag), ["tag:date_added"])
+        XCTAssertEqual(try database.searchTag(keyword: "_").map(\.tag), ["tag:date_added"])
+    }
+
+    func testSearchTagTreatsBackslashAsLiteralText() throws {
+        let database = try makeInMemoryDatabase(tags: [("artist:a\\b", 1), ("artist:e auo", 100)])
+
+        XCTAssertEqual(try database.searchTag(keyword: "a\\b").map(\.tag), ["artist:a\\b"])
+        XCTAssertEqual(try database.searchTag(keyword: "\\").map(\.tag), ["artist:a\\b"])
+    }
+
+    func testSearchTagStillRanksEscapedPrefixMatchFirst() throws {
+        let database = try makeInMemoryDatabase(tags: [("100% cotton", 1), ("tag:100% cotton", 100)])
+
+        XCTAssertEqual(
+            try database.searchTag(keyword: "100%").map(\.tag),
+            ["100% cotton", "tag:100% cotton"]
+        )
+    }
+
+    @MainActor
+    func testGenerateSuggestionUsesWholePredicate() async throws {
+        let database = try makeInMemoryDatabase(tags: [("artist:e auo", 5), ("artist:auokawa", 10)])
+        let clock = TestClock()
+
+        let store = TestStore(initialState: SearchFeature.State()) {
+            SearchFeature()
+        } withDependencies: {
+            $0.appDatabase = database
+            $0.continuousClock = clock
+        }
+
+        await store.send(.generateSuggestion("artist:e au"))
+        await clock.advance(by: .milliseconds(150))
+        await store.receive(\.suggestionsUpdated) {
+            $0.suggestedTag = [TagWithType(tag: "artist:e auo", type: .suggested)]
+        }
+    }
+
+    @MainActor
+    func testGenerateSuggestionDebouncesKeystrokes() async throws {
+        let database = try makeInMemoryDatabase(tags: [("artist:e auo", 5)])
+        let clock = TestClock()
+
+        let store = TestStore(initialState: SearchFeature.State()) {
+            SearchFeature()
+        } withDependencies: {
+            $0.appDatabase = database
+            $0.continuousClock = clock
+        }
+
+        // Each keystroke cancels the previous lookup, so only the final one reaches the database.
+        await store.send(.generateSuggestion("a"))
+        await clock.advance(by: .milliseconds(100))
+        await store.send(.generateSuggestion("ar"))
+        await clock.advance(by: .milliseconds(100))
+        await store.send(.generateSuggestion("artist:e au"))
+        await clock.advance(by: .milliseconds(150))
+
+        await store.receive(\.suggestionsUpdated) {
+            $0.suggestedTag = [TagWithType(tag: "artist:e auo", type: .suggested)]
+        }
+    }
+
+    @MainActor
+    func testGenerateSuggestionFallsBackToPopularTagAfterPredicateSeparator() async throws {
+        let database = try makeInMemoryDatabase(tags: [("artist:e auo", 5)])
+
+        var initialState = SearchFeature.State()
+        initialState.popularTag = [TagWithType(tag: "artist:e auo", type: .popular)]
+
+        let store = TestStore(initialState: initialState) {
+            SearchFeature()
+        } withDependencies: {
+            $0.appDatabase = database
+            $0.continuousClock = TestClock()
+        }
+
+        await store.send(.generateSuggestion("artist:e auo$,")) {
+            $0.suggestedTag = [TagWithType(tag: "artist:e auo", type: .popular)]
+        }
+    }
+
+    @MainActor
+    func testSuggestionTappedCancelsPendingLookup() async throws {
+        let database = try makeInMemoryDatabase(tags: [("artist:e auo", 5)])
+        let clock = TestClock()
+
+        let store = TestStore(initialState: SearchFeature.State()) {
+            SearchFeature()
+        } withDependencies: {
+            $0.appDatabase = database
+            $0.continuousClock = clock
+        }
+
+        await store.send(.generateSuggestion("artist:e au"))
+        await store.send(.suggestionTapped(TagWithType(tag: "artist:e auo", type: .suggested))) {
+            $0.keyword = "artist:e auo$,"
+        }
+        // The in-flight lookup was cancelled, so no late result reopens the suggestion panel.
+        await clock.advance(by: .milliseconds(150))
+    }
+
+    @MainActor
+    func testSuggestionTappedKeepsEarlierPredicates() async throws {
+        var initialState = SearchFeature.State()
+        initialState.keyword = "language:english$, e au"
+
+        let store = TestStore(initialState: initialState) {
+            SearchFeature()
+        }
+
+        await store.send(.suggestionTapped(TagWithType(tag: "artist:e auo", type: .suggested))) {
+            $0.keyword = "language:english$, artist:e auo$,"
+        }
+    }
+}
+
+private func makeInMemoryDatabase(tags: [(String, Int)]) throws -> AppDatabase {
+    let database = try AppDatabase(DatabaseQueue())
+    for (tag, count) in tags {
+        var tagItem = TagItem(tag: tag, count: count)
+        try database.saveTag(tagItem: &tagItem)
+    }
+    return database
+}


### PR DESCRIPTION
## What changed
- Match all words in the current search predicate and rank prefix matches first.
- Preserve comma-separated predicates, exclusions, quoted input, and tag completion.
- Debounce local tag lookups and keep them off the main thread.
- Add focused search feature and database tests.
- Bump the app and Action targets to marketing version 3.9.5, build 200.

## Verification
- `./scripts/lint`
- `./scripts/test-ios` (151 tests passed)