### PR TITLE
Improve archive tag editing UI

### DIFF
--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		E902FC4E2CD870530071106B /* UICategoryList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E902FC4D2CD8704E0071106B /* UICategoryList.swift */; };
 		E902FC502CD87A780071106B /* UICategoryArchiveGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = E902FC4F2CD87A710071106B /* UICategoryArchiveGrid.swift */; };
 		E90576B629F6BF8700C3CE3F /* WrappingHStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90576B529F6BF8700C3CE3F /* WrappingHStack.swift */; };
+		E9AA10022E0000020000AA02 /* TagTokenField.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9AA10012E0000010000AA01 /* TagTokenField.swift */; };
 		E90576BF29F8C10700C3CE3F /* Puppy in Frameworks */ = {isa = PBXBuildFile; productRef = E90576BE29F8C10700C3CE3F /* Puppy */; };
 		E90C26CB2C1A7A6D00BE87D9 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = E90C26CA2C1A7A6D00BE87D9 /* ComposableArchitecture */; };
 		E91EE6832CAB78ED0046853C /* UIArchiveReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91EE6822CAB78E80046853C /* UIArchiveReader.swift */; };
@@ -178,6 +179,7 @@
 		E902FC4D2CD8704E0071106B /* UICategoryList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UICategoryList.swift; sourceTree = "<group>"; };
 		E902FC4F2CD87A710071106B /* UICategoryArchiveGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UICategoryArchiveGrid.swift; sourceTree = "<group>"; };
 		E90576B529F6BF8700C3CE3F /* WrappingHStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrappingHStack.swift; sourceTree = "<group>"; };
+		E9AA10012E0000010000AA01 /* TagTokenField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagTokenField.swift; sourceTree = "<group>"; };
 		E91EE6822CAB78E80046853C /* UIArchiveReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIArchiveReader.swift; sourceTree = "<group>"; };
 		E91EE6842CAB94F60046853C /* UIPageCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIPageCollection.swift; sourceTree = "<group>"; };
 		E93C0F862D93ACF400B030AE /* TransactionObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionObserver.swift; sourceTree = "<group>"; };
@@ -313,6 +315,7 @@
 				E9BFA2062AF52C3300DDE107 /* PageImageV2.swift */,
 				F1A2B3C72F60000100AAA001 /* ReaderPositioning.swift */,
 				E90576B529F6BF8700C3CE3F /* WrappingHStack.swift */,
+				E9AA10012E0000010000AA01 /* TagTokenField.swift */,
 				E9BFA2042AF51DB500DDE107 /* ArchiveReader.swift */,
 				E9A8612C2BF31534003534FA /* AutomaticPageConfig.swift */,
 			);
@@ -754,6 +757,7 @@
 				E9886A6E2DDAEAF20086370F /* TranslatorService.swift in Sources */,
 				E9C3550F2CA65101004C10CD /* UIArchiveCell.swift in Sources */,
 				E90576B629F6BF8700C3CE3F /* WrappingHStack.swift in Sources */,
+				E9AA10022E0000020000AA02 /* TagTokenField.swift in Sources */,
 				E9810CD52DDC0641002B047A /* AdvancedSettings.swift in Sources */,
 				E9BE57B22942CFEC00A3AEA0 /* LockScreen.swift in Sources */,
 				E9BFA2072AF52C3300DDE107 /* PageImageV2.swift in Sources */,
@@ -955,7 +959,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreader.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202;
+				CURRENT_PROJECT_VERSION = 203;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -983,7 +987,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreaderRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202;
+				CURRENT_PROJECT_VERSION = 203;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1057,7 +1061,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202;
+				CURRENT_PROJECT_VERSION = 203;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1087,7 +1091,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202;
+				CURRENT_PROJECT_VERSION = 203;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;

--- a/LANreader.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/LANreader.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sushichop/Puppy",
       "state" : {
-        "revision" : "80ebe6ab25fb7050904647cb96f6ad7bee77bad6",
-        "version" : "0.9.0"
+        "revision" : "1a2f5d511e64c7e98ccb36249215944727351bcc",
+        "version" : "0.10.0"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "a8cd6c976f335ed361dcecddb0dc39ebda51bc3e",
-        "version" : "1.6.1"
+        "revision" : "e9c34fd54ece006b491a0e6d23fe9a6024b9a828",
+        "version" : "1.7.0"
       }
     },
     {
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
-        "version" : "1.6.4"
+        "revision" : "3ffafb9722d5d918c614feb496c8789a3b59d222",
+        "version" : "1.15.0"
       }
     },
     {

--- a/LANreader/Page/ArchiveDetailsTagParser.swift
+++ b/LANreader/Page/ArchiveDetailsTagParser.swift
@@ -6,6 +6,27 @@ enum ArchiveDetailsTagParser {
     static let dateTag = "date_added"
     static let otherTag = "other"
 
+    static func isTagSeparator(_ character: Character) -> Bool {
+        character == "," || character.isNewline
+    }
+
+    static func tokens(from tags: String) -> [String] {
+        tags
+            .split(whereSeparator: isTagSeparator)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    static func tagsString(from tokens: [String]) -> String {
+        tokens.joined(separator: ", ")
+    }
+
+    static func namespaceKey(for tag: String) -> String {
+        let tagPair = tag.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+        let rawNamespace = tagPair.first?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return tagPair.count == 2 && !rawNamespace.isEmpty ? rawNamespace.lowercased() : otherTag
+    }
+
     static func tagGroups(from tags: String) -> [ArchiveTagGroup] {
         let parsedTags = tags
             .split(separator: ",")
@@ -45,9 +66,9 @@ enum ArchiveDetailsTagParser {
         }
 
         let tagPair = raw.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
-        let rawNamespace = tagPair.first?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        let hasNamespace = tagPair.count == 2 && !rawNamespace.isEmpty
-        let namespaceKey = hasNamespace ? rawNamespace.lowercased() : otherTag
+        let hasNamespace = tagPair.count == 2
+            && !(tagPair[0].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        let namespaceKey = namespaceKey(for: raw)
         let value = hasNamespace
             ? tagPair[1].trimmingCharacters(in: .whitespacesAndNewlines)
             : raw

--- a/LANreader/Page/ArchiveDetailsV2.swift
+++ b/LANreader/Page/ArchiveDetailsV2.swift
@@ -474,16 +474,7 @@ struct ArchiveDetailsV2: View {
     }
 
     private func editableTagsField(store: StoreOf<ArchiveDetailsFeature>) -> some View {
-        TextField("archive.details.tags", text: $store.editableTags, axis: .vertical)
-            .textInputAutocapitalization(.never)
-            .autocorrectionDisabled()
-            .font(.body.monospaced())
-            .lineLimit(5...14)
-            .padding(14)
-            .background(
-                Color(uiColor: .secondarySystemGroupedBackground),
-                in: RoundedRectangle(cornerRadius: 16, style: .continuous)
-            )
+        TagTokenField(text: $store.editableTags)
     }
 
     private func emptyTagsView() -> some View {
@@ -590,7 +581,7 @@ struct ArchiveDetailsV2: View {
     }
 
     private func tagButton(_ tag: ArchiveDetailsTag, navigationEnabled: Bool = true) -> some View {
-        let tint = tagTint(for: tag.namespaceKey)
+        let tint = ArchiveTagStyle.tint(for: tag.namespaceKey)
 
         return Button {
             guard navigationEnabled else { return }
@@ -601,7 +592,7 @@ struct ArchiveDetailsV2: View {
             }
         } label: {
             HStack(spacing: 6) {
-                if let iconName = tagIconName(for: tag.namespaceKey) {
+                if let iconName = ArchiveTagStyle.iconName(for: tag.namespaceKey) {
                     Image(systemName: iconName)
                         .font(.caption2.weight(.bold))
                 }
@@ -624,32 +615,6 @@ struct ArchiveDetailsV2: View {
         .buttonStyle(.plain)
         .disabled(!navigationEnabled)
         .accessibilityLabel(Text(verbatim: tag.accessibilityLabel))
-    }
-
-    private func tagTint(for namespaceKey: String) -> Color {
-        switch namespaceKey {
-        case ArchiveDetailsTagParser.artistTag:
-            return .orange
-        case ArchiveDetailsTagParser.sourceTag:
-            return .teal
-        case ArchiveDetailsTagParser.dateTag:
-            return .indigo
-        case ArchiveDetailsTagParser.otherTag:
-            return .secondary
-        default:
-            return .blue
-        }
-    }
-
-    private func tagIconName(for namespaceKey: String) -> String? {
-        switch namespaceKey {
-        case ArchiveDetailsTagParser.sourceTag:
-            return "link"
-        case ArchiveDetailsTagParser.dateTag:
-            return "calendar"
-        default:
-            return nil
-        }
     }
 
     private func sourceURL(for tag: ArchiveDetailsTag) -> URL? {

--- a/LANreader/Page/TagTokenField.swift
+++ b/LANreader/Page/TagTokenField.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+
+enum ArchiveTagStyle {
+    static func tint(for namespaceKey: String) -> Color {
+        switch namespaceKey {
+        case ArchiveDetailsTagParser.artistTag:
+            return .orange
+        case ArchiveDetailsTagParser.sourceTag:
+            return .teal
+        case ArchiveDetailsTagParser.dateTag:
+            return .indigo
+        case ArchiveDetailsTagParser.otherTag:
+            return .secondary
+        default:
+            return .blue
+        }
+    }
+
+    static func iconName(for namespaceKey: String) -> String? {
+        switch namespaceKey {
+        case ArchiveDetailsTagParser.sourceTag:
+            return "link"
+        case ArchiveDetailsTagParser.dateTag:
+            return "calendar"
+        default:
+            return nil
+        }
+    }
+}
+
+struct TagTokenField: View {
+    @Binding var text: String
+
+    @State private var tokens: [String] = []
+    @State private var input = ""
+    @FocusState private var inputFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if !tokens.isEmpty {
+                WrappingHStack(horizontalSpacing: 4, verticalSpacing: 4) {
+                    ForEach(Array(tokens.enumerated()), id: \.offset) { index, token in
+                        tokenChip(token, index: index)
+                    }
+                }
+
+                Divider()
+            }
+
+            HStack(spacing: 8) {
+                Image(systemName: "plus.circle.fill")
+                    .font(.body)
+                    .foregroundStyle(.tint)
+
+                TextField("archive.details.tags.add", text: $input)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .font(.body.monospaced())
+                    .submitLabel(.done)
+                    .focused($inputFocused)
+                    .onSubmit {
+                        commitInput()
+                        inputFocused = true
+                    }
+                    .onChange(of: input) { _, newValue in
+                        splitCompletedTokens(in: newValue)
+                        syncText()
+                    }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(
+                Color(uiColor: .tertiarySystemGroupedBackground),
+                in: RoundedRectangle(cornerRadius: 12, style: .continuous)
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .strokeBorder(
+                        inputFocused ? Color.accentColor.opacity(0.6) : Color.primary.opacity(0.1),
+                        lineWidth: 1
+                    )
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            Color(uiColor: .secondarySystemGroupedBackground),
+            in: RoundedRectangle(cornerRadius: 16, style: .continuous)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            inputFocused = true
+        }
+        .onAppear {
+            tokens = ArchiveDetailsTagParser.tokens(from: text)
+            input = ""
+        }
+    }
+
+    private func tokenChip(_ token: String, index: Int) -> some View {
+        let namespaceKey = ArchiveDetailsTagParser.namespaceKey(for: token)
+        let tint = ArchiveTagStyle.tint(for: namespaceKey)
+
+        return HStack(spacing: 6) {
+            if let iconName = ArchiveTagStyle.iconName(for: namespaceKey) {
+                Image(systemName: iconName)
+                    .font(.caption2.weight(.bold))
+            }
+
+            Text(token)
+                .font(.caption.weight(.semibold))
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            Button {
+                tokens.remove(at: index)
+                syncText()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.caption)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(Text("archive.details.tags.remove"))
+        }
+        .padding(.horizontal, 11)
+        .padding(.vertical, 7)
+        .frame(maxWidth: 280, alignment: .leading)
+        .foregroundStyle(tint)
+        .background(tint.opacity(0.14), in: Capsule())
+        .overlay {
+            Capsule()
+                .strokeBorder(tint.opacity(0.18), lineWidth: 1)
+        }
+    }
+
+    private func commitInput() {
+        tokens.append(contentsOf: ArchiveDetailsTagParser.tokens(from: input))
+        input = ""
+        syncText()
+    }
+
+    private func splitCompletedTokens(in value: String) {
+        guard let lastSeparator = value.lastIndex(where: ArchiveDetailsTagParser.isTagSeparator) else {
+            return
+        }
+        tokens.append(contentsOf: ArchiveDetailsTagParser.tokens(from: String(value[..<lastSeparator])))
+        input = String(value[value.index(after: lastSeparator)...])
+    }
+
+    private func syncText() {
+        let pending = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        text = ArchiveDetailsTagParser.tagsString(from: pending.isEmpty ? tokens : tokens + [pending])
+    }
+}

--- a/LANreaderTests/ArchiveDetailsTagParserTests.swift
+++ b/LANreaderTests/ArchiveDetailsTagParserTests.swift
@@ -32,6 +32,27 @@ final class ArchiveDetailsTagParserTests: XCTestCase {
         XCTAssertEqual(sourceTags?.map(\.raw), ["source: example.com"])
     }
 
+    func testTokensSplitOnCommasAndNewlinesAndDropBlanks() {
+        XCTAssertEqual(
+            ArchiveDetailsTagParser.tokens(from: " artist: Bob ,,\n plain tag \n source:example.com,"),
+            ["artist: Bob", "plain tag", "source:example.com"]
+        )
+        XCTAssertEqual(ArchiveDetailsTagParser.tokens(from: " , \n "), [])
+    }
+
+    func testTagsStringJoinsTokens() {
+        XCTAssertEqual(
+            ArchiveDetailsTagParser.tagsString(from: ["artist:bob", "series:one"]),
+            "artist:bob, series:one"
+        )
+    }
+
+    func testNamespaceKeyMatchesGroupNamespace() {
+        XCTAssertEqual(ArchiveDetailsTagParser.namespaceKey(for: " Artist: Bob "), "artist")
+        XCTAssertEqual(ArchiveDetailsTagParser.namespaceKey(for: "plain tag"), "other")
+        XCTAssertEqual(ArchiveDetailsTagParser.namespaceKey(for: ":no namespace"), "other")
+    }
+
     @MainActor
     func testArchiveDetailsLoadLocalFieldsUsesTankoubonMetadataTags() async {
         let archive = Shared(value: makeDetailsArchive(

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -770,6 +770,41 @@
         }
       }
     },
+    "archive.details.tags.add" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add tag"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タグを追加"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "태그 추가"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加标签"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增標籤"
+          }
+        }
+      }
+    },
     "archive.details.tags.included" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -836,6 +871,41 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "唯讀"
+          }
+        }
+      }
+    },
+    "archive.details.tags.remove" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove tag"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タグを削除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "태그 제거"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除标签"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除標籤"
           }
         }
       }


### PR DESCRIPTION
## What changed
- Replace the multiline archive tag field with tokenized tag editing.
- Support comma/newline parsing, tag removal, namespace styling, and localized add/remove labels.
- Add parser coverage and advance the synchronized build number to 203.

## Why
Make editing archive tags easier to scan and modify while preserving the existing tag format and marketing version 3.9.5.

## Verification
- `./scripts/lint` — 0 violations
- `./scripts/test-ios` — 155 tests passed
- All LANreader/Action Debug and Release settings resolve to build 203 / marketing version 3.9.5
- `jq empty Localizable.xcstrings`
- `git diff --cached --check`