### PR TITLE
Add optional archive-list pagination

### DIFF
--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -105,6 +105,9 @@
 		F1A2B3CA2F60000300AAA001 /* ArchiveDetailsTagParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3CB2F60000300AAA001 /* ArchiveDetailsTagParser.swift */; };
 		F1A2B3CC2F70000100AAA001 /* ArchiveListFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3CD2F70000100AAA001 /* ArchiveListFeatureTests.swift */; };
 		F1A2B3CE2F80000100AAA001 /* LogTextRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3CF2F80000100AAA001 /* LogTextRendererTests.swift */; };
+		F1A2B3E12FA0000100AAA001 /* PaginationPositioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3E22FA0000100AAA001 /* PaginationPositioning.swift */; };
+		F1A2B3E32FA0000100AAA001 /* PaginationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3E42FA0000100AAA001 /* PaginationBar.swift */; };
+		F1A2B3E52FA0000100AAA001 /* PaginationPositioningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3E62FA0000100AAA001 /* PaginationPositioningTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -232,6 +235,9 @@
 		F1A2B3CB2F60000300AAA001 /* ArchiveDetailsTagParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailsTagParser.swift; sourceTree = "<group>"; };
 		F1A2B3CD2F70000100AAA001 /* ArchiveListFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveListFeatureTests.swift; sourceTree = "<group>"; };
 		F1A2B3CF2F80000100AAA001 /* LogTextRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogTextRendererTests.swift; sourceTree = "<group>"; };
+		F1A2B3E22FA0000100AAA001 /* PaginationPositioning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationPositioning.swift; sourceTree = "<group>"; };
+		F1A2B3E42FA0000100AAA001 /* PaginationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationBar.swift; sourceTree = "<group>"; };
+		F1A2B3E62FA0000100AAA001 /* PaginationPositioningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationPositioningTests.swift; sourceTree = "<group>"; };
 		F1A2B3D72F90000100AAA001 /* SearchKeyword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKeyword.swift; sourceTree = "<group>"; };
 		F1A2B3D92F90000200AAA001 /* SearchFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFeatureTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -341,6 +347,8 @@
 				E9BE57B12942CFEC00A3AEA0 /* LockScreen.swift */,
 				6DA71C5CFBC9FDA5C1244254 /* LoadingView.swift */,
 				E997D7FF2AF20EE2007C91F1 /* ArchiveGridV2.swift */,
+				F1A2B3E22FA0000100AAA001 /* PaginationPositioning.swift */,
+				F1A2B3E42FA0000100AAA001 /* PaginationBar.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -448,6 +456,7 @@
 				F1A2B3CD2F70000100AAA001 /* ArchiveListFeatureTests.swift */,
 				F1A2B3CF2F80000100AAA001 /* LogTextRendererTests.swift */,
 				F1A2B3D92F90000200AAA001 /* SearchFeatureTests.swift */,
+				F1A2B3E62FA0000100AAA001 /* PaginationPositioningTests.swift */,
 				7D354CB824F1316E00617F4A /* Info.plist */,
 				4BD820A697A4726B7B747BFD /* Service */,
 			);
@@ -753,6 +762,8 @@
 				E9A452242D90F0D60010CEE3 /* SupportView.swift in Sources */,
 				4BD82CED54A4C9689B0E9E55 /* ContentView.swift in Sources */,
 				E997D8002AF20EE2007C91F1 /* ArchiveGridV2.swift in Sources */,
+				F1A2B3E12FA0000100AAA001 /* PaginationPositioning.swift in Sources */,
+				F1A2B3E32FA0000100AAA001 /* PaginationBar.swift in Sources */,
 				E9C354E22CA64161004C10CD /* UIArchiveList.swift in Sources */,
 				E9886A6E2DDAEAF20086370F /* TranslatorService.swift in Sources */,
 				E9C3550F2CA65101004C10CD /* UIArchiveCell.swift in Sources */,
@@ -783,6 +794,7 @@
 				F1A2B3C62F60000200AAA001 /* ArchiveDetailsTagParserTests.swift in Sources */,
 				F1A2B3CC2F70000100AAA001 /* ArchiveListFeatureTests.swift in Sources */,
 				F1A2B3CE2F80000100AAA001 /* LogTextRendererTests.swift in Sources */,
+				F1A2B3E52FA0000100AAA001 /* PaginationPositioningTests.swift in Sources */,
 				F1A2B3D82F90000200AAA001 /* SearchFeatureTests.swift in Sources */,
 				4BD82555CE41A0467CCC6411 /* LANraragiServiceTest.swift in Sources */,
 				7DF6FFAA252DC3BB009280A5 /* FileUtils.swift in Sources */,
@@ -959,7 +971,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreader.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 204;
+				CURRENT_PROJECT_VERSION = 205;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -987,7 +999,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreaderRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 204;
+				CURRENT_PROJECT_VERSION = 205;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1061,7 +1073,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 204;
+				CURRENT_PROJECT_VERSION = 205;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1091,7 +1103,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 204;
+				CURRENT_PROJECT_VERSION = 205;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;

--- a/LANreader/Common/PaginationBar.swift
+++ b/LANreader/Common/PaginationBar.swift
@@ -1,0 +1,142 @@
+import UIKit
+
+/// Floating archive pager. Tapping its position opens direct page entry.
+final class PaginationBar: UIView {
+    private var onSelectPage: ((Int) -> Void)?
+    private var onRequestPageInput: (() -> Void)?
+    private var currentPage = 0
+    private var pageCount = 0
+
+    private let background: UIVisualEffectView = {
+        let view = UIVisualEffectView(effect: UIBlurEffect(style: .systemThinMaterial))
+        view.clipsToBounds = true
+        return view
+    }()
+
+    private let stackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.alignment = .center
+        stack.distribution = .fill
+        stack.spacing = 2
+        return stack
+    }()
+
+    private let previousButton = UIButton(configuration: .plain())
+    private let positionButton = UIButton(configuration: .plain())
+    private let nextButton = UIButton(configuration: .plain())
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.18
+        layer.shadowRadius = 8
+        layer.shadowOffset = CGSize(width: 0, height: 2)
+
+        addSubview(background)
+        background.contentView.addSubview(stackView)
+        background.translatesAutoresizingMaskIntoConstraints = false
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            background.topAnchor.constraint(equalTo: topAnchor),
+            background.bottomAnchor.constraint(equalTo: bottomAnchor),
+            background.leadingAnchor.constraint(equalTo: leadingAnchor),
+            background.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: background.contentView.topAnchor, constant: 4),
+            stackView.bottomAnchor.constraint(equalTo: background.contentView.bottomAnchor, constant: -4),
+            stackView.leadingAnchor.constraint(equalTo: background.contentView.leadingAnchor, constant: 6),
+            stackView.trailingAnchor.constraint(equalTo: background.contentView.trailingAnchor, constant: -6)
+        ])
+
+        setupButtons()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        background.layer.cornerRadius = bounds.height / 2
+    }
+
+    func configure(
+        currentPage: Int,
+        pageCount: Int,
+        onSelectPage: @escaping (Int) -> Void,
+        onRequestPageInput: @escaping () -> Void
+    ) {
+        self.onSelectPage = onSelectPage
+        self.onRequestPageInput = onRequestPageInput
+        self.pageCount = pageCount
+        self.currentPage = PaginationPositioning.clampedPage(currentPage, pageCount: pageCount)
+        render()
+    }
+
+    private func setupButtons() {
+        let symbol = UIImage.SymbolConfiguration(textStyle: .headline, scale: .large)
+        previousButton.configuration?.image = UIImage(
+            systemName: "chevron.left",
+            withConfiguration: symbol
+        )
+        nextButton.configuration?.image = UIImage(
+            systemName: "chevron.right",
+            withConfiguration: symbol
+        )
+
+        previousButton.accessibilityLabel = String(localized: "archive.list.page.previous")
+        previousButton.addAction(
+            UIAction { [weak self] _ in self?.step(-1) },
+            for: .touchUpInside
+        )
+
+        nextButton.accessibilityLabel = String(localized: "archive.list.page.next")
+        nextButton.addAction(
+            UIAction { [weak self] _ in self?.step(1) },
+            for: .touchUpInside
+        )
+
+        positionButton.configuration?.baseForegroundColor = .label
+        positionButton.configuration?.titleTextAttributesTransformer =
+            UIConfigurationTextAttributesTransformer { incoming in
+                var outgoing = incoming
+                outgoing.font = .preferredFont(forTextStyle: .headline)
+                return outgoing
+            }
+        positionButton.accessibilityHint = String(localized: "archive.list.page.jump.title")
+        positionButton.addAction(
+            UIAction { [weak self] _ in self?.onRequestPageInput?() },
+            for: .touchUpInside
+        )
+
+        [previousButton, positionButton, nextButton].forEach { button in
+            button.translatesAutoresizingMaskIntoConstraints = false
+            stackView.addArrangedSubview(button)
+            button.heightAnchor.constraint(greaterThanOrEqualToConstant: 44).isActive = true
+        }
+        [previousButton, nextButton].forEach { button in
+            button.widthAnchor.constraint(greaterThanOrEqualToConstant: 44).isActive = true
+        }
+    }
+
+    private func step(_ offset: Int) {
+        onSelectPage?(currentPage + offset)
+    }
+
+    private func render() {
+        guard pageCount > 1 else { return }
+
+        previousButton.isEnabled = currentPage > 0
+        nextButton.isEnabled = currentPage < pageCount - 1
+        positionButton.configuration?.title = String(
+            format: String(localized: "archive.list.page.position %1$lld %2$lld"),
+            Int64(currentPage + 1), Int64(pageCount)
+        )
+        positionButton.accessibilityLabel = String(
+            format: String(localized: "archive.list.page.position.accessibility %1$lld %2$lld"),
+            Int64(currentPage + 1), Int64(pageCount)
+        )
+    }
+}

--- a/LANreader/Common/PaginationBar.swift
+++ b/LANreader/Common/PaginationBar.swift
@@ -86,13 +86,11 @@ final class PaginationBar: UIView {
             withConfiguration: symbol
         )
 
-        previousButton.accessibilityLabel = String(localized: "archive.list.page.previous")
         previousButton.addAction(
             UIAction { [weak self] _ in self?.step(-1) },
             for: .touchUpInside
         )
 
-        nextButton.accessibilityLabel = String(localized: "archive.list.page.next")
         nextButton.addAction(
             UIAction { [weak self] _ in self?.step(1) },
             for: .touchUpInside
@@ -132,10 +130,6 @@ final class PaginationBar: UIView {
         nextButton.isEnabled = currentPage < pageCount - 1
         positionButton.configuration?.title = String(
             format: String(localized: "archive.list.page.position %1$lld %2$lld"),
-            Int64(currentPage + 1), Int64(pageCount)
-        )
-        positionButton.accessibilityLabel = String(
-            format: String(localized: "archive.list.page.position.accessibility %1$lld %2$lld"),
             Int64(currentPage + 1), Int64(pageCount)
         )
     }

--- a/LANreader/Common/PaginationPositioning.swift
+++ b/LANreader/Common/PaginationPositioning.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Pure page-arithmetic for the archive list pager. Pages are zero-based internally and
+/// displayed one-based; the server is addressed by item offset, never by page number.
+enum PaginationPositioning {
+    static func pageCount(total: Int, pageSize: Int) -> Int {
+        guard total > 0, pageSize > 0 else { return 0 }
+        return (total - 1) / pageSize + 1
+    }
+
+    static func clampedPage(_ page: Int, pageCount: Int) -> Int {
+        guard pageCount > 0 else { return 0 }
+        return min(max(page, 0), pageCount - 1)
+    }
+
+    /// Item offset to send as the LANraragi `start` parameter for a given page.
+    static func itemOffset(page: Int, pageSize: Int) -> Int {
+        guard pageSize > 0 else { return 0 }
+        return max(page, 0) * pageSize
+    }
+}

--- a/LANreader/Common/UIArchiveList.swift
+++ b/LANreader/Common/UIArchiveList.swift
@@ -14,6 +14,7 @@ import Logging
         @SharedReader(.appStorage(SettingsKey.lanraragiUrl)) var lanraragiUrl = ""
         @SharedReader(.appStorage(SettingsKey.searchSortCustom)) var searchSortCustom = ""
         @Shared(.appStorage(SettingsKey.hideRead)) var hideRead = false
+        @Shared(.appStorage(SettingsKey.paginateArchiveList)) var paginateArchiveList = false
         @Shared(.appStorage(SettingsKey.searchSort)) var searchSort = SearchSort.dateAdded.rawValue
         @Shared(.appStorage(SettingsKey.searchSortOrder)) var searchSortOrder = SearchSortOrder.asc.rawValue
         @Shared(.appStorage(SettingsKey.lastTagRefresh)) var lastTagRefresh = 0.0
@@ -33,6 +34,17 @@ import Logging
         var currentTab: TabName
 
         var archivesToDisplay: IdentifiedArrayOf<GridFeature.State> = []
+
+        /// Zero-based index of the page currently shown in pagination mode.
+        var currentPage = 0
+        var pendingPage: Int?
+        /// Items returned per request. LANraragi has no page-size parameter, so this is
+        /// discovered from a page-zero response rather than chosen by the app.
+        var serverPageSize = 0
+
+        var pageCount: Int {
+            PaginationPositioning.pageCount(total: total, pageSize: serverPageSize)
+        }
 
         // Library/category can load an unfiltered list; Search treats an empty filter as no query yet.
         var canLoadArchives: Bool {
@@ -72,6 +84,7 @@ import Logging
         case setSearchSortOrder(String)
         case setSearchSort(String)
         case toggleHideRead
+        case goToPage(Int)
 
         case deleteButtonTapped
         case deleteSuccess(Set<String>)
@@ -97,6 +110,8 @@ import Logging
             case .resetArchives:
                 state.archivesToDisplay = .init()
                 state.archives = .init()
+                state.currentPage = 0
+                state.pendingPage = nil
                 return .none
             case let .load(showLoading):
                 guard state.canLoadArchives else {
@@ -110,11 +125,19 @@ import Logging
                 if showLoading {
                     state.showLoading = showLoading
                 }
+                // A reload keeps the page the user is on, so pull-to-refresh reloads what is on
+                // screen. Every path that means "start over" sends `resetArchives` first, which
+                // is what puts the pager back on the first page.
+                let page = state.paginationActive
+                    ? PaginationPositioning.clampedPage(state.currentPage, pageCount: state.pageCount)
+                    : 0
+                state.currentPage = page
+                let start = PaginationPositioning.itemOffset(page: page, pageSize: state.serverPageSize)
                 let sortby = state.searchSort
                 let order = state.searchSortOrder
                 self.populateTags(state: &state)
                 return self.search(
-                    searchFilter: state.filter, sortby: sortby, start: "0", order: order, append: false
+                    searchFilter: state.filter, sortby: sortby, start: String(start), order: order, append: false
                 )
             case let .appendArchives(start):
                 guard state.canLoadArchives else {
@@ -136,7 +159,7 @@ import Logging
                 state.$archiveItems.withLock {
                     _ = $0.remove(id: id)
                 }
-                return .none
+                return reloadPageAfterRemoval(state: &state, removedCount: 1)
             case let .populateArchives(archives, total, append):
                 archives.forEach { item in
                     state.$archiveItems.withLock {
@@ -148,12 +171,23 @@ import Logging
                 }.map {
                     GridFeature.State(archive: $0)
                 }
+                if let pendingPage = state.pendingPage {
+                    state.currentPage = pendingPage
+                    state.pendingPage = nil
+                }
                 if !append {
                     state.archives = .init()
                     state.archivesToDisplay = .init()
                     state.total = 0
                 }
                 state.archives.append(contentsOf: gridFeatureState)
+
+                // LANraragi exposes no page-size parameter, so the size is inferred from a
+                // full page-zero response. Later pages can be short, which is why only page
+                // zero is trusted to define it.
+                if !append, state.currentPage == 0, !archives.isEmpty {
+                    state.serverPageSize = archives.count
+                }
 
                 if state.hideRead {
                     let result = state.archives.filter {
@@ -167,6 +201,15 @@ import Logging
                 state.total = total
                 state.loading = false
                 state.showLoading = false
+
+                // Archives removed elsewhere can shrink the list past the page being reloaded.
+                // Fall back to the last valid page instead of leaving an empty grid behind.
+                if !append, state.paginationActive, state.pageCount > 0, state.currentPage >= state.pageCount {
+                    state.currentPage = PaginationPositioning.clampedPage(
+                        state.currentPage, pageCount: state.pageCount
+                    )
+                    return .send(.load(false))
+                }
                 return .none
             case let .refreshThumbnail(archiveId):
                 if state.archivesToDisplay.contains(where: { $0.id == archiveId }) {
@@ -177,6 +220,7 @@ import Logging
             case let .setErrorMessage(message):
                 state.loading = false
                 state.showLoading = false
+                state.pendingPage = nil
                 state.errorMessage = message
                 return .none
             case let .setSuccessMessage(message):
@@ -185,6 +229,7 @@ import Logging
             case .grid:
                 return .none
             case .cancelSearch:
+                state.pendingPage = nil
                 if state.loading {
                     state.loading = false
                     state.showLoading = false
@@ -266,7 +311,7 @@ import Logging
                     state.archives.remove(id: id)
                 }
                 state.loading = false
-                return .none
+                return reloadPageAfterRemoval(state: &state, removedCount: archiveIds.count)
             case .alert(.presented(.confirmDelete)):
                 state.loading = true
                 return .run { [state] send in
@@ -321,6 +366,26 @@ import Logging
                     state.archivesToDisplay = state.archives
                 }
                 return .none
+            case let .goToPage(page):
+                guard state.canLoadArchives, state.paginationActive else { return .none }
+                guard state.loading == false else { return .none }
+                let targetPage = PaginationPositioning.clampedPage(page, pageCount: state.pageCount)
+                guard targetPage != state.currentPage else { return .none }
+
+                state.loading = true
+                state.showLoading = true
+                state.pendingPage = targetPage
+                let start = PaginationPositioning.itemOffset(
+                    page: targetPage,
+                    pageSize: state.serverPageSize
+                )
+                return self.search(
+                    searchFilter: state.filter,
+                    sortby: state.searchSort,
+                    start: String(start),
+                    order: state.searchSortOrder,
+                    append: false
+                )
             case .deleteButtonTapped:
                 state.alert = AlertState {
                     TextState("archive.selected.delete")
@@ -355,7 +420,7 @@ import Logging
                     }
                 }
                 state.loading = false
-                return .none
+                return reloadPageAfterRemoval(state: &state, removedCount: archiveIds.count)
             case .loadCategory:
                 return .run { send in
                     let categories = try await service.retrieveCategories().value
@@ -436,13 +501,30 @@ import Logging
         }
         .ifLet(\.$alert, action: \.alert)
     }
+}
 
+extension ArchiveListFeature {
     func clearArchives(state: inout State) {
         state.archivesToDisplay = .init()
         state.archives = .init()
         state.total = 0
+        state.currentPage = 0
+        state.pendingPage = nil
         state.loading = false
         state.showLoading = false
+    }
+
+    private func reloadPageAfterRemoval(
+        state: inout State,
+        removedCount: Int
+    ) -> EffectOf<Self> {
+        guard state.paginationActive, removedCount > 0 else { return .none }
+        state.total = max(state.total - removedCount, 0)
+        state.currentPage = PaginationPositioning.clampedPage(
+            state.currentPage,
+            pageCount: state.pageCount
+        )
+        return .send(.load(false))
     }
 
     func populateTags(state: inout State) {
@@ -517,6 +599,18 @@ import Logging
     }
 }
 
+extension ArchiveListFeature.State {
+    /// Random sort is served by an endpoint that has no offset paging, so the pager
+    /// stays hidden there even when the mode is enabled.
+    var paginationActive: Bool {
+        paginateArchiveList && searchSort != SearchSort.random.rawValue
+    }
+
+    var showsPager: Bool {
+        paginationActive && pageCount > 1
+    }
+}
+
 class UIArchiveListViewController: UIViewController {
     let store: StoreOf<ArchiveListFeature>
 
@@ -530,6 +624,8 @@ class UIArchiveListViewController: UIViewController {
     private var lastObservedSearchSort: String?
     private var lastObservedSearchSortOrder: String?
     private var lastObservedFilter: SearchFilter?
+    private var lastObservedPaginateArchiveList: Bool?
+    private let paginationBar = PaginationBar()
 
     init(store: StoreOf<ArchiveListFeature>) {
         self.store = store
@@ -554,6 +650,40 @@ class UIArchiveListViewController: UIViewController {
             collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
+    }
+
+    private func setupPaginationBar() {
+        paginationBar.translatesAutoresizingMaskIntoConstraints = false
+        paginationBar.isHidden = true
+        view.addSubview(paginationBar)
+
+        // Soft side margins: the strip is sized by its content, so on the narrowest phone
+        // with the largest text these would be unsatisfiable rather than compressing it.
+        let leading = paginationBar.leadingAnchor.constraint(
+            greaterThanOrEqualTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 12
+        )
+        let trailing = paginationBar.trailingAnchor.constraint(
+            lessThanOrEqualTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -12
+        )
+        leading.priority = .defaultHigh
+        trailing.priority = .defaultHigh
+
+        NSLayoutConstraint.activate([
+            paginationBar.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            paginationBar.bottomAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -12
+            ),
+            leading,
+            trailing
+        ])
+    }
+
+    /// Keeps the last row scrollable clear of the floating bar instead of hiding under it.
+    private func updateContentInsetForPaginationBar() {
+        let inset = paginationBar.isHidden ? 0 : paginationBar.bounds.height + 24
+        guard collectionView.contentInset.bottom != inset else { return }
+        collectionView.contentInset.bottom = inset
+        collectionView.verticalScrollIndicatorInsets.bottom = inset
     }
 
     private func makeCollectionViewLayout() -> UICollectionViewCompositionalLayout {
@@ -677,6 +807,70 @@ class UIArchiveListViewController: UIViewController {
         }
     }
 
+    private func goToPage(_ page: Int) {
+        let target = PaginationPositioning.clampedPage(page, pageCount: store.pageCount)
+        guard store.paginationActive, store.loading == false, target != store.currentPage else { return }
+        Task {
+            // Reuses the pull-to-refresh spinner, which also parks the list back at the top.
+            refreshControl.beginRefreshing()
+            let offsetPoint = CGPoint(
+                x: 0,
+                y: -collectionView.adjustedContentInset.top - refreshControl.frame.height
+            )
+            collectionView.setContentOffset(offsetPoint, animated: true)
+            await store.send(.goToPage(target)).finish()
+            refreshControl.endRefreshing()
+        }
+    }
+
+    private func renderPaginationBar() {
+        paginationBar.isHidden = !store.showsPager
+        if store.showsPager {
+            paginationBar.configure(
+                currentPage: store.currentPage,
+                pageCount: store.pageCount,
+                onSelectPage: { [weak self] page in
+                    self?.goToPage(page)
+                },
+                onRequestPageInput: { [weak self] in
+                    self?.presentPageInput()
+                }
+            )
+            paginationBar.layoutIfNeeded()
+        }
+        updateContentInsetForPaginationBar()
+    }
+
+    private func presentPageInput() {
+        let pageCount = store.pageCount
+        guard pageCount > 1 else { return }
+
+        let alert = UIAlertController(
+            title: String(localized: "archive.list.page.jump.title"),
+            message: String(
+                format: String(localized: "archive.list.page.jump.message %lld"), Int64(pageCount)
+            ),
+            preferredStyle: .alert
+        )
+        alert.addTextField { field in
+            field.keyboardType = .numberPad
+            field.textAlignment = .center
+            field.text = String(self.store.currentPage + 1)
+            field.clearButtonMode = .whileEditing
+        }
+        alert.addAction(UIAlertAction(title: String(localized: "cancel"), style: .cancel))
+        let goAction = UIAlertAction(
+            title: String(localized: "archive.list.page.jump.go"), style: .default
+        ) { [weak self, weak alert] _ in
+            guard let self, let text = alert?.textFields?.first?.text,
+                  let requested = Int(text.trimmingCharacters(in: .whitespaces)) else { return }
+            // Displayed page numbers are one-based; the reducer works in zero-based pages.
+            goToPage(requested - 1)
+        }
+        alert.addAction(goAction)
+        present(alert, animated: true)
+    }
+
     // swiftlint:disable function_body_length
     func setupToolbar() {
         let actions = SearchSort.allCases.filter { $0 != SearchSort.random }.map { sort in
@@ -736,7 +930,9 @@ class UIArchiveListViewController: UIViewController {
             store.send(.toggleHideRead)
         }
 
-        let otherGroup = UIMenu(title: "", options: .displayInline, children: [randomAction, hideReadAction])
+        let otherGroup = UIMenu(
+            title: "", options: .displayInline, children: [randomAction, hideReadAction]
+        )
 
         // Create a menu with the actions
         let menu = UIMenu(title: "", children: [sortGroup, otherGroup])
@@ -773,13 +969,18 @@ class UIArchiveListViewController: UIViewController {
 
         observe { [weak self] in
             guard let self else { return }
+            // `observe` only re-runs when the state read here changes, and rendering the bar
+            // is idempotent, so no change tracking of its own is needed.
+            renderPaginationBar()
+        }
+
+        observe { [weak self] in
+            guard let self else { return }
             let lanraragiUrl = store.lanraragiUrl
             defer { lastObservedLanraragiUrl = lanraragiUrl }
 
             guard lanraragiUrl != lastObservedLanraragiUrl, !lanraragiUrl.isEmpty else { return }
-            store.send(.cancelSearch)
-            store.send(.resetArchives)
-            manualTriggerPullToRefresh()
+            reloadFromFirstPage()
         }
 
         observe { [weak self] in
@@ -788,9 +989,7 @@ class UIArchiveListViewController: UIViewController {
             defer { lastObservedSearchSort = searchSort }
 
             guard searchSort != lastObservedSearchSort else { return }
-            store.send(.cancelSearch)
-            store.send(.resetArchives)
-            manualTriggerPullToRefresh()
+            reloadFromFirstPage()
         }
 
         observe { [weak self] in
@@ -799,9 +998,18 @@ class UIArchiveListViewController: UIViewController {
             defer { lastObservedSearchSortOrder = searchSortOrder }
 
             guard searchSortOrder != lastObservedSearchSortOrder else { return }
-            store.send(.cancelSearch)
-            store.send(.resetArchives)
-            manualTriggerPullToRefresh()
+            reloadFromFirstPage()
+        }
+
+        observe { [weak self] in
+            guard let self else { return }
+            let paginate = store.paginateArchiveList
+            let previous = lastObservedPaginateArchiveList
+            defer { lastObservedPaginateArchiveList = paginate }
+
+            // The two modes hold different slices of the result set, so reload from the top.
+            guard let previous, previous != paginate else { return }
+            reloadFromFirstPage()
         }
 
         observe { [weak self] in
@@ -812,9 +1020,7 @@ class UIArchiveListViewController: UIViewController {
 
             guard filter.filter?.isEmpty == false else { return }
             guard previousFilter?.filter != filter.filter else { return }
-            store.send(.cancelSearch)
-            store.send(.resetArchives)
-            manualTriggerPullToRefresh()
+            reloadFromFirstPage()
         }
     }
     // swiftlint:enable function_body_length
@@ -825,6 +1031,7 @@ class UIArchiveListViewController: UIViewController {
         setupCollectionView()
         setupRefresh()
         setupCell()
+        setupPaginationBar()
         setupObserve()
 
         collectionView.delegate = self
@@ -856,6 +1063,12 @@ class UIArchiveListViewController: UIViewController {
         collectionView.refreshControl?.sendActions(for: .valueChanged)
     }
 
+    private func reloadFromFirstPage() {
+        store.send(.cancelSearch)
+        store.send(.resetArchives)
+        manualTriggerPullToRefresh()
+    }
+
     enum Section {
         case main
     }
@@ -867,7 +1080,8 @@ extension UIArchiveListViewController: UICollectionViewDelegate {
         willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath
     ) {
         if indexPath.item == collectionView.numberOfItems(inSection: 0) - 1 {
-            if store.searchSort != SearchSort.random.rawValue
+            if store.paginationActive == false
+                && store.searchSort != SearchSort.random.rawValue
                 && store.loading == false
                 && store.archives.count < store.total {
                 Task {

--- a/LANreader/Models/AppModels.swift
+++ b/LANreader/Models/AppModels.swift
@@ -112,6 +112,7 @@ struct SettingsKey {
     static let enablePasscode = "settings:view:passcode:enable"
     static let passcode = "settings:view:passcode"
     static let hideRead = "settings:view:hideRead"
+    static let paginateArchiveList = "settings:view:paginate"
 
     static let lastTagRefresh = "lastTagRefresh"
     static let tabBarHidden = "tab:bar:hidden"

--- a/LANreader/SettingsView.swift
+++ b/LANreader/SettingsView.swift
@@ -52,10 +52,7 @@ struct SettingsView: View {
             Section(header: Text("settings.host")) {
                 ServerSettings()
             }
-            Section(
-                header: Text("settings.view"),
-                footer: Text("settings.archive.list.order.custom.explain")
-            ) {
+            Section(header: Text("settings.view")) {
                 ViewSettings(store: self.store.scope(\.view, action: \.view))
             }
             Section(

--- a/LANreader/ViewSettings.swift
+++ b/LANreader/ViewSettings.swift
@@ -61,7 +61,12 @@ struct ViewSettings: View {
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled()
         } label: {
-            Text("settings.archive.list.order.custom.title")
+            VStack(alignment: .leading, spacing: 2) {
+                Text("settings.archive.list.order.custom.title")
+                Text("settings.archive.list.order.custom.explain")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
         .padding()
         Toggle(isOn: Binding(self.store.$blurInterfaceWhenInactive), label: {

--- a/LANreader/ViewSettings.swift
+++ b/LANreader/ViewSettings.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
         @Shared(.appStorage(SettingsKey.searchSortCustom)) var searchSortCustom = ""
         @Shared(.appStorage(SettingsKey.blurInterfaceWhenInactive)) var blurInterfaceWhenInactive = false
+        @Shared(.appStorage(SettingsKey.paginateArchiveList)) var paginateArchiveList = false
         @Shared(.appStorage(SettingsKey.enablePasscode)) var enablePasscode = false
         @Shared(.appStorage(SettingsKey.passcode)) var storedPasscode = ""
     }
@@ -65,6 +66,15 @@ struct ViewSettings: View {
         .padding()
         Toggle(isOn: Binding(self.store.$blurInterfaceWhenInactive), label: {
             Text("settings.view.blur.inactive")
+        })
+        .padding()
+        Toggle(isOn: Binding(self.store.$paginateArchiveList), label: {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("settings.view.paginate")
+                Text("settings.view.paginate.description")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         })
         .padding()
         Toggle(isOn: Binding(self.store.$enablePasscode), label: {

--- a/LANreaderTests/ArchiveListFeatureTests.swift
+++ b/LANreaderTests/ArchiveListFeatureTests.swift
@@ -53,6 +53,291 @@ final class ArchiveListFeatureTests: XCTestCase {
     }
 
     @MainActor
+    func testPageZeroResponseDefinesServerPageSize() async {
+        let store = TestStore(initialState: makePaginatedState()) {
+            ArchiveListFeature()
+        }
+
+        await store.send(.populateArchives(makeArchives(count: 100), 250, false)) {
+            $0.archives = expectedGridStates(in: &$0, count: 100)
+            $0.archivesToDisplay = $0.archives
+            $0.serverPageSize = 100
+            $0.total = 250
+            $0.loading = false
+            $0.showLoading = false
+        }
+
+        XCTAssertEqual(store.state.pageCount, 3)
+    }
+
+    @MainActor
+    func testShortFinalPageDoesNotShrinkServerPageSize() async {
+        var initialState = makePaginatedState()
+        initialState.serverPageSize = 100
+        initialState.total = 250
+        initialState.currentPage = 2
+
+        let store = TestStore(initialState: initialState) {
+            ArchiveListFeature()
+        }
+
+        // The last page returns fewer records; the discovered size must survive it.
+        await store.send(.populateArchives(makeArchives(count: 50), 250, false)) {
+            $0.archives = expectedGridStates(in: &$0, count: 50)
+            $0.archivesToDisplay = $0.archives
+            $0.loading = false
+            $0.showLoading = false
+        }
+
+        XCTAssertEqual(store.state.serverPageSize, 100)
+        XCTAssertEqual(store.state.pageCount, 3)
+    }
+
+    @MainActor
+    func testGoToPageIsIgnoredWhilePaginationIsDisabled() async {
+        var initialState = ArchiveListFeature.State(
+            filter: SearchFilter(category: nil, filter: nil),
+            loadOnAppear: false,
+            currentTab: .library
+        )
+        initialState.$paginateArchiveList = Shared(value: false)
+        initialState.serverPageSize = 100
+        initialState.total = 250
+
+        let store = TestStore(initialState: initialState) {
+            ArchiveListFeature()
+        }
+
+        await store.send(.goToPage(2))
+    }
+
+    @MainActor
+    func testGoToPageIsIgnoredForRandomSort() async {
+        var initialState = makePaginatedState()
+        initialState.$searchSort = Shared(value: SearchSort.random.rawValue)
+        initialState.serverPageSize = 100
+        initialState.total = 250
+
+        let store = TestStore(initialState: initialState) {
+            ArchiveListFeature()
+        }
+
+        XCTAssertFalse(store.state.paginationActive)
+        await store.send(.goToPage(2))
+    }
+
+    @MainActor
+    func testGoToPageRequestsMatchingServerOffset() async throws {
+        try await configureVerifiedClient()
+        stubSearchExpectingStart("200", recordsFiltered: 250)
+
+        var initialState = makePaginatedState()
+        initialState.serverPageSize = 100
+        initialState.total = 250
+
+        let store = TestStore(initialState: initialState) {
+            ArchiveListFeature()
+        }
+
+        await store.send(.goToPage(2)) {
+            $0.loading = true
+            $0.showLoading = true
+            $0.pendingPage = 2
+        }
+        // Only a request with start=200 is stubbed, so reaching populateArchives proves the offset.
+        await store.receive(.populateArchives([], 250, false)) {
+            $0.currentPage = 2
+            $0.pendingPage = nil
+            $0.total = 250
+            $0.loading = false
+            $0.showLoading = false
+        }
+    }
+
+    @MainActor
+    func testGoToPageClampsBeyondLastPage() async throws {
+        try await configureVerifiedClient()
+        stubSearchExpectingStart("200", recordsFiltered: 250)
+
+        var initialState = makePaginatedState()
+        initialState.serverPageSize = 100
+        initialState.total = 250
+
+        let store = TestStore(initialState: initialState) {
+            ArchiveListFeature()
+        }
+
+        await store.send(.goToPage(99)) {
+            $0.loading = true
+            $0.showLoading = true
+            $0.pendingPage = 2
+        }
+        await store.receive(.populateArchives([], 250, false)) {
+            $0.currentPage = 2
+            $0.pendingPage = nil
+            $0.total = 250
+            $0.loading = false
+            $0.showLoading = false
+        }
+    }
+
+    @MainActor
+    func testFailedPageRequestKeepsCurrentPageAndArchives() async throws {
+        try await configureVerifiedClient()
+        stubFailedSearchExpectingStart("200")
+
+        var initialState = makePaginatedState()
+        initialState.serverPageSize = 100
+        initialState.total = 250
+        initialState.archives = expectedGridStates(in: &initialState, count: 1)
+        initialState.archivesToDisplay = initialState.archives
+
+        let store = TestStore(initialState: initialState) {
+            ArchiveListFeature()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.goToPage(2)) {
+            $0.loading = true
+            $0.showLoading = true
+            $0.pendingPage = 2
+        }
+        await store.receive(\.setErrorMessage)
+
+        XCTAssertEqual(store.state.currentPage, 0)
+        XCTAssertNil(store.state.pendingPage)
+        XCTAssertEqual(store.state.archives.map(\.id), ["archive-0"])
+    }
+
+    @MainActor
+    func testLoadKeepsCurrentPageInPaginationMode() async throws {
+        try await configureVerifiedClient()
+        stubSearchExpectingStart("200", recordsFiltered: 250)
+
+        var initialState = makePaginatedState()
+        initialState.serverPageSize = 100
+        initialState.total = 250
+        initialState.currentPage = 2
+
+        let store = TestStore(initialState: initialState) {
+            ArchiveListFeature()
+        }
+        // populateTags stamps a shared timestamp that is irrelevant here.
+        store.exhaustivity = .off
+
+        await store.send(.load(true)) {
+            $0.loading = true
+            $0.showLoading = true
+        }
+        // Only start=200 is stubbed, so reaching populateArchives proves the page was kept.
+        await store.receive(.populateArchives([], 250, false)) {
+            $0.total = 250
+            $0.loading = false
+            $0.showLoading = false
+        }
+        XCTAssertEqual(store.state.currentPage, 2)
+    }
+
+    @MainActor
+    func testResetArchivesSendsLoadBackToFirstPage() async throws {
+        try await configureVerifiedClient()
+        stubSearchExpectingStart("0", recordsFiltered: 250)
+
+        var initialState = makePaginatedState()
+        initialState.serverPageSize = 100
+        initialState.total = 250
+        initialState.currentPage = 2
+
+        let store = TestStore(initialState: initialState) {
+            ArchiveListFeature()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.resetArchives) {
+            $0.currentPage = 0
+        }
+        await store.send(.load(true)) {
+            $0.loading = true
+            $0.showLoading = true
+        }
+        await store.receive(.populateArchives([], 250, false)) {
+            $0.total = 250
+            $0.loading = false
+            $0.showLoading = false
+        }
+        XCTAssertEqual(store.state.currentPage, 0)
+    }
+
+    @MainActor
+    func testLoadFallsBackWhenCurrentPageNoLongerExists() async throws {
+        try await configureVerifiedClient()
+        stubSearchExpectingStart("200", recordsFiltered: 150)
+        stubSearchExpectingStart("100", recordsFiltered: 150)
+
+        var initialState = makePaginatedState()
+        initialState.serverPageSize = 100
+        initialState.total = 250
+        initialState.currentPage = 2
+
+        let store = TestStore(initialState: initialState) {
+            ArchiveListFeature()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.load(true))
+        // The shrunken total leaves page 2 out of range, so the reducer retries the last page.
+        await store.receive(.populateArchives([], 150, false)) {
+            $0.currentPage = 1
+        }
+        await store.receive(.load(false))
+        await store.receive(.populateArchives([], 150, false))
+        XCTAssertEqual(store.state.currentPage, 1)
+    }
+
+    @MainActor
+    func testDeletingLastPageReloadsPreviousPage() async throws {
+        try await configureVerifiedClient()
+        stubSearchExpectingStart("0", recordsFiltered: 100)
+
+        var initialState = makePaginatedState()
+        initialState.serverPageSize = 100
+        initialState.total = 101
+        initialState.currentPage = 1
+        initialState.archives = expectedGridStates(in: &initialState, count: 1)
+        initialState.archivesToDisplay = initialState.archives
+
+        let store = TestStore(initialState: initialState) {
+            ArchiveListFeature()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.deleteSuccess(["archive-0"])) {
+            $0.total = 100
+            $0.currentPage = 0
+        }
+        await store.receive(.load(false))
+        // Only start=0 is stubbed, so the response proves the reducer reloaded the valid page.
+        await store.receive(.populateArchives([], 100, false))
+
+        XCTAssertEqual(store.state.currentPage, 0)
+        XCTAssertEqual(store.state.total, 100)
+    }
+
+    @MainActor
+    func testPagerHiddenUntilThereIsMoreThanOnePage() {
+        var state = makePaginatedState()
+        state.serverPageSize = 100
+
+        state.total = 80
+        XCTAssertEqual(state.pageCount, 1)
+        XCTAssertFalse(state.showsPager)
+
+        state.total = 180
+        XCTAssertEqual(state.pageCount, 2)
+        XCTAssertTrue(state.showsPager)
+    }
+
+    @MainActor
     func testGridLoadUsesArchiveThumbnailEndpointForNormalArchive() async throws {
         try await configureVerifiedClient()
 
@@ -132,8 +417,37 @@ private func configureVerifiedClient() async throws {
     _ = try await LANraragiService.shared.verifyClient(url: url, apiKey: apiKey)
 }
 
-private func stubArchiveThumbnail(id: String, data: Data) {
+/// Stubs `/api/search` only for the given `start` offset, so a mismatched offset simply
+/// fails to match and surfaces as a missing `populateArchives`.
+private func stubSearchExpectingStart(_ start: String, recordsFiltered: Int) {
     stub(condition: isHost("localhost")
+            && isPath("/api/search")
+            && isMethodGET()
+            && containsQueryParams(["start": start])) { _ in
+        HTTPStubsResponse(
+            data: Data("""
+            {"data":[],"recordsFiltered":\(recordsFiltered),"recordsTotal":\(recordsFiltered)}
+            """.utf8),
+            statusCode: 200,
+            headers: ["Content-Type": "application/json"]
+        )
+    }
+}
+
+private func stubFailedSearchExpectingStart(_ start: String) {
+    stub(condition: isHost("localhost")
+            && isPath("/api/search")
+            && isMethodGET()
+            && containsQueryParams(["start": start])) { _ in
+        HTTPStubsResponse(
+            data: Data(),
+            statusCode: 500,
+            headers: ["Content-Type": "application/json"]
+        )
+    }
+}
+
+private func stubArchiveThumbnail(id: String, data: Data) {    stub(condition: isHost("localhost")
             && isPath("/api/archives/\(id)/thumbnail")
             && containsQueryParams(["no_fallback": "true", "page": "0"])
             && isMethodGET()
@@ -164,8 +478,54 @@ private func makeGridTestStore(
     }
 }
 
-private func makeArchive(id: String, fileExtension: String) -> ArchiveItem {
-    ArchiveItem(
+@MainActor
+private func makePaginatedState() -> ArchiveListFeature.State {
+    let state = ArchiveListFeature.State(
+        filter: SearchFilter(category: nil, filter: nil),
+        loadOnAppear: false,
+        currentTab: .library
+    )
+    state.$paginateArchiveList = Shared(value: true)
+    state.$searchSort = Shared(value: SearchSort.dateAdded.rawValue)
+    state.$searchSortOrder = Shared(value: SearchSortOrder.desc.rawValue)
+    state.$hideRead = Shared(value: false)
+    return state
+}
+
+private func makeArchives(count: Int) -> [ArchiveItem] {
+    (0..<count).map { index in
+        ArchiveItem(
+            id: "archive-\(index)",
+            name: "Archive \(index)",
+            extension: "zip",
+            tags: "",
+            isNew: false,
+            progress: 0,
+            pagecount: 10,
+            dateAdded: nil
+        )
+    }
+}
+
+/// Rebuilds the grid states the reducer derives from the shared archive store, so tests
+/// assert against the same `Shared` references rather than detached copies.
+@MainActor
+private func expectedGridStates(
+    in state: inout ArchiveListFeature.State,
+    count: Int
+) -> IdentifiedArrayOf<GridFeature.State> {
+    let items = makeArchives(count: count)
+    items.forEach { item in
+        state.$archiveItems.withLock { _ = $0.updateOrAppend(item) }
+    }
+    return IdentifiedArray(
+        uniqueElements: items.compactMap { item in
+            Shared(state.$archiveItems[id: item.id]).map { GridFeature.State(archive: $0) }
+        }
+    )
+}
+
+private func makeArchive(id: String, fileExtension: String) -> ArchiveItem {    ArchiveItem(
         id: id,
         name: "Archive",
         extension: fileExtension,

--- a/LANreaderTests/ArchiveListFeatureTests.swift
+++ b/LANreaderTests/ArchiveListFeatureTests.swift
@@ -138,6 +138,7 @@ final class ArchiveListFeatureTests: XCTestCase {
         let store = TestStore(initialState: initialState) {
             ArchiveListFeature()
         }
+        store.timeout = .seconds(5)
 
         await store.send(.goToPage(2)) {
             $0.loading = true
@@ -166,6 +167,7 @@ final class ArchiveListFeatureTests: XCTestCase {
         let store = TestStore(initialState: initialState) {
             ArchiveListFeature()
         }
+        store.timeout = .seconds(5)
 
         await store.send(.goToPage(99)) {
             $0.loading = true
@@ -195,6 +197,7 @@ final class ArchiveListFeatureTests: XCTestCase {
         let store = TestStore(initialState: initialState) {
             ArchiveListFeature()
         }
+        store.timeout = .seconds(5)
         store.exhaustivity = .off
 
         await store.send(.goToPage(2)) {
@@ -222,6 +225,7 @@ final class ArchiveListFeatureTests: XCTestCase {
         let store = TestStore(initialState: initialState) {
             ArchiveListFeature()
         }
+        store.timeout = .seconds(5)
         // populateTags stamps a shared timestamp that is irrelevant here.
         store.exhaustivity = .off
 
@@ -251,6 +255,7 @@ final class ArchiveListFeatureTests: XCTestCase {
         let store = TestStore(initialState: initialState) {
             ArchiveListFeature()
         }
+        store.timeout = .seconds(5)
         store.exhaustivity = .off
 
         await store.send(.resetArchives) {
@@ -282,6 +287,7 @@ final class ArchiveListFeatureTests: XCTestCase {
         let store = TestStore(initialState: initialState) {
             ArchiveListFeature()
         }
+        store.timeout = .seconds(5)
         store.exhaustivity = .off
 
         await store.send(.load(true))
@@ -309,6 +315,7 @@ final class ArchiveListFeatureTests: XCTestCase {
         let store = TestStore(initialState: initialState) {
             ArchiveListFeature()
         }
+        store.timeout = .seconds(5)
         store.exhaustivity = .off
 
         await store.send(.deleteSuccess(["archive-0"])) {

--- a/LANreaderTests/PaginationPositioningTests.swift
+++ b/LANreaderTests/PaginationPositioningTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import LANreader
+
+final class PaginationPositioningTests: XCTestCase {
+    func testPageCountRoundsUpPartialFinalPage() {
+        XCTAssertEqual(PaginationPositioning.pageCount(total: 250, pageSize: 100), 3)
+        XCTAssertEqual(PaginationPositioning.pageCount(total: 200, pageSize: 100), 2)
+        XCTAssertEqual(PaginationPositioning.pageCount(total: 1, pageSize: 100), 1)
+    }
+
+    func testPageCountIsZeroWhenTotalOrPageSizeUnknown() {
+        XCTAssertEqual(PaginationPositioning.pageCount(total: 0, pageSize: 100), 0)
+        XCTAssertEqual(PaginationPositioning.pageCount(total: 50, pageSize: 0), 0)
+    }
+
+    func testItemOffsetUsesServerPageSize() {
+        XCTAssertEqual(PaginationPositioning.itemOffset(page: 0, pageSize: 100), 0)
+        XCTAssertEqual(PaginationPositioning.itemOffset(page: 3, pageSize: 100), 300)
+        XCTAssertEqual(PaginationPositioning.itemOffset(page: 2, pageSize: 25), 50)
+    }
+
+    func testItemOffsetIsZeroWhenPageSizeUnknown() {
+        XCTAssertEqual(PaginationPositioning.itemOffset(page: 4, pageSize: 0), 0)
+    }
+
+    func testClampedPageKeepsPageInsideRange() {
+        XCTAssertEqual(PaginationPositioning.clampedPage(-3, pageCount: 20), 0)
+        XCTAssertEqual(PaginationPositioning.clampedPage(99, pageCount: 20), 19)
+        XCTAssertEqual(PaginationPositioning.clampedPage(5, pageCount: 20), 5)
+        XCTAssertEqual(PaginationPositioning.clampedPage(5, pageCount: 0), 0)
+    }
+}

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -1326,41 +1326,6 @@
         }
       }
     },
-    "archive.list.page.next" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Next page"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "次のページ"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "다음 페이지"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "下一页"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "下一頁"
-          }
-        }
-      }
-    },
     "archive.list.page.position %1$lld %2$lld" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1392,76 +1357,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$lld / %2$lld"
-          }
-        }
-      }
-    },
-    "archive.list.page.position.accessibility %1$lld %2$lld" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Page %1$lld of %2$lld"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%2$lldページ中%1$lldページ目"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%2$lld페이지 중 %1$lld페이지"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "第 %1$lld 页，共 %2$lld 页"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "第 %1$lld 頁，共 %2$lld 頁"
-          }
-        }
-      }
-    },
-    "archive.list.page.previous" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Previous page"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "前のページ"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이전 페이지"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "上一页"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "上一頁"
           }
         }
       }

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -1221,6 +1221,251 @@
         }
       }
     },
+    "archive.list.page.jump.go" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Go"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移動"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이동"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跳转"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跳轉"
+          }
+        }
+      }
+    },
+    "archive.list.page.jump.message %lld" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter a page number between 1 and %lld."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1〜%lldのページ番号を入力してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1에서 %lld 사이의 페이지 번호를 입력하세요."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请输入 1 到 %lld 之间的页码。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請輸入 1 到 %lld 之間的頁碼。"
+          }
+        }
+      }
+    },
+    "archive.list.page.jump.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Go to page"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ページ移動"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "페이지 이동"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跳转到页面"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跳轉到頁面"
+          }
+        }
+      }
+    },
+    "archive.list.page.next" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next page"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "次のページ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다음 페이지"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下一页"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下一頁"
+          }
+        }
+      }
+    },
+    "archive.list.page.position %1$lld %2$lld" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld of %2$lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld / %2$lld"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld / %2$lld"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld / %2$lld"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld / %2$lld"
+          }
+        }
+      }
+    },
+    "archive.list.page.position.accessibility %1$lld %2$lld" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page %1$lld of %2$lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%2$lldページ中%1$lldページ目"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%2$lld페이지 중 %1$lld페이지"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第 %1$lld 页，共 %2$lld 页"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第 %1$lld 頁，共 %2$lld 頁"
+          }
+        }
+      }
+    },
+    "archive.list.page.previous" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Previous page"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前のページ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이전 페이지"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上一页"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上一頁"
+          }
+        }
+      }
+    },
     "archive.read.fromStart" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -6031,6 +6276,76 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "隱藏已讀"
+          }
+        }
+      }
+    },
+    "settings.view.paginate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paginate list"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ページ送り表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "페이지 나누기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分页显示"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分頁顯示"
+          }
+        }
+      }
+    },
+    "settings.view.paginate.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show a page bar instead of loading more as you scroll."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スクロールで読み込む代わりに、ページバーを表示します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스크롤할 때 계속 불러오는 대신 페이지 막대를 표시합니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示页码栏，而不是滚动时继续加载。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示頁碼列，而不是捲動時繼續載入。"
           }
         }
       }


### PR DESCRIPTION
## What changed
- Add an optional pagination mode for library, category, and search archive lists.
- Add direct page entry and compact previous/next controls.
- Keep continuous scrolling for random sort and when pagination is disabled.
- Keep page state consistent on failed requests and after archive removal.
- Increment the build number to 205; marketing version remains 3.9.5.

## Why
Addresses #355 and avoids empty or mismatched pages after failed loads or deletions.

## Verification
- `./scripts/lint` — passed
- `./scripts/test-ios` — 175 tests passed
- `jq empty Localizable.xcstrings` — passed
- `git diff --check` — passed