### PR TITLE
Stabilize vertical reader page layout

### DIFF
--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		E9F0ABCD2F90000100ABCDEF /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = E9F0ABCC2F90000100ABCDEF /* InfoPlist.xcstrings */; };
 		E9F3B0122B01A21C00F60F62 /* CategoryListV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F3B0112B01A21C00F60F62 /* CategoryListV2.swift */; };
 		F1A2B3C42F60000100AAA001 /* ReaderPositioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C72F60000100AAA001 /* ReaderPositioning.swift */; };
+		F1A2B3F02FB0000100AAA001 /* ReaderPageLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3F12FB0000100AAA001 /* ReaderPageLayout.swift */; };
 		F1A2B3C52F60000100AAA001 /* ArchiveReaderFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C82F60000100AAA001 /* ArchiveReaderFeatureTests.swift */; };
 		F1A2B3D52F60000400DDD001 /* LANraragiConfigFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3D42F60000400DDD001 /* LANraragiConfigFeatureTests.swift */; };
 		F1A2B3C62F60000200AAA001 /* ArchiveDetailsTagParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C92F60000200AAA001 /* ArchiveDetailsTagParserTests.swift */; };
@@ -229,6 +230,7 @@
 		E9F0ABCC2F90000100ABCDEF /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		E9F3B0112B01A21C00F60F62 /* CategoryListV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryListV2.swift; sourceTree = "<group>"; };
 		F1A2B3C72F60000100AAA001 /* ReaderPositioning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPositioning.swift; sourceTree = "<group>"; };
+		F1A2B3F12FB0000100AAA001 /* ReaderPageLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPageLayout.swift; sourceTree = "<group>"; };
 		F1A2B3C82F60000100AAA001 /* ArchiveReaderFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveReaderFeatureTests.swift; sourceTree = "<group>"; };
 		F1A2B3D42F60000400DDD001 /* LANraragiConfigFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LANraragiConfigFeatureTests.swift; sourceTree = "<group>"; };
 		F1A2B3C92F60000200AAA001 /* ArchiveDetailsTagParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailsTagParserTests.swift; sourceTree = "<group>"; };
@@ -320,6 +322,7 @@
 				F1A2B3CB2F60000300AAA001 /* ArchiveDetailsTagParser.swift */,
 				E9BFA2062AF52C3300DDE107 /* PageImageV2.swift */,
 				F1A2B3C72F60000100AAA001 /* ReaderPositioning.swift */,
+				F1A2B3F12FB0000100AAA001 /* ReaderPageLayout.swift */,
 				E90576B529F6BF8700C3CE3F /* WrappingHStack.swift */,
 				E9AA10012E0000010000AA01 /* TagTokenField.swift */,
 				E9BFA2042AF51DB500DDE107 /* ArchiveReader.swift */,
@@ -781,6 +784,7 @@
 				E9E3631F26F471E400C58D01 /* LogView.swift in Sources */,
 				6DA713301F56AA72BA0B4BE3 /* ServerSettings.swift in Sources */,
 				F1A2B3C42F60000100AAA001 /* ReaderPositioning.swift in Sources */,
+				F1A2B3F02FB0000100AAA001 /* ReaderPageLayout.swift in Sources */,
 				E9BFA2052AF51DB500DDE107 /* ArchiveReader.swift in Sources */,
 				6DA711FA92BEE61419224BB4 /* LoadingView.swift in Sources */,
 			);
@@ -971,7 +975,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreader.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 207;
+				CURRENT_PROJECT_VERSION = 208;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -982,7 +986,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.9.5;
+				MARKETING_VERSION = 3.9.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -999,7 +1003,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreaderRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 207;
+				CURRENT_PROJECT_VERSION = 208;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1010,7 +1014,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.9.5;
+				MARKETING_VERSION = 3.9.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1073,7 +1077,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 207;
+				CURRENT_PROJECT_VERSION = 208;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1085,7 +1089,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.9.5;
+				MARKETING_VERSION = 3.9.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1103,7 +1107,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 207;
+				CURRENT_PROJECT_VERSION = 208;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1115,7 +1119,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.9.5;
+				MARKETING_VERSION = 3.9.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/LANreader/Page/ArchiveReader.swift
+++ b/LANreader/Page/ArchiveReader.swift
@@ -75,6 +75,9 @@ public struct SliderPreviewThumbnailQueueResult: Equatable, Sendable {
         var sliderPreviewLoading = false
         var sliderThumbnailJobsById: [Int: String] = [:]
         var sliderReadyThumbnailPages: Set<Int> = []
+        /// Median aspect ratio of the pages measured so far, used to size pages that have not been
+        /// measured yet. Pages within an archive are near-uniform, so this converges almost immediately.
+        var estimatedPageAspectRatio: Double = ReaderPageLayout.defaultAspectRatio
 
         var allArchives: IdentifiedArrayOf<Shared<ArchiveItem>> = []
 
@@ -143,6 +146,8 @@ public struct SliderPreviewThumbnailQueueResult: Equatable, Sendable {
         case page(IdentifiedActionOf<PageFeature>)
         case extractArchive
         case finishExtracting([ReaderExtractedPage], TankoubonDetailsMetadata?)
+        case primePageAspectRatios
+        case pageAspectRatiosPrimed([Int: Double])
         case toggleControlUi(Bool?)
         case toggleDoublePageLayout
         case visiblePageChanged(Int)
@@ -194,6 +199,7 @@ public struct SliderPreviewThumbnailQueueResult: Equatable, Sendable {
         case sliderPreviewThumbnailQueue
         case sliderPreviewThumbnailPolling
         case sliderPreviewLoad
+        case primePageAspectRatios
     }
 
     public var body: some ReducerOf<Self> {
@@ -242,7 +248,10 @@ public struct SliderPreviewThumbnailQueueResult: Equatable, Sendable {
                    )
                    state.controlUiHidden = true
                    state.extracting = false
-                   return .send(.requestJump(state.currentPageIndex, source: .initialRestore))
+                   return .merge(
+                       .send(.requestJump(state.currentPageIndex, source: .initialRestore)),
+                       .send(.primePageAspectRatios)
+                   )
                } else {
                    self.resetSliderPreviewArchiveState(state: &state)
                    state.controlUiHidden = true
@@ -350,7 +359,27 @@ public struct SliderPreviewThumbnailQueueResult: Equatable, Sendable {
                 state.extracting = false
                 guard !state.pages.isEmpty else { return .none }
                 let initialRestore = Effect<Action>.send(.requestJump(state.currentPageIndex, source: .initialRestore))
-                return .merge(initialRestore, .send(.prepareSliderPreviewThumbnails))
+                return .merge(
+                    initialRestore,
+                    .send(.primePageAspectRatios),
+                    .send(.prepareSliderPreviewThumbnails)
+                )
+            case .primePageAspectRatios:
+                guard let folder = state.pages.first?.folder else { return .none }
+                return .run(priority: .utility) { send in
+                    let aspectRatios = imageService.storedImageAspectRatios(folderUrl: folder)
+                    guard !aspectRatios.isEmpty else { return }
+                    await send(.pageAspectRatiosPrimed(aspectRatios))
+                }
+                .cancellable(id: CancelId.primePageAspectRatios, cancelInFlight: true)
+            case let .pageAspectRatiosPrimed(aspectRatios):
+                for pageId in state.pages.ids {
+                    guard let page = state.pages[id: pageId], page.imageAspectRatio == nil else { continue }
+                    guard let aspectRatio = aspectRatios[page.pageNumber] else { continue }
+                    state.pages[id: pageId]?.imageAspectRatio = aspectRatio
+                }
+                self.updateEstimatedPageAspectRatio(state: &state)
+                return .none
             case let .toggleControlUi(show):
                 if let shouldShow = show {
                     state.controlUiHidden = shouldShow
@@ -741,6 +770,7 @@ public struct SliderPreviewThumbnailQueueResult: Equatable, Sendable {
                     shouldDisplayAsSplitPages: shouldDisplayAsSplitPages,
                     state: &state
                 )
+                self.updateEstimatedPageAspectRatio(state: &state)
                 return .none
             case .page:
                 return .none
@@ -968,6 +998,14 @@ public struct SliderPreviewThumbnailQueueResult: Equatable, Sendable {
         }
     }
 
+    private func updateEstimatedPageAspectRatio(state: inout State) {
+        guard let median = ReaderPageLayout.medianAspectRatio(state.pages.compactMap(\.imageAspectRatio)) else {
+            return
+        }
+        guard state.estimatedPageAspectRatio != median else { return }
+        state.estimatedPageAspectRatio = median
+    }
+
     private func handleSplitResolution(
         id: PageFeature.State.ID,
         shouldDisplayAsSplitPages: Bool,
@@ -1049,6 +1087,7 @@ public struct SliderPreviewThumbnailQueueResult: Equatable, Sendable {
             cached: current.cached
         )
         insertedPage.imageLoaded = true
+        insertedPage.imageAspectRatio = current.imageAspectRatio
         guard state.pages[id: insertedPage.id] == nil else { return }
 
         let leadingSplitMode = PageMode.preferredSplitMode(priorityLeft: state.piorityLeft)
@@ -1179,6 +1218,7 @@ public struct SliderPreviewThumbnailQueueResult: Equatable, Sendable {
         state.errorMessage = ""
         state.successMessage = ""
         state.currentTankoubonDetails = nil
+        state.estimatedPageAspectRatio = ReaderPageLayout.defaultAspectRatio
         resetSliderPreviewArchiveState(state: &state)
     }
 }

--- a/LANreader/Page/PageImageV2.swift
+++ b/LANreader/Page/PageImageV2.swift
@@ -24,9 +24,20 @@ import Logging
         let cached: Bool
         var imageLoaded = false
         var translationStatus = ""
+        /// Aspect ratio (height / width) of the source image, measured from the image header.
+        var imageAspectRatio: Double?
 
         public var id: String {
             "\(pageId)-\(suffix)"
+        }
+
+        /// Aspect ratio of what this page actually renders. Split pages show half of the source
+        /// image width, so they are twice as tall relative to their width.
+        var displayAspectRatio: Double? {
+            guard let imageAspectRatio else { return nil }
+            return pageMode.isSplitMode
+                ? ReaderPageLayout.splitAspectRatio(for: imageAspectRatio)
+                : imageAspectRatio
         }
 
         let folder: URL?
@@ -110,6 +121,7 @@ import Logging
 
                 if force {
                     state.pageMode = .loading
+                    state.imageAspectRatio = nil
                 } else if state.pageMode == .loading {
                     let normalPath = imageService.storedImagePath(
                         folderUrl: state.folder,
@@ -119,6 +131,7 @@ import Logging
                     if let normalPath {
                         let shouldDisplayAsSplitPages = state.splitImage
                             && imageService.shouldSplitWideImage(imageUrl: normalPath)
+                        state.imageAspectRatio = imageService.imageAspectRatio(imageUrl: normalPath)
                         return applyStoredImage(
                             shouldDisplayAsSplitPages: shouldDisplayAsSplitPages,
                             state: &state
@@ -253,6 +266,9 @@ import Logging
         state.progress = 0
         state.loading = false
         state.imageLoaded = true
+        if state.imageAspectRatio == nil {
+            state.imageAspectRatio = storedImageAspectRatio(state: state)
+        }
 
         if shouldDisplayAsSplitPages {
             return .send(.storedImageResolved(shouldDisplayAsSplitPages: true))
@@ -261,6 +277,17 @@ import Logging
         state.pageMode = .normal
         state.pendingSplitMode = nil
         return .send(.storedImageResolved(shouldDisplayAsSplitPages: false))
+    }
+
+    /// Header-only read of the stored file, so the reader knows the page height without decoding it.
+    private func storedImageAspectRatio(state: State) -> Double? {
+        guard let imageUrl = imageService.storedImagePath(
+            folderUrl: state.folder,
+            pageNumber: String(state.pageNumber)
+        ) else {
+            return nil
+        }
+        return imageService.imageAspectRatio(imageUrl: imageUrl)
     }
 }
 

--- a/LANreader/Page/ReaderPageLayout.swift
+++ b/LANreader/Page/ReaderPageLayout.swift
@@ -1,0 +1,42 @@
+import CoreGraphics
+import Foundation
+
+/// Pure layout math for the continuous vertical reader.
+///
+/// Page height is treated as a known layout input derived from the image aspect ratio, rather than
+/// something discovered by self-sizing after the image decodes. Pages whose real dimensions are not
+/// known yet fall back to the archive's measured median, which keeps the estimate close because
+/// pages within an archive are near-uniform.
+enum ReaderPageLayout {
+    /// Aspect ratio (height / width) used before any page in the archive has been measured.
+    /// Roughly matches the common A-series and B-series page proportions.
+    static let defaultAspectRatio: Double = 1.4
+
+    static func validatedAspectRatio(_ aspectRatio: Double?) -> Double {
+        guard let aspectRatio, aspectRatio.isFinite, aspectRatio > 0 else {
+            return defaultAspectRatio
+        }
+        return aspectRatio
+    }
+
+    static func aspectRatio(for imageSize: CGSize) -> Double? {
+        guard imageSize.width > 0, imageSize.height > 0 else { return nil }
+        return Double(imageSize.height / imageSize.width)
+    }
+
+    /// A split page shows half of the source image width, so it renders twice as tall relative to its width.
+    static func splitAspectRatio(for sourceAspectRatio: Double) -> Double {
+        sourceAspectRatio * 2
+    }
+
+    static func medianAspectRatio(_ aspectRatios: [Double]) -> Double? {
+        let usable = aspectRatios.filter { $0.isFinite && $0 > 0 }.sorted()
+        guard !usable.isEmpty else { return nil }
+        return usable[usable.count / 2]
+    }
+
+    static func itemHeight(width: CGFloat, aspectRatio: Double?) -> CGFloat {
+        guard width > 0 else { return 0 }
+        return (width * validatedAspectRatio(aspectRatio)).rounded()
+    }
+}

--- a/LANreader/Page/UIPageCell.swift
+++ b/LANreader/Page/UIPageCell.swift
@@ -398,18 +398,6 @@ class UIPageCell: UICollectionViewCell {
         fitPageWidth = false
         resetImageLayout()
     }
-
-    override func preferredLayoutAttributesFitting(
-        _ layoutAttributes: UICollectionViewLayoutAttributes
-    ) -> UICollectionViewLayoutAttributes {
-        let attributes = super.preferredLayoutAttributesFitting(layoutAttributes)
-        if let image = imageView.image {
-            let width = layoutAttributes.frame.width
-            let height = width * (image.size.height / image.size.width)
-            attributes.frame.size.height = height
-        }
-        return attributes
-    }
 }
 
 extension UIPageCell: UIScrollViewDelegate {

--- a/LANreader/Page/UIPageCollection.swift
+++ b/LANreader/Page/UIPageCollection.swift
@@ -27,6 +27,7 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
     private var lastReportedVisiblePageIndex: Int?
     private var appliedPageIds: [String] = []
     private var appliedDoublePageLayout: Bool?
+    private var appliedAspectRatios: [Double] = []
     private var isApplyingSnapshot = false
     private var activeAnimatedScrollTargetPageId: String?
 
@@ -63,13 +64,28 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private func makeLayout() -> UICollectionViewCompositionalLayout {
-        let heightDimension =
-        store.readDirection == ReadDirection.upDown.rawValue
-        ? NSCollectionLayoutDimension.estimated(UIScreen.main.bounds.height)
-        : NSCollectionLayoutDimension.fractionalHeight(1)
+    private func makeLayout() -> UICollectionViewLayout {
+        guard store.readDirection != ReadDirection.upDown.rawValue else {
+            return makeVerticalLayout()
+        }
+        return makeHorizontalLayout()
+    }
+
+    /// Vertical reading uses explicit per-item heights derived from each page's aspect ratio, so a
+    /// page never has to resize itself once its image finishes loading.
+    private func makeVerticalLayout() -> UICollectionViewFlowLayout {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .vertical
+        layout.minimumLineSpacing = 0
+        layout.minimumInteritemSpacing = 0
+        layout.sectionInset = .zero
+        return layout
+    }
+
+    private func makeHorizontalLayout() -> UICollectionViewCompositionalLayout {
+        let heightDimension = NSCollectionLayoutDimension.fractionalHeight(1)
         let widthDimension =
-        store.readDirection != ReadDirection.upDown.rawValue && store.doublePageLayout
+        store.doublePageLayout
         ? NSCollectionLayoutDimension.fractionalWidth(0.5)
         : NSCollectionLayoutDimension.fractionalWidth(1)
         let itemSize = NSCollectionLayoutSize(
@@ -85,7 +101,7 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
         let group = NSCollectionLayoutGroup.horizontal(
             layoutSize: groupSize,
             repeatingSubitem: item,
-            count: store.readDirection != ReadDirection.upDown.rawValue && store.doublePageLayout ? 2 : 1
+            count: store.doublePageLayout ? 2 : 1
         )
 
         let section = NSCollectionLayoutSection(group: group)
@@ -96,7 +112,7 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
         }
 
         let configuration = UICollectionViewCompositionalLayoutConfiguration()
-        configuration.scrollDirection = store.readDirection == ReadDirection.upDown.rawValue ? .vertical : .horizontal
+        configuration.scrollDirection = .horizontal
         return UICollectionViewCompositionalLayout(section: section, configuration: configuration)
     }
 
@@ -180,6 +196,37 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
         resolvedReadDirection != .upDown && store.fitPageWidth
     }
 
+    // MARK: - Vertical Item Sizing
+
+    private func availableItemWidth() -> CGFloat {
+        guard collectionView != nil else { return 0 }
+        let insets = collectionView.adjustedContentInset
+        return max(0, collectionView.bounds.width - insets.left - insets.right)
+    }
+
+    /// Aspect ratio a page renders at. Falls back to the archive's measured median while the page's
+    /// own dimensions are still unknown, which keeps the first layout close enough that no
+    /// correction is usually needed.
+    private func effectiveAspectRatio(for page: PageFeature.State) -> Double {
+        ReaderPageLayout.validatedAspectRatio(page.displayAspectRatio ?? store.estimatedPageAspectRatio)
+    }
+
+    private func currentAspectRatios() -> [Double] {
+        store.pages.map { effectiveAspectRatio(for: $0) }
+    }
+
+    /// Applies a corrected page height without moving anything the reader can currently see.
+    private func refreshVerticalItemHeights() {
+        guard resolvedReadDirection == .upDown else { return }
+        guard collectionView != nil, dataSource != nil else { return }
+        guard !isApplyingSnapshot else { return }
+
+        let anchor = currentSnapshotAnchor()
+        collectionView.collectionViewLayout.invalidateLayout()
+        collectionView.layoutIfNeeded()
+        restoreSnapshotAnchor(anchor)
+    }
+
     private func scrollPosition(for request: ScrollRequest) -> UICollectionView.ScrollPosition {
         switch request.source {
         case .initialRestore, .slider:
@@ -201,7 +248,7 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
         )
         let indexPath = IndexPath(row: idx, section: 0)
         collectionView.layoutIfNeeded()
-        guard let attr = collectionView.layoutAttributesForItem(at: indexPath) else {
+        guard collectionView.layoutAttributesForItem(at: indexPath) != nil else {
             return false
         }
         activeAnimatedScrollTargetPageId = request.animated ? dataSource.itemIdentifier(for: indexPath) : nil
@@ -209,7 +256,9 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
             store.send(.collectionScrollStarted)
         }
         if store.readDirection == ReadDirection.upDown.rawValue {
-            collectionView.scrollRectToVisible(attr.frame, animated: request.animated)
+            // Pages are now sized to their real height, so a minimal "make visible" scroll could
+            // leave a short page parked at the bottom of the viewport. Always align it to the top.
+            collectionView.scrollToItem(at: indexPath, at: .top, animated: request.animated)
         } else {
             collectionView.scrollToItem(at: indexPath, at: scrollPosition(for: request), animated: request.animated)
         }
@@ -240,23 +289,17 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
             guard !store.pages.isEmpty else { return }
             let pageIds = store.pages.map(\.id)
             guard pageIds != appliedPageIds else { return }
-            let snapshotAnchor = currentSnapshotAnchor()
-            appliedPageIds = pageIds
-
-            var snapshot = NSDiffableDataSourceSnapshot<Section, String>()
-            snapshot.appendSections([.main])
-            snapshot.appendItems(pageIds)
-            isApplyingSnapshot = true
-            UIView.performWithoutAnimation {
-                dataSource.apply(snapshot, animatingDifferences: false) { [weak self] in
-                    guard let self else { return }
-                    self.restoreSnapshotAnchor(snapshotAnchor)
-                    self.consumePendingScrollRequestIfPossible()
-                    self.isApplyingSnapshot = false
-                }
-                collectionView.layoutIfNeeded()
-                restoreSnapshotAnchor(snapshotAnchor)
-            }
+            applyPageSnapshot(pageIds: pageIds)
+        }
+        observe { [weak self] in
+            guard let self else { return }
+            let aspectRatios = currentAspectRatios()
+            let pageIds = store.pages.map(\.id)
+            guard aspectRatios != appliedAspectRatios else { return }
+            appliedAspectRatios = aspectRatios
+            // The snapshot observer lays out fresh page sets, so only correct in-place changes here.
+            guard pageIds == appliedPageIds else { return }
+            refreshVerticalItemHeights()
         }
         observe { [weak self] in
             guard let self else { return }
@@ -271,6 +314,28 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
                 .forEach { $0.setFitPageWidth(fitPageWidth) }
         }
     }
+
+    private func applyPageSnapshot(pageIds: [String]) {
+        let snapshotAnchor = currentSnapshotAnchor()
+        appliedPageIds = pageIds
+        appliedAspectRatios = currentAspectRatios()
+
+        var snapshot = NSDiffableDataSourceSnapshot<Section, String>()
+        snapshot.appendSections([.main])
+        snapshot.appendItems(pageIds)
+        isApplyingSnapshot = true
+        UIView.performWithoutAnimation {
+            dataSource.apply(snapshot, animatingDifferences: false) { [weak self] in
+                guard let self else { return }
+                self.restoreSnapshotAnchor(snapshotAnchor)
+                self.consumePendingScrollRequestIfPossible()
+                self.isApplyingSnapshot = false
+            }
+            collectionView.layoutIfNeeded()
+            restoreSnapshotAnchor(snapshotAnchor)
+        }
+    }
+
     private func setupGesture() {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
         tapGesture.numberOfTapsRequired = 1
@@ -426,7 +491,12 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
             x: attributes.frame.minX - anchor.offsetFromViewportOrigin.x,
             y: attributes.frame.minY - anchor.offsetFromViewportOrigin.y
         )
-        collectionView.setContentOffset(clampedContentOffset(proposedOffset), animated: false)
+        let targetOffset = clampedContentOffset(proposedOffset)
+        // Writing an unchanged offset would cancel an in-flight deceleration, so only move when needed.
+        if abs(targetOffset.x - collectionView.contentOffset.x) > 0.5
+            || abs(targetOffset.y - collectionView.contentOffset.y) > 0.5 {
+            collectionView.setContentOffset(targetOffset, animated: false)
+        }
         if anchor.resolvesAnimatedScroll {
             activeAnimatedScrollTargetPageId = nil
         }
@@ -461,12 +531,17 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
 
     private func resnap(to indexPath: IndexPath?) {
         guard collectionView != nil else { return }
-        guard store.readDirection != ReadDirection.upDown.rawValue else { return }
         guard let indexPath else { return }
         let numberOfItems = collectionView.numberOfItems(inSection: indexPath.section)
         guard indexPath.row < numberOfItems else { return }
         // Scroll without animation to avoid intermediate half pages
-        collectionView.scrollToItem(at: indexPath, at: .left, animated: false)
+        if store.readDirection == ReadDirection.upDown.rawValue {
+            // Item heights are derived from the item width, so a width change invalidates the
+            // current offset. Put the page the reader was on back at the top of the viewport.
+            collectionView.scrollToItem(at: indexPath, at: .top, animated: false)
+        } else {
+            collectionView.scrollToItem(at: indexPath, at: .left, animated: false)
+        }
     }
 
     override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
@@ -908,6 +983,7 @@ extension UIPageCollectionController {
             Section, String
         >()
         appliedPageIds = []
+        appliedAspectRatios = []
         activeAnimatedScrollTargetPageId = nil
         dataSource.apply(snapshot, animatingDifferences: false)
         collectionView.setContentOffset(.zero, animated: false)
@@ -958,7 +1034,7 @@ extension UIPageCollectionController {
     }
 }
 
-extension UIPageCollectionController: UICollectionViewDataSourcePrefetching {
+extension UIPageCollectionController: UICollectionViewDelegateFlowLayout {
     func collectionView(
         _ collectionView: UICollectionView,
         willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath
@@ -966,13 +1042,31 @@ extension UIPageCollectionController: UICollectionViewDataSourcePrefetching {
         if let pageCell = cell as? UIPageCell {
             Task {
                 await pageCell.store?.send(.load(false)).finish()
-                if store.readDirection == ReadDirection.upDown.rawValue {
-                    collectionView.performBatchUpdates { }
-                }
             }
         }
     }
 
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        sizeForItemAt indexPath: IndexPath
+    ) -> CGSize {
+        let width = availableItemWidth()
+        guard let pageId = dataSource.itemIdentifier(for: indexPath),
+              let page = store.pages[id: pageId] else {
+            return CGSize(
+                width: width,
+                height: ReaderPageLayout.itemHeight(width: width, aspectRatio: store.estimatedPageAspectRatio)
+            )
+        }
+        return CGSize(
+            width: width,
+            height: ReaderPageLayout.itemHeight(width: width, aspectRatio: effectiveAspectRatio(for: page))
+        )
+    }
+}
+
+extension UIPageCollectionController: UICollectionViewDataSourcePrefetching {
     func collectionView(
         _ collectionView: UICollectionView,
         prefetchItemsAt indexPaths: [IndexPath]

--- a/LANreader/Service/ImageService.swift
+++ b/LANreader/Service/ImageService.swift
@@ -56,6 +56,38 @@ final class ImageService: Sendable {
         return matched.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }).first
     }
 
+    /// Reads only the image header, so this never decodes pixel data and stays cheap enough to run
+    /// for every page of an archive up front.
+    func imageAspectRatio(imageUrl: URL) -> Double? {
+        guard let imageSize = imagePixelSize(imageUrl: imageUrl) else { return nil }
+        return ReaderPageLayout.aspectRatio(for: imageSize)
+    }
+
+    /// Aspect ratios of every already stored page in `folderUrl`, keyed by page number.
+    /// The directory is listed once so priming an archive stays linear in the number of pages.
+    func storedImageAspectRatios(folderUrl: URL?) -> [Int: Double] {
+        guard let folderUrl else { return [:] }
+
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: folderUrl,
+            includingPropertiesForKeys: nil
+        ) else {
+            return [:]
+        }
+
+        var aspectRatios: [Int: Double] = [:]
+        for url in files.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
+            guard !url.hasDirectoryPath,
+                  let pageNumber = Int(url.deletingPathExtension().lastPathComponent),
+                  aspectRatios[pageNumber] == nil,
+                  let aspectRatio = imageAspectRatio(imageUrl: url) else {
+                continue
+            }
+            aspectRatios[pageNumber] = aspectRatio
+        }
+        return aspectRatios
+    }
+
     func splitImage(imageUrl: URL, side: ImageSplitSide) -> UIImage? {
         guard let image = UIImage(contentsOfFile: imageUrl.path(percentEncoded: false)),
               let cgImage = image.cgImage else {

--- a/LANreaderTests/ArchiveReaderFeatureTests.swift
+++ b/LANreaderTests/ArchiveReaderFeatureTests.swift
@@ -76,6 +76,46 @@ final class ArchiveReaderFeatureTests: XCTestCase {
         XCTAssertNil(UIPageCell.fitWidthAspectRatio(for: CGSize(width: 0, height: 1_500)))
     }
 
+    func testReaderPageLayoutValidatedAspectRatio() {
+        XCTAssertEqual(ReaderPageLayout.validatedAspectRatio(nil), ReaderPageLayout.defaultAspectRatio)
+        XCTAssertEqual(ReaderPageLayout.validatedAspectRatio(0), ReaderPageLayout.defaultAspectRatio)
+        XCTAssertEqual(ReaderPageLayout.validatedAspectRatio(-1), ReaderPageLayout.defaultAspectRatio)
+        XCTAssertEqual(ReaderPageLayout.validatedAspectRatio(.nan), ReaderPageLayout.defaultAspectRatio)
+        XCTAssertEqual(ReaderPageLayout.validatedAspectRatio(.infinity), ReaderPageLayout.defaultAspectRatio)
+        XCTAssertEqual(ReaderPageLayout.validatedAspectRatio(0.01), 0.01)
+        XCTAssertEqual(ReaderPageLayout.validatedAspectRatio(100), 100)
+        XCTAssertEqual(ReaderPageLayout.validatedAspectRatio(1.6), 1.6)
+    }
+
+    func testReaderPageLayoutAspectRatioForSize() {
+        XCTAssertEqual(ReaderPageLayout.aspectRatio(for: CGSize(width: 1_000, height: 1_400)), 1.4)
+        XCTAssertNil(ReaderPageLayout.aspectRatio(for: CGSize(width: 0, height: 1_400)))
+        XCTAssertNil(ReaderPageLayout.aspectRatio(for: CGSize(width: 1_000, height: 0)))
+    }
+
+    func testReaderPageLayoutSplitAspectRatioDoublesSource() {
+        // A split page shows half the source width at the same height.
+        XCTAssertEqual(ReaderPageLayout.splitAspectRatio(for: 0.7), 1.4)
+    }
+
+    func testReaderPageLayoutMedianAspectRatio() {
+        XCTAssertNil(ReaderPageLayout.medianAspectRatio([]))
+        XCTAssertNil(ReaderPageLayout.medianAspectRatio([0, -1, .nan]))
+        XCTAssertEqual(ReaderPageLayout.medianAspectRatio([1.5]), 1.5)
+        XCTAssertEqual(ReaderPageLayout.medianAspectRatio([1.8, 1.2, 1.5]), 1.5)
+        XCTAssertEqual(ReaderPageLayout.medianAspectRatio([1.0, 2.0, 1.4, 1.6]), 1.6)
+    }
+
+    func testReaderPageLayoutItemHeight() {
+        XCTAssertEqual(ReaderPageLayout.itemHeight(width: 100, aspectRatio: 1.4), 140)
+        XCTAssertEqual(ReaderPageLayout.itemHeight(width: 100, aspectRatio: 1.406), 141)
+        // Long-strip webtoon pages must keep their full-width rendered height.
+        XCTAssertEqual(ReaderPageLayout.itemHeight(width: 100, aspectRatio: 20), 2_000)
+        // Unmeasured pages fall back to the default ratio rather than collapsing to zero height.
+        XCTAssertEqual(ReaderPageLayout.itemHeight(width: 100, aspectRatio: nil), 140)
+        XCTAssertEqual(ReaderPageLayout.itemHeight(width: 0, aspectRatio: 1.4), 0)
+    }
+
     func testReaderPositioningFinishedMath() {
         // Progress is one-based, so an archive counts as finished only at the last page.
         XCTAssertTrue(ReaderPositioning.isFinished(progress: 5, archivePageCount: 5))
@@ -472,6 +512,7 @@ final class ArchiveReaderFeatureTests: XCTestCase {
                 animated: false
             )
         }
+        await store.receive(.primePageAspectRatios)
         await store.receive(.prepareSliderPreviewThumbnails)
         await store.receive(
             .sliderPreviewThumbnailsQueued([readyThumbnailQueueResult()])
@@ -499,6 +540,7 @@ final class ArchiveReaderFeatureTests: XCTestCase {
                 animated: false
             )
         }
+        await store.receive(.primePageAspectRatios)
         await store.receive(.prepareSliderPreviewThumbnails)
         await store.receive(
             .sliderPreviewThumbnailsQueued([readyThumbnailQueueResult()])
@@ -525,6 +567,7 @@ final class ArchiveReaderFeatureTests: XCTestCase {
                 animated: false
             )
         }
+        await store.receive(.primePageAspectRatios)
         await store.receive(.prepareSliderPreviewThumbnails)
         await store.receive(
             .sliderPreviewThumbnailsQueued([readyThumbnailQueueResult()])
@@ -553,6 +596,7 @@ final class ArchiveReaderFeatureTests: XCTestCase {
                 animated: false
             )
         }
+        await store.receive(.primePageAspectRatios)
         await store.receive(.prepareSliderPreviewThumbnails)
         await store.receive(
             .sliderPreviewThumbnailsQueued([readyThumbnailQueueResult()])
@@ -580,6 +624,7 @@ final class ArchiveReaderFeatureTests: XCTestCase {
                 animated: false
             )
         }
+        await store.receive(.primePageAspectRatios)
         await store.receive(.prepareSliderPreviewThumbnails)
         await store.receive(
             .sliderPreviewThumbnailsQueued([readyThumbnailQueueResult()])
@@ -607,6 +652,7 @@ final class ArchiveReaderFeatureTests: XCTestCase {
                 animated: false
             )
         }
+        await store.receive(.primePageAspectRatios)
         await store.receive(.prepareSliderPreviewThumbnails)
         await store.receive(
             .sliderPreviewThumbnailsQueued([readyThumbnailQueueResult()])
@@ -634,6 +680,7 @@ final class ArchiveReaderFeatureTests: XCTestCase {
                 animated: false
             )
         }
+        await store.receive(.primePageAspectRatios)
         await store.receive(.prepareSliderPreviewThumbnails)
         await store.receive(
             .sliderPreviewThumbnailsQueued([readyThumbnailQueueResult()])
@@ -690,6 +737,7 @@ final class ArchiveReaderFeatureTests: XCTestCase {
                 animated: false
             )
         }
+        await store.receive(.primePageAspectRatios)
         await store.receive(.prepareSliderPreviewThumbnails)
         await store.receive(
             .sliderPreviewThumbnailsQueued(readyThumbnailQueueResults(for: sourceArchives))
@@ -1109,6 +1157,7 @@ final class ArchiveReaderFeatureTests: XCTestCase {
                 animated: false
             )
         }
+        await store.receive(.primePageAspectRatios)
     }
 
     @MainActor
@@ -1148,6 +1197,7 @@ final class ArchiveReaderFeatureTests: XCTestCase {
                 animated: false
             )
         }
+        await store.receive(.primePageAspectRatios)
     }
 
     @MainActor
@@ -1193,6 +1243,7 @@ final class ArchiveReaderFeatureTests: XCTestCase {
                 animated: false
             )
         }
+        await store.receive(.primePageAspectRatios)
     }
 
     func testArchiveCachePersistsChapters() throws {
@@ -1311,6 +1362,76 @@ final class ArchiveReaderFeatureTests: XCTestCase {
         await store.receive(.refreshProgress)
         await clock.advance(by: .seconds(2))
         await store.finish()
+    }
+
+    @MainActor
+    func testPageAspectRatiosPrimedAssignsRatiosAndMedianEstimate() async {
+        configureReaderDefaults(readDirection: .upDown)
+        var initialState = makeState(readDirection: .upDown)
+        initialState.pages = makePageStates(count: 3)
+        let store = makeTestStore(initialState: initialState)
+
+        await store.send(.pageAspectRatiosPrimed([1: 1.2, 2: 1.5, 3: 1.8])) {
+            $0.pages[0].imageAspectRatio = 1.2
+            $0.pages[1].imageAspectRatio = 1.5
+            $0.pages[2].imageAspectRatio = 1.8
+            $0.estimatedPageAspectRatio = 1.5
+        }
+    }
+
+    @MainActor
+    func testPageAspectRatiosPrimedLeavesAlreadyMeasuredPagesUntouched() async {
+        configureReaderDefaults(readDirection: .upDown)
+        var initialState = makeState(readDirection: .upDown)
+        initialState.pages = makePageStates(count: 2)
+        initialState.pages[0].imageAspectRatio = 2.0
+        let store = makeTestStore(initialState: initialState)
+
+        await store.send(.pageAspectRatiosPrimed([1: 1.2, 2: 1.4])) {
+            $0.pages[1].imageAspectRatio = 1.4
+            $0.estimatedPageAspectRatio = 2.0
+        }
+    }
+
+    @MainActor
+    func testPrimePageAspectRatiosWithoutPagesDoesNothing() async {
+        configureReaderDefaults(readDirection: .upDown)
+        let store = makeTestStore(initialState: makeState(readDirection: .upDown))
+
+        await store.send(.primePageAspectRatios)
+    }
+
+    @MainActor
+    func testSplitPageResolutionCopiesAspectRatioToInsertedSibling() async {
+        configureReaderDefaults(splitWideImage: true)
+        var initialState = makeState(progress: 1)
+        initialState.$splitImage = SharedReader(value: true)
+        initialState.pages = makePageStates(count: 2)
+        initialState.pages[0].imageAspectRatio = 0.7
+        initialState.currentPageIndex = 0
+        let splittingPageId = initialState.pages[0].id
+        let store = makeTestStore(initialState: initialState)
+
+        await store.send(.page(.element(
+            id: splittingPageId,
+            action: .storedImageResolved(shouldDisplayAsSplitPages: true)
+        ))) {
+            $0.pages[0].pageMode = .right
+            $0.pages[0].imageLoaded = true
+            var sibling = loadedPageState(
+                archiveId: "archive",
+                pageId: "1",
+                pageNumber: 1,
+                pageMode: .left
+            )
+            sibling.imageAspectRatio = 0.7
+            $0.pages.insert(sibling, at: 1)
+            $0.estimatedPageAspectRatio = 0.7
+        }
+
+        // A split page shows half the source width, so it renders twice as tall relative to its width.
+        XCTAssertEqual(store.state.pages[0].displayAspectRatio, 1.4)
+        XCTAssertEqual(store.state.pages[1].displayAspectRatio, 1.4)
     }
 
     @MainActor


### PR DESCRIPTION
## What changed

- Size continuous vertical-reader pages from image-header aspect ratios instead of post-render self-sizing.
- Prime stored page ratios and preserve the visible page while dimensions update.
- Preserve full-height webtoon ratios without an arbitrary maximum.
- Bump LANreader and Action to version 3.9.6, build 208.

## Why

Prevent vertical-reader images from repeatedly shifting as pages finish loading while keeping long-strip webtoon pages at full width.

## Verification

- `./scripts/lint`
- `./scripts/test-ios` — 186 tests passed
- `git diff --check`
- Resolved Debug and Release build settings for LANreader and Action: 3.9.6 (208)