### PR TITLE
Guard reader spread navigation

### DIFF
--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		F1A2B3E12FA0000100AAA001 /* PaginationPositioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3E22FA0000100AAA001 /* PaginationPositioning.swift */; };
 		F1A2B3E32FA0000100AAA001 /* PaginationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3E42FA0000100AAA001 /* PaginationBar.swift */; };
 		F1A2B3E52FA0000100AAA001 /* PaginationPositioningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3E62FA0000100AAA001 /* PaginationPositioningTests.swift */; };
+		F1A2B3F22FC0000100AAA001 /* ReaderPositioningInvariantTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3F32FC0000100AAA001 /* ReaderPositioningInvariantTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -240,6 +241,7 @@
 		F1A2B3E22FA0000100AAA001 /* PaginationPositioning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationPositioning.swift; sourceTree = "<group>"; };
 		F1A2B3E42FA0000100AAA001 /* PaginationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationBar.swift; sourceTree = "<group>"; };
 		F1A2B3E62FA0000100AAA001 /* PaginationPositioningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationPositioningTests.swift; sourceTree = "<group>"; };
+		F1A2B3F32FC0000100AAA001 /* ReaderPositioningInvariantTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPositioningInvariantTests.swift; sourceTree = "<group>"; };
 		F1A2B3D72F90000100AAA001 /* SearchKeyword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKeyword.swift; sourceTree = "<group>"; };
 		F1A2B3D92F90000200AAA001 /* SearchFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFeatureTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -460,6 +462,7 @@
 				F1A2B3CF2F80000100AAA001 /* LogTextRendererTests.swift */,
 				F1A2B3D92F90000200AAA001 /* SearchFeatureTests.swift */,
 				F1A2B3E62FA0000100AAA001 /* PaginationPositioningTests.swift */,
+				F1A2B3F32FC0000100AAA001 /* ReaderPositioningInvariantTests.swift */,
 				7D354CB824F1316E00617F4A /* Info.plist */,
 				4BD820A697A4726B7B747BFD /* Service */,
 			);
@@ -799,6 +802,7 @@
 				F1A2B3CC2F70000100AAA001 /* ArchiveListFeatureTests.swift in Sources */,
 				F1A2B3CE2F80000100AAA001 /* LogTextRendererTests.swift in Sources */,
 				F1A2B3E52FA0000100AAA001 /* PaginationPositioningTests.swift in Sources */,
+				F1A2B3F22FC0000100AAA001 /* ReaderPositioningInvariantTests.swift in Sources */,
 				F1A2B3D82F90000200AAA001 /* SearchFeatureTests.swift in Sources */,
 				4BD82555CE41A0467CCC6411 /* LANraragiServiceTest.swift in Sources */,
 				7DF6FFAA252DC3BB009280A5 /* FileUtils.swift in Sources */,
@@ -975,7 +979,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreader.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 211;
+				CURRENT_PROJECT_VERSION = 212;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1003,7 +1007,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreaderRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 211;
+				CURRENT_PROJECT_VERSION = 212;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1077,7 +1081,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 211;
+				CURRENT_PROJECT_VERSION = 212;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1107,7 +1111,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 211;
+				CURRENT_PROJECT_VERSION = 212;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;

--- a/LANreader/Page/ReaderPositioning.swift
+++ b/LANreader/Page/ReaderPositioning.swift
@@ -154,8 +154,14 @@ enum ReaderPositioning {
             readDirection: readDirection,
             doublePageLayout: doublePageLayout
         ) {
+            let currentCanonicalIndex = canonicalPageIndex(
+                forVisibleIndex: currentIndex,
+                pageCount: pageCount,
+                readDirection: readDirection,
+                doublePageLayout: doublePageLayout
+            )
             let currentAnchor = scrollAnchorIndex(
-                forPageIndex: currentIndex,
+                forPageIndex: currentCanonicalIndex,
                 pageCount: pageCount,
                 readDirection: readDirection,
                 doublePageLayout: doublePageLayout
@@ -169,13 +175,14 @@ enum ReaderPositioning {
             }
 
             let clampedAnchor = clampedPageIndex(targetAnchor, pageCount: pageCount)
-            guard clampedAnchor != currentAnchor else { return nil }
-            return canonicalPageIndex(
+            let targetIndex = canonicalPageIndex(
                 forVisibleIndex: clampedAnchor,
                 pageCount: pageCount,
                 readDirection: readDirection,
                 doublePageLayout: doublePageLayout
             )
+            guard targetIndex != currentCanonicalIndex else { return nil }
+            return targetIndex
         }
 
         let targetIndex: Int

--- a/LANreaderTests/ArchiveReaderFeatureTests.swift
+++ b/LANreaderTests/ArchiveReaderFeatureTests.swift
@@ -991,6 +991,23 @@ final class ArchiveReaderFeatureTests: XCTestCase {
     }
 
     @MainActor
+    func testNavigateNextAtFinalEvenSpreadDoesNothing() async {
+        configureReaderDefaults(doublePageLayout: true)
+        var initialState = makeState(
+            progress: 6,
+            readDirection: .leftRight,
+            doublePageLayout: true
+        )
+        initialState.pages = makePageStates(count: 6)
+        initialState.currentPageIndex = 5
+        let store = makeTestStore(initialState: initialState)
+
+        await store.send(.navigate(.next, source: .tap))
+
+        XCTAssertNil(store.state.scrollRequest)
+    }
+
+    @MainActor
     func testNavigatePreviousUsesCanonicalDoublePageIndex() async {
         configureReaderDefaults(
             readDirection: .rightLeft,

--- a/LANreaderTests/ReaderPositioningInvariantTests.swift
+++ b/LANreaderTests/ReaderPositioningInvariantTests.swift
@@ -1,0 +1,300 @@
+import XCTest
+@testable import LANreader
+
+final class ReaderPositioningInvariantTests: XCTestCase {
+    func testInitialPageIndexMatrix() {
+        let cases: [InitialPageCase] = [
+            .init("empty archive", 0, 0, false, false, .leftRight, false, 0),
+            .init("negative progress", -3, 5, false, false, .leftRight, false, 0),
+            .init("progress beyond last page", 99, 5, false, false, .rightLeft, false, 4),
+            .init("one-page double layout", 1, 1, false, false, .rightLeft, true, 0),
+            .init("first even spread", 0, 2, false, false, .leftRight, true, 1),
+            .init("middle odd spread", 3, 5, false, false, .rightLeft, true, 3),
+            .init("last even spread", 6, 6, false, false, .leftRight, true, 5),
+            .init("vertical reader", 3, 5, false, false, .upDown, true, 2),
+            .init("from-start first spread", 5, 5, true, false, .leftRight, true, 1),
+            .init("finished restart first spread", 6, 6, false, true, .rightLeft, true, 1)
+        ]
+
+        for testCase in cases {
+            XCTAssertEqual(
+                ReaderPositioning.initialPageIndex(
+                    progress: testCase.progress,
+                    pageCount: testCase.pageCount,
+                    fromStart: testCase.fromStart,
+                    restartFinishedArchive: testCase.restartFinishedArchive,
+                    readDirection: testCase.readDirection,
+                    doublePageLayout: testCase.doublePageLayout
+                ),
+                testCase.expected,
+                testCase.name
+            )
+        }
+    }
+
+    func testCanonicalPageAndScrollAnchorMatrix() {
+        let cases: [PageMappingCase] = [
+            .init("empty archive", 0, .leftRight, false, [0], [0]),
+            .init("one-page spread", 1, .rightLeft, true, [0], [0]),
+            .init("two-page spread", 2, .leftRight, true, [1, 1], [0, 0]),
+            .init("odd final spread", 5, .rightLeft, true, [1, 1, 3, 3, 4], [0, 0, 2, 2, 4]),
+            .init("even final spread", 6, .leftRight, true, [1, 1, 3, 3, 5, 5], [0, 0, 2, 2, 4, 4]),
+            .init("vertical reader", 5, .upDown, true, [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]),
+            .init("single-page reader", 5, .leftRight, false, [0, 1, 2, 3, 4], [0, 1, 2, 3, 4])
+        ]
+
+        for testCase in cases {
+            let indices = testCase.pageCount == 0 ? [0] : Array(0..<testCase.pageCount)
+            let canonicalPages = indices.map {
+                ReaderPositioning.canonicalPageIndex(
+                    forVisibleIndex: $0,
+                    pageCount: testCase.pageCount,
+                    readDirection: testCase.readDirection,
+                    doublePageLayout: testCase.doublePageLayout
+                )
+            }
+            let scrollAnchors = canonicalPages.map {
+                ReaderPositioning.scrollAnchorIndex(
+                    forPageIndex: $0,
+                    pageCount: testCase.pageCount,
+                    readDirection: testCase.readDirection,
+                    doublePageLayout: testCase.doublePageLayout
+                )
+            }
+
+            XCTAssertEqual(canonicalPages, testCase.canonicalPages, testCase.name)
+            XCTAssertEqual(scrollAnchors, testCase.scrollAnchors, testCase.name)
+        }
+    }
+
+    func testAdjacentNavigationMatrix() {
+        let cases: [NavigationCase] = [
+            .init("empty archive", 0, .leftRight, false, []),
+            .init("one-page spread", 1, .rightLeft, true, [0]),
+            .init("single-page reader", 5, .leftRight, false, [0, 1, 2, 3, 4]),
+            .init("vertical reader", 5, .upDown, true, [0, 1, 2, 3, 4]),
+            .init("odd spread reader", 5, .leftRight, true, [1, 3, 4]),
+            .init("even spread reader", 6, .rightLeft, true, [1, 3, 5])
+        ]
+
+        for testCase in cases {
+            guard !testCase.canonicalPages.isEmpty else {
+                XCTAssertNil(adjacentPageIndex(in: testCase, from: 0, direction: .next), testCase.name)
+                XCTAssertNil(adjacentPageIndex(in: testCase, from: 0, direction: .previous), testCase.name)
+                continue
+            }
+            assertAdjacentNavigation(in: testCase)
+        }
+    }
+
+    func testHorizontalReadingDirectionsShareLogicalPositioning() {
+        for pageCount in 0...8 {
+            for doublePageLayout in [false, true] {
+                for pageIndex in -1...pageCount {
+                    let context = "pages=\(pageCount), index=\(pageIndex), double=\(doublePageLayout)"
+                    XCTAssertEqual(
+                        positioningSnapshot(
+                            pageIndex: pageIndex,
+                            pageCount: pageCount,
+                            readDirection: .leftRight,
+                            doublePageLayout: doublePageLayout
+                        ),
+                        positioningSnapshot(
+                            pageIndex: pageIndex,
+                            pageCount: pageCount,
+                            readDirection: .rightLeft,
+                            doublePageLayout: doublePageLayout
+                        ),
+                        context
+                    )
+                }
+            }
+        }
+    }
+
+    func testVerticalReaderIgnoresDoublePageLayout() {
+        for pageCount in 0...8 {
+            for pageIndex in -1...pageCount {
+                let context = "pages=\(pageCount), index=\(pageIndex)"
+                XCTAssertEqual(
+                    positioningSnapshot(
+                        pageIndex: pageIndex,
+                        pageCount: pageCount,
+                        readDirection: .upDown,
+                        doublePageLayout: false
+                    ),
+                    positioningSnapshot(
+                        pageIndex: pageIndex,
+                        pageCount: pageCount,
+                        readDirection: .upDown,
+                        doublePageLayout: true
+                    ),
+                    context
+                )
+            }
+        }
+    }
+
+    private func assertAdjacentNavigation(in testCase: NavigationCase) {
+        for (offset, pageIndex) in testCase.canonicalPages.enumerated() {
+            let previous = offset > 0 ? testCase.canonicalPages[offset - 1] : nil
+            let next = offset < testCase.canonicalPages.count - 1
+                ? testCase.canonicalPages[offset + 1]
+                : nil
+
+            XCTAssertEqual(
+                adjacentPageIndex(in: testCase, from: pageIndex, direction: .previous),
+                previous,
+                "\(testCase.name), previous from \(pageIndex)"
+            )
+            XCTAssertEqual(
+                adjacentPageIndex(in: testCase, from: pageIndex, direction: .next),
+                next,
+                "\(testCase.name), next from \(pageIndex)"
+            )
+        }
+    }
+
+    private func adjacentPageIndex(
+        in testCase: NavigationCase,
+        from pageIndex: Int,
+        direction: ReaderNavigationDirection
+    ) -> Int? {
+        ReaderPositioning.adjacentPageIndex(
+            from: pageIndex,
+            direction: direction,
+            pageCount: testCase.pageCount,
+            readDirection: testCase.readDirection,
+            doublePageLayout: testCase.doublePageLayout
+        )
+    }
+
+    private func positioningSnapshot(
+        pageIndex: Int,
+        pageCount: Int,
+        readDirection: ReadDirection,
+        doublePageLayout: Bool
+    ) -> PositioningSnapshot {
+        PositioningSnapshot(
+            initialPage: ReaderPositioning.initialPageIndex(
+                progress: pageIndex + 1,
+                pageCount: pageCount,
+                fromStart: false,
+                readDirection: readDirection,
+                doublePageLayout: doublePageLayout
+            ),
+            canonicalPage: ReaderPositioning.canonicalPageIndex(
+                forVisibleIndex: pageIndex,
+                pageCount: pageCount,
+                readDirection: readDirection,
+                doublePageLayout: doublePageLayout
+            ),
+            scrollAnchor: ReaderPositioning.scrollAnchorIndex(
+                forPageIndex: pageIndex,
+                pageCount: pageCount,
+                readDirection: readDirection,
+                doublePageLayout: doublePageLayout
+            ),
+            previousPage: ReaderPositioning.adjacentPageIndex(
+                from: pageIndex,
+                direction: .previous,
+                pageCount: pageCount,
+                readDirection: readDirection,
+                doublePageLayout: doublePageLayout
+            ),
+            nextPage: ReaderPositioning.adjacentPageIndex(
+                from: pageIndex,
+                direction: .next,
+                pageCount: pageCount,
+                readDirection: readDirection,
+                doublePageLayout: doublePageLayout
+            )
+        )
+    }
+}
+
+private struct InitialPageCase {
+    let name: String
+    let progress: Int
+    let pageCount: Int
+    let fromStart: Bool
+    let restartFinishedArchive: Bool
+    let readDirection: ReadDirection
+    let doublePageLayout: Bool
+    let expected: Int
+
+    init(
+        _ name: String,
+        _ progress: Int,
+        _ pageCount: Int,
+        _ fromStart: Bool,
+        _ restartFinishedArchive: Bool,
+        _ readDirection: ReadDirection,
+        _ doublePageLayout: Bool,
+        _ expected: Int
+    ) {
+        self.name = name
+        self.progress = progress
+        self.pageCount = pageCount
+        self.fromStart = fromStart
+        self.restartFinishedArchive = restartFinishedArchive
+        self.readDirection = readDirection
+        self.doublePageLayout = doublePageLayout
+        self.expected = expected
+    }
+}
+
+private struct PageMappingCase {
+    let name: String
+    let pageCount: Int
+    let readDirection: ReadDirection
+    let doublePageLayout: Bool
+    let canonicalPages: [Int]
+    let scrollAnchors: [Int]
+
+    init(
+        _ name: String,
+        _ pageCount: Int,
+        _ readDirection: ReadDirection,
+        _ doublePageLayout: Bool,
+        _ canonicalPages: [Int],
+        _ scrollAnchors: [Int]
+    ) {
+        self.name = name
+        self.pageCount = pageCount
+        self.readDirection = readDirection
+        self.doublePageLayout = doublePageLayout
+        self.canonicalPages = canonicalPages
+        self.scrollAnchors = scrollAnchors
+    }
+}
+
+private struct NavigationCase {
+    let name: String
+    let pageCount: Int
+    let readDirection: ReadDirection
+    let doublePageLayout: Bool
+    let canonicalPages: [Int]
+
+    init(
+        _ name: String,
+        _ pageCount: Int,
+        _ readDirection: ReadDirection,
+        _ doublePageLayout: Bool,
+        _ canonicalPages: [Int]
+    ) {
+        self.name = name
+        self.pageCount = pageCount
+        self.readDirection = readDirection
+        self.doublePageLayout = doublePageLayout
+        self.canonicalPages = canonicalPages
+    }
+}
+
+private struct PositioningSnapshot: Equatable {
+    let initialPage: Int
+    let canonicalPage: Int
+    let scrollAnchor: Int
+    let previousPage: Int?
+    let nextPage: Int?
+}


### PR DESCRIPTION
## What changed

- Added table-driven reader positioning invariants for empty and one-page archives, odd and even page counts, horizontal directions, vertical reading, single-page layout, double-page layout, progress bounds, and adjacent navigation.
- Canonicalized the current spread before calculating adjacent double-page navigation.
- Stopped next navigation at the final even-page spread instead of issuing a no-op scroll request.
- Added reducer regression coverage and bumped build 211 to 212 while keeping marketing version 3.9.6.

## Why

The new invariant matrix exposed an even-page boundary defect: navigating next from the final double-page spread returned the current page instead of no destination. These executable contracts protect future AI-assisted changes without introducing a broad coverage target or process ceremony.

## Verification

- `./scripts/verify origin/master` — repository checks and SwiftLint passed; all 192 tests passed.
- `./scripts/test-ios -only-testing:LANreaderTests/ReaderPositioningInvariantTests` — 5 tests passed.
- `./scripts/test-ios -only-testing:LANreaderTests/ArchiveReaderFeatureTests/testNavigateNextAtFinalEvenSpreadDoesNothing` — passed.
- LANreader and Action, Debug and Release resolve to `CURRENT_PROJECT_VERSION = 212` and `MARKETING_VERSION = 3.9.6`.
