### PR TITLE
Display page stamps in reader

### DIFF
--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -45,7 +45,6 @@
 		E902FC4E2CD870530071106B /* UICategoryList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E902FC4D2CD8704E0071106B /* UICategoryList.swift */; };
 		E902FC502CD87A780071106B /* UICategoryArchiveGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = E902FC4F2CD87A710071106B /* UICategoryArchiveGrid.swift */; };
 		E90576B629F6BF8700C3CE3F /* WrappingHStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90576B529F6BF8700C3CE3F /* WrappingHStack.swift */; };
-		E9AA10022E0000020000AA02 /* TagTokenField.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9AA10012E0000010000AA01 /* TagTokenField.swift */; };
 		E90576BF29F8C10700C3CE3F /* Puppy in Frameworks */ = {isa = PBXBuildFile; productRef = E90576BE29F8C10700C3CE3F /* Puppy */; };
 		E90C26CB2C1A7A6D00BE87D9 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = E90C26CA2C1A7A6D00BE87D9 /* ComposableArchitecture */; };
 		E91EE6832CAB78ED0046853C /* UIArchiveReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91EE6822CAB78E80046853C /* UIArchiveReader.swift */; };
@@ -75,6 +74,7 @@
 		E9A4DD122D5ACEA300E16FEC /* UINavigationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A4DD112D5ACE9B00E16FEC /* UINavigationHelper.swift */; };
 		E9A4E0D42F3EE6010099BE6C /* AnimatedImage in Frameworks */ = {isa = PBXBuildFile; productRef = E9A4E0D32F3EE6010099BE6C /* AnimatedImage */; };
 		E9A8612D2BF31534003534FA /* AutomaticPageConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A8612C2BF31534003534FA /* AutomaticPageConfig.swift */; };
+		E9AA10022E0000020000AA02 /* TagTokenField.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9AA10012E0000010000AA01 /* TagTokenField.swift */; };
 		E9AAC1352CBC8FC600E5E89A /* UIPageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9AAC1342CBC8FC600E5E89A /* UIPageCell.swift */; };
 		E9BE57B22942CFEC00A3AEA0 /* LockScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9BE57B12942CFEC00A3AEA0 /* LockScreen.swift */; };
 		E9BFA2052AF51DB500DDE107 /* ArchiveReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9BFA2042AF51DB500DDE107 /* ArchiveReader.swift */; };
@@ -83,8 +83,6 @@
 		E9C354E42CA646D7004C10CD /* UILibraryList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C354E32CA646D3004C10CD /* UILibraryList.swift */; };
 		E9C3550F2CA65101004C10CD /* UIArchiveCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C3550E2CA650FE004C10CD /* UIArchiveCell.swift */; };
 		E9CA49D02F80000100A53A54 /* SearchSuggestionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9CA49D12F80000100A53A54 /* SearchSuggestionCell.swift */; };
-		F1A2B3D62F90000100AAA001 /* SearchKeyword.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3D72F90000100AAA001 /* SearchKeyword.swift */; };
-		F1A2B3D82F90000200AAA001 /* SearchFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3D92F90000200AAA001 /* SearchFeatureTests.swift */; };
 		E9CA49E62E81FF3000A53A54 /* UISearchViewV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9CA49E52E81FF2B00A53A54 /* UISearchViewV2.swift */; };
 		E9CBC0F02A3DD62F00CCD592 /* LogFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9CBC0EF2A3DD62F00CCD592 /* LogFormatter.swift */; };
 		E9DA93612C16960E003272B9 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = E9DA93602C16960E003272B9 /* Localizable.xcstrings */; };
@@ -99,16 +97,18 @@
 		E9F0ABCD2F90000100ABCDEF /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = E9F0ABCC2F90000100ABCDEF /* InfoPlist.xcstrings */; };
 		E9F3B0122B01A21C00F60F62 /* CategoryListV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F3B0112B01A21C00F60F62 /* CategoryListV2.swift */; };
 		F1A2B3C42F60000100AAA001 /* ReaderPositioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C72F60000100AAA001 /* ReaderPositioning.swift */; };
-		F1A2B3F02FB0000100AAA001 /* ReaderPageLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3F12FB0000100AAA001 /* ReaderPageLayout.swift */; };
 		F1A2B3C52F60000100AAA001 /* ArchiveReaderFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C82F60000100AAA001 /* ArchiveReaderFeatureTests.swift */; };
-		F1A2B3D52F60000400DDD001 /* LANraragiConfigFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3D42F60000400DDD001 /* LANraragiConfigFeatureTests.swift */; };
 		F1A2B3C62F60000200AAA001 /* ArchiveDetailsTagParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C92F60000200AAA001 /* ArchiveDetailsTagParserTests.swift */; };
 		F1A2B3CA2F60000300AAA001 /* ArchiveDetailsTagParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3CB2F60000300AAA001 /* ArchiveDetailsTagParser.swift */; };
 		F1A2B3CC2F70000100AAA001 /* ArchiveListFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3CD2F70000100AAA001 /* ArchiveListFeatureTests.swift */; };
 		F1A2B3CE2F80000100AAA001 /* LogTextRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3CF2F80000100AAA001 /* LogTextRendererTests.swift */; };
+		F1A2B3D52F60000400DDD001 /* LANraragiConfigFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3D42F60000400DDD001 /* LANraragiConfigFeatureTests.swift */; };
+		F1A2B3D62F90000100AAA001 /* SearchKeyword.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3D72F90000100AAA001 /* SearchKeyword.swift */; };
+		F1A2B3D82F90000200AAA001 /* SearchFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3D92F90000200AAA001 /* SearchFeatureTests.swift */; };
 		F1A2B3E12FA0000100AAA001 /* PaginationPositioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3E22FA0000100AAA001 /* PaginationPositioning.swift */; };
 		F1A2B3E32FA0000100AAA001 /* PaginationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3E42FA0000100AAA001 /* PaginationBar.swift */; };
 		F1A2B3E52FA0000100AAA001 /* PaginationPositioningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3E62FA0000100AAA001 /* PaginationPositioningTests.swift */; };
+		F1A2B3F02FB0000100AAA001 /* ReaderPageLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3F12FB0000100AAA001 /* ReaderPageLayout.swift */; };
 		F1A2B3F22FC0000100AAA001 /* ReaderPositioningInvariantTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3F32FC0000100AAA001 /* ReaderPositioningInvariantTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -184,7 +184,6 @@
 		E902FC4D2CD8704E0071106B /* UICategoryList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UICategoryList.swift; sourceTree = "<group>"; };
 		E902FC4F2CD87A710071106B /* UICategoryArchiveGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UICategoryArchiveGrid.swift; sourceTree = "<group>"; };
 		E90576B529F6BF8700C3CE3F /* WrappingHStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrappingHStack.swift; sourceTree = "<group>"; };
-		E9AA10012E0000010000AA01 /* TagTokenField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagTokenField.swift; sourceTree = "<group>"; };
 		E91EE6822CAB78E80046853C /* UIArchiveReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIArchiveReader.swift; sourceTree = "<group>"; };
 		E91EE6842CAB94F60046853C /* UIPageCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIPageCollection.swift; sourceTree = "<group>"; };
 		E93C0F862D93ACF400B030AE /* TransactionObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionObserver.swift; sourceTree = "<group>"; };
@@ -215,6 +214,7 @@
 		E9A4DD0D2D558D1E00E16FEC /* UIAppTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIAppTabView.swift; sourceTree = "<group>"; };
 		E9A4DD112D5ACE9B00E16FEC /* UINavigationHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UINavigationHelper.swift; sourceTree = "<group>"; };
 		E9A8612C2BF31534003534FA /* AutomaticPageConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticPageConfig.swift; sourceTree = "<group>"; };
+		E9AA10012E0000010000AA01 /* TagTokenField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagTokenField.swift; sourceTree = "<group>"; };
 		E9AAC1342CBC8FC600E5E89A /* UIPageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIPageCell.swift; sourceTree = "<group>"; };
 		E9BE57B12942CFEC00A3AEA0 /* LockScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LockScreen.swift; path = LANreader/Common/LockScreen.swift; sourceTree = SOURCE_ROOT; };
 		E9BFA2042AF51DB500DDE107 /* ArchiveReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveReader.swift; sourceTree = "<group>"; };
@@ -231,19 +231,19 @@
 		E9F0ABCC2F90000100ABCDEF /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		E9F3B0112B01A21C00F60F62 /* CategoryListV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryListV2.swift; sourceTree = "<group>"; };
 		F1A2B3C72F60000100AAA001 /* ReaderPositioning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPositioning.swift; sourceTree = "<group>"; };
-		F1A2B3F12FB0000100AAA001 /* ReaderPageLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPageLayout.swift; sourceTree = "<group>"; };
 		F1A2B3C82F60000100AAA001 /* ArchiveReaderFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveReaderFeatureTests.swift; sourceTree = "<group>"; };
-		F1A2B3D42F60000400DDD001 /* LANraragiConfigFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LANraragiConfigFeatureTests.swift; sourceTree = "<group>"; };
 		F1A2B3C92F60000200AAA001 /* ArchiveDetailsTagParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailsTagParserTests.swift; sourceTree = "<group>"; };
 		F1A2B3CB2F60000300AAA001 /* ArchiveDetailsTagParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailsTagParser.swift; sourceTree = "<group>"; };
 		F1A2B3CD2F70000100AAA001 /* ArchiveListFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveListFeatureTests.swift; sourceTree = "<group>"; };
 		F1A2B3CF2F80000100AAA001 /* LogTextRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogTextRendererTests.swift; sourceTree = "<group>"; };
+		F1A2B3D42F60000400DDD001 /* LANraragiConfigFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LANraragiConfigFeatureTests.swift; sourceTree = "<group>"; };
+		F1A2B3D72F90000100AAA001 /* SearchKeyword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKeyword.swift; sourceTree = "<group>"; };
+		F1A2B3D92F90000200AAA001 /* SearchFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFeatureTests.swift; sourceTree = "<group>"; };
 		F1A2B3E22FA0000100AAA001 /* PaginationPositioning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationPositioning.swift; sourceTree = "<group>"; };
 		F1A2B3E42FA0000100AAA001 /* PaginationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationBar.swift; sourceTree = "<group>"; };
 		F1A2B3E62FA0000100AAA001 /* PaginationPositioningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationPositioningTests.swift; sourceTree = "<group>"; };
+		F1A2B3F12FB0000100AAA001 /* ReaderPageLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPageLayout.swift; sourceTree = "<group>"; };
 		F1A2B3F32FC0000100AAA001 /* ReaderPositioningInvariantTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPositioningInvariantTests.swift; sourceTree = "<group>"; };
-		F1A2B3D72F90000100AAA001 /* SearchKeyword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKeyword.swift; sourceTree = "<group>"; };
-		F1A2B3D92F90000200AAA001 /* SearchFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFeatureTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -979,7 +979,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreader.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 214;
+				CURRENT_PROJECT_VERSION = 215;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -990,7 +990,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.9.6;
+				MARKETING_VERSION = 3.10.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1007,7 +1007,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreaderRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 214;
+				CURRENT_PROJECT_VERSION = 215;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1018,7 +1018,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.9.6;
+				MARKETING_VERSION = 3.10.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1081,7 +1081,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 214;
+				CURRENT_PROJECT_VERSION = 215;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1093,7 +1093,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.9.6;
+				MARKETING_VERSION = 3.10.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1111,7 +1111,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 214;
+				CURRENT_PROJECT_VERSION = 215;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1123,7 +1123,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.9.6;
+				MARKETING_VERSION = 3.10.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/LANreader.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/LANreader.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sushichop/Puppy",
       "state" : {
-        "revision" : "1a2f5d511e64c7e98ccb36249215944727351bcc",
-        "version" : "0.10.0"
+        "revision" : "c095c2abf314d84ed43bcfe0e7e8fe1e0c9007f0",
+        "version" : "0.11.0"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "794f4b0a9cf32042592388d014f6a1ea987d323a",
-        "version" : "1.9.1"
+        "revision" : "1866d1046fd4e54d590af6be5b23de6ca3af2bf9",
+        "version" : "1.9.2"
       }
     },
     {
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "8dc1fbf2f6255a73dec53b4648164884898db4c5",
-        "version" : "1.14.1"
+        "revision" : "5e0815746534ccaa9e20588ea35d3bb2cb27bab8",
+        "version" : "1.17.0"
       }
     },
     {
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "8f6abcf4c8950e2679d5b2fee4ca284fd7c34886",
-        "version" : "1.11.0"
+        "revision" : "7bbd97af585672a3dcdf6575ad37b339ad41b579",
+        "version" : "1.13.0"
       }
     }
   ],

--- a/LANreader/Models/AppModels.swift
+++ b/LANreader/Models/AppModels.swift
@@ -103,6 +103,7 @@ struct SettingsKey {
     static let autoPageInterval = "settings:read:auto:page:interval"
     static let doublePageLayout = "settings:read:double:page"
     static let fitPageWidth = "settings:read:fit:page:width"
+    static let showStamps = "settings:read:show:stamps"
     static let restartFinished = "settings:read:restart:finished"
 
     static let searchSort = "settings:search:sort"

--- a/LANreader/Models/LANraragiResponse.swift
+++ b/LANreader/Models/LANraragiResponse.swift
@@ -43,6 +43,40 @@ struct ArchiveExtractResponse: Decodable {
     let pages: [String]
 }
 
+struct ArchiveStampsResponse: Decodable, Equatable, Sendable {
+    let result: [ArchiveStamp]
+}
+
+public struct ArchiveStamp: Decodable, Equatable, Sendable {
+    let id: String?
+    let position: String
+    let content: String
+
+    var normalizedPosition: ArchiveStampPosition? {
+        ArchiveStampPosition(rawValue: position)
+    }
+}
+
+struct ArchiveStampPosition: Equatable, Sendable {
+    let horizontalPercentage: Double
+    let verticalPercentage: Double
+
+    init?(rawValue: String) {
+        let components = rawValue.split(separator: ",", omittingEmptySubsequences: false)
+        guard components.count == 2,
+              let horizontalPercentage = Double(components[0].trimmingCharacters(in: .whitespaces)),
+              let verticalPercentage = Double(components[1].trimmingCharacters(in: .whitespaces)),
+              horizontalPercentage.isFinite,
+              verticalPercentage.isFinite,
+              (0...100).contains(horizontalPercentage),
+              (0...100).contains(verticalPercentage) else {
+            return nil
+        }
+        self.horizontalPercentage = horizontalPercentage
+        self.verticalPercentage = verticalPercentage
+    }
+}
+
 struct ArchiveCategoriesResponse: Decodable {
     let archives: [String]
     let id: String

--- a/LANreader/Page/ArchiveReader.swift
+++ b/LANreader/Page/ArchiveReader.swift
@@ -46,6 +46,7 @@ public struct SliderPreviewThumbnailQueueResult: Equatable, Sendable {
         @SharedReader(.appStorage(SettingsKey.autoPageInterval)) var autoPageInterval = 5.0
         @Shared(.appStorage(SettingsKey.doublePageLayout)) var doublePageLayout = false
         @SharedReader(.appStorage(SettingsKey.fitPageWidth)) var fitPageWidth = false
+        @Shared(.appStorage(SettingsKey.showStamps)) var showStamps = false
         @SharedReader(.appStorage(SettingsKey.restartFinished)) var restartFinished = false
 
         var currentArchiveId = ""
@@ -151,6 +152,7 @@ public struct SliderPreviewThumbnailQueueResult: Equatable, Sendable {
         case pageAspectRatiosPrimed([Int: Double])
         case toggleControlUi(Bool?)
         case toggleDoublePageLayout
+        case toggleStampsVisibility
         case visiblePageChanged(Int)
         case chapterSelected(Int)
         case requestJump(Int, source: ReaderNavigationSource)
@@ -210,7 +212,7 @@ public struct SliderPreviewThumbnailQueueResult: Equatable, Sendable {
             AutomaticPageFeature()
         }
 
-        Reduce { state, action in
+        Reduce<State, Action> { (state: inout State, action: Action) -> Effect<Action> in
             switch action {
             case .loadCached:
                state.extracting = true
@@ -221,7 +223,7 @@ public struct SliderPreviewThumbnailQueueResult: Equatable, Sendable {
                if let content = try? FileManager.default.contentsOfDirectory(
                    at: cacheFolder, includingPropertiesForKeys: []
                ) {
-                   let pageState = content.compactMap { url in
+                   let pageState: [PageFeature.State] = content.compactMap { url in
                        let page = url.deletingPathExtension().lastPathComponent
                        if let pageNumber = Int(page) {
                            return PageFeature.State(archiveId: id, pageId: page, pageNumber: pageNumber, cached: true)
@@ -408,6 +410,10 @@ public struct SliderPreviewThumbnailQueueResult: Equatable, Sendable {
                     spreadOffset: state.spreadPairingOffset
                 )
                 return .send(.requestJump(targetIndex, source: .layoutChange))
+            case .toggleStampsVisibility:
+                let showsStamps = !state.showStamps
+                state.$showStamps.withLock { $0 = showsStamps }
+                return .none
             case let .visiblePageChanged(index):
                 guard !state.pages.isEmpty else { return .none }
                 let clampedIndex = ReaderPositioning.clampedPageIndex(index, pageCount: state.pages.count)
@@ -1502,6 +1508,17 @@ struct ArchiveReader: View {
         let cacheActionRemoves = store.cached || store.inCache
 
         return Menu {
+            Button {
+                store.send(.toggleStampsVisibility)
+            } label: {
+                if store.showStamps {
+                    Label("archive.reader.stamps.hide", systemImage: "mappin.slash")
+                } else {
+                    Label("archive.reader.stamps.show", systemImage: "mappin")
+                }
+            }
+            .disabled(store.cached)
+
             Button {
                 store.send(.setThumbnail)
             } label: {

--- a/LANreader/Page/PageImageV2.swift
+++ b/LANreader/Page/PageImageV2.swift
@@ -24,6 +24,9 @@ import Logging
         let cached: Bool
         var imageLoaded = false
         var translationStatus = ""
+        var stamps: [ArchiveStamp] = []
+        var stampsLoading = false
+        var stampsLoaded = false
         /// Aspect ratio (height / width) of the source image, measured from the image header.
         var imageAspectRatio: Double?
 
@@ -69,6 +72,9 @@ import Logging
 
     public enum Action: Equatable {
         case load(Bool)
+        case loadStamps
+        case stampsLoaded([ArchiveStamp])
+        case stampsLoadFailed
         case setIsLoading(Bool)
         case subscribeToProgress(DownloadRequest)
         case cancelSubscribeImageProgress
@@ -86,11 +92,44 @@ import Logging
     public enum CancelId: Sendable {
         case imageLoad
         case imageProgress
+        case stampsLoad
     }
 
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
+            case .loadStamps:
+                guard !state.cached, !state.stampsLoading, !state.stampsLoaded else {
+                    return .none
+                }
+                state.stampsLoading = true
+                let archiveId = state.sourceArchiveId
+                let page = state.sourcePageNumber
+                return .run { send in
+                    do {
+                        let response = try await service.retrieveStamps(id: archiveId, page: page).value
+                        await send(.stampsLoaded(response.result))
+                    } catch is CancellationError {
+                        return
+                    } catch {
+                        logger.warning(
+                            "failed to load stamps. archive=\(archiveId) page=\(page) \(error.localizedDescription)"
+                        )
+                        await send(.stampsLoadFailed)
+                    }
+                }
+                .cancellable(id: CancelId.stampsLoad, cancelInFlight: true)
+            case let .stampsLoaded(stamps):
+                state.stamps = stamps
+                state.stampsLoading = false
+                state.stampsLoaded = true
+                return .none
+            case .stampsLoadFailed:
+                // Older LANraragi servers do not expose stamps. Keep reading unaffected and avoid
+                // retrying the unsupported endpoint every time this cell becomes visible.
+                state.stampsLoading = false
+                state.stampsLoaded = true
+                return .none
             case let .subscribeToProgress(progress):
                 return .run(priority: .utility) { send in
                     var step: Double = 0.0

--- a/LANreader/Page/UIPageCell.swift
+++ b/LANreader/Page/UIPageCell.swift
@@ -22,6 +22,261 @@ private final class PreviewAwareAnimatedImageView: AnimatedImageView {
     }
 }
 
+enum StampOverlayPositioning {
+    static func displayedPosition(
+        _ position: ArchiveStampPosition,
+        pageMode: PageMode
+    ) -> ArchiveStampPosition? {
+        switch pageMode {
+        case .left:
+            guard position.horizontalPercentage < 50 else { return nil }
+            return ArchiveStampPosition(
+                horizontalPercentage: position.horizontalPercentage * 2,
+                verticalPercentage: position.verticalPercentage
+            )
+        case .right:
+            guard position.horizontalPercentage >= 50 else { return nil }
+            return ArchiveStampPosition(
+                horizontalPercentage: (position.horizontalPercentage - 50) * 2,
+                verticalPercentage: position.verticalPercentage
+            )
+        case .loading, .normal, .error:
+            return position
+        }
+    }
+
+    static func aspectFitRect(imageSize: CGSize, in bounds: CGRect) -> CGRect? {
+        guard imageSize.width > 0,
+              imageSize.height > 0,
+              bounds.width > 0,
+              bounds.height > 0 else {
+            return nil
+        }
+        let scale = min(bounds.width / imageSize.width, bounds.height / imageSize.height)
+        let size = CGSize(width: imageSize.width * scale, height: imageSize.height * scale)
+        return CGRect(
+            x: bounds.midX - size.width / 2,
+            y: bounds.midY - size.height / 2,
+            width: size.width,
+            height: size.height
+        )
+    }
+}
+
+private extension ArchiveStampPosition {
+    init(horizontalPercentage: Double, verticalPercentage: Double) {
+        self.horizontalPercentage = horizontalPercentage
+        self.verticalPercentage = verticalPercentage
+    }
+}
+
+private final class StampCommentLabel: UILabel {
+    private let contentInsets = UIEdgeInsets(top: 8, left: 10, bottom: 8, right: 10)
+
+    override func drawText(in rect: CGRect) {
+        super.drawText(in: rect.inset(by: contentInsets))
+    }
+
+    override func sizeThatFits(_ size: CGSize) -> CGSize {
+        let contentSize = CGSize(
+            width: max(0, size.width - contentInsets.left - contentInsets.right),
+            height: max(0, size.height - contentInsets.top - contentInsets.bottom)
+        )
+        let labelSize = super.sizeThatFits(contentSize)
+        return CGSize(
+            width: labelSize.width + contentInsets.left + contentInsets.right,
+            height: labelSize.height + contentInsets.top + contentInsets.bottom
+        )
+    }
+}
+
+private final class StampOverlayView: UIView {
+    private struct DisplayedStamp {
+        let sourceIndex: Int
+        let stamp: ArchiveStamp
+        let position: ArchiveStampPosition
+    }
+
+    private let markerSize: CGFloat = 30
+    private let calloutSpacing: CGFloat = 6
+    private var stamps: [ArchiveStamp] = []
+    private var displayedStamps: [DisplayedStamp] = []
+    private var markerButtons: [UIButton] = []
+    private var selectedSourceIndex: Int?
+    private var imageSize: CGSize?
+    private var pageMode: PageMode = .normal
+
+    private let commentLabel: StampCommentLabel = {
+        let label = StampCommentLabel()
+        label.backgroundColor = UIColor.secondarySystemBackground.withAlphaComponent(0.96)
+        label.textColor = .label
+        label.font = .preferredFont(forTextStyle: .callout)
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
+        label.layer.cornerRadius = 8
+        label.layer.cornerCurve = .continuous
+        label.layer.borderWidth = 1
+        label.layer.borderColor = UIColor.separator.withAlphaComponent(0.35).cgColor
+        label.clipsToBounds = true
+        label.isHidden = true
+        label.isUserInteractionEnabled = false
+        return label
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .clear
+        addSubview(commentLabel)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(stamps: [ArchiveStamp], pageMode: PageMode, imageSize: CGSize?) {
+        let contentsChanged = self.stamps != stamps || self.pageMode != pageMode
+        self.stamps = stamps
+        self.pageMode = pageMode
+        self.imageSize = imageSize
+        if contentsChanged {
+            rebuildMarkers()
+        }
+        setNeedsLayout()
+    }
+
+    func clear() {
+        stamps = []
+        displayedStamps = []
+        imageSize = nil
+        selectedSourceIndex = nil
+        markerButtons.forEach { $0.removeFromSuperview() }
+        markerButtons = []
+        commentLabel.isHidden = true
+        commentLabel.text = nil
+    }
+
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        markerButtons.contains { !$0.isHidden && $0.frame.insetBy(dx: -4, dy: -4).contains(point) }
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        guard let imageSize,
+              let imageRect = StampOverlayPositioning.aspectFitRect(imageSize: imageSize, in: bounds) else {
+            markerButtons.forEach { $0.isHidden = true }
+            commentLabel.isHidden = true
+            return
+        }
+
+        for (index, displayedStamp) in displayedStamps.enumerated() {
+            let button = markerButtons[index]
+            let point = CGPoint(
+                x: imageRect.minX
+                    + imageRect.width * CGFloat(displayedStamp.position.horizontalPercentage / 100),
+                y: imageRect.minY
+                    + imageRect.height * CGFloat(displayedStamp.position.verticalPercentage / 100)
+            )
+            let origin = CGPoint(
+                x: min(max(point.x - markerSize / 2, imageRect.minX), imageRect.maxX - markerSize),
+                y: min(max(point.y - markerSize / 2, imageRect.minY), imageRect.maxY - markerSize)
+            )
+            button.frame = CGRect(origin: origin, size: CGSize(width: markerSize, height: markerSize))
+            button.isHidden = false
+        }
+
+        layoutComment(in: imageRect)
+    }
+
+    private func rebuildMarkers() {
+        markerButtons.forEach { $0.removeFromSuperview() }
+        markerButtons = []
+        displayedStamps = stamps.enumerated().compactMap { index, stamp in
+            guard let position = stamp.normalizedPosition,
+                  let displayedPosition = StampOverlayPositioning.displayedPosition(
+                    position,
+                    pageMode: pageMode
+                  ) else {
+                return nil
+            }
+            return DisplayedStamp(sourceIndex: index, stamp: stamp, position: displayedPosition)
+        }
+
+        if !displayedStamps.contains(where: { $0.sourceIndex == selectedSourceIndex }) {
+            selectedSourceIndex = nil
+        }
+
+        for displayedStamp in displayedStamps {
+            let button = UIButton(type: .system)
+            button.setImage(UIImage(systemName: "seal.fill"), for: .normal)
+            button.tintColor = .white
+            button.backgroundColor = .systemOrange
+            button.layer.cornerRadius = markerSize / 2
+            button.layer.cornerCurve = .continuous
+            button.layer.shadowColor = UIColor.black.cgColor
+            button.layer.shadowOpacity = 0.3
+            button.layer.shadowRadius = 2
+            button.layer.shadowOffset = CGSize(width: 0, height: 1)
+            button.accessibilityLabel = displayedStamp.stamp.content
+            button.addAction(
+                UIAction { [weak self] _ in
+                    self?.toggleComment(for: displayedStamp.sourceIndex)
+                },
+                for: .touchUpInside
+            )
+            addSubview(button)
+            markerButtons.append(button)
+        }
+        bringSubviewToFront(commentLabel)
+    }
+
+    private func toggleComment(for sourceIndex: Int) {
+        selectedSourceIndex = selectedSourceIndex == sourceIndex ? nil : sourceIndex
+        setNeedsLayout()
+    }
+
+    private func layoutComment(in imageRect: CGRect) {
+        guard let selectedSourceIndex,
+              let selectedIndex = displayedStamps.firstIndex(where: { $0.sourceIndex == selectedSourceIndex }),
+              displayedStamps.indices.contains(selectedIndex),
+              markerButtons.indices.contains(selectedIndex) else {
+            commentLabel.isHidden = true
+            commentLabel.text = nil
+            return
+        }
+
+        let content = displayedStamps[selectedIndex].stamp.content
+        guard !content.isEmpty else {
+            commentLabel.isHidden = true
+            commentLabel.text = nil
+            return
+        }
+
+        commentLabel.text = content
+        let maxWidth = min(280, imageRect.width)
+        let fittedSize = commentLabel.sizeThatFits(
+            CGSize(width: maxWidth, height: max(imageRect.height, 1))
+        )
+        let calloutSize = CGSize(
+            width: min(fittedSize.width, maxWidth),
+            height: min(fittedSize.height, imageRect.height)
+        )
+        let markerFrame = markerButtons[selectedIndex].frame
+        let proposedY = markerFrame.maxY + calloutSpacing
+        let verticalOrigin = proposedY + calloutSize.height <= imageRect.maxY
+            ? proposedY
+            : max(imageRect.minY, markerFrame.minY - calloutSpacing - calloutSize.height)
+        let horizontalOrigin = min(
+            max(markerFrame.midX - calloutSize.width / 2, imageRect.minX),
+            imageRect.maxX - calloutSize.width
+        )
+        commentLabel.frame = CGRect(
+            origin: CGPoint(x: horizontalOrigin, y: verticalOrigin),
+            size: calloutSize
+        )
+        commentLabel.isHidden = false
+    }
+}
+
 class UIPageCell: UICollectionViewCell {
     static let reuseIdentifier = "UIPageCell"
 
@@ -68,6 +323,8 @@ class UIPageCell: UICollectionViewCell {
         return view
     }()
 
+    private let stampOverlayView = StampOverlayView()
+
     private let progressView: UIProgressView = {
         let view = UIProgressView(progressViewStyle: .default)
         view.progressTintColor = .label
@@ -105,6 +362,7 @@ class UIPageCell: UICollectionViewCell {
         scrollView.addSubview(imageContainerView)
         imageContainerView.addSubview(imageView)
         imageContainerView.addSubview(animatedImageView)
+        setupStampOverlay()
         contentView.addSubview(progressView)
         contentView.addSubview(progressViewLabel)
 
@@ -161,11 +419,24 @@ class UIPageCell: UICollectionViewCell {
         ])
     }
 
-    func configure(with store: StoreOf<PageFeature>, fitPageWidth: Bool) {
+    private func setupStampOverlay() {
+        imageContainerView.addSubview(stampOverlayView)
+        stampOverlayView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            stampOverlayView.topAnchor.constraint(equalTo: imageContainerView.topAnchor),
+            stampOverlayView.leadingAnchor.constraint(equalTo: imageContainerView.leadingAnchor),
+            stampOverlayView.trailingAnchor.constraint(equalTo: imageContainerView.trailingAnchor),
+            stampOverlayView.bottomAnchor.constraint(equalTo: imageContainerView.bottomAnchor)
+        ])
+    }
+
+    func configure(with store: StoreOf<PageFeature>, fitPageWidth: Bool, showsStamps: Bool) {
         // Tear down any existing observation from a previous page assignment
         cancelSubscriptions()
         animatedImageView.resetFirstFrameState()
         self.fitPageWidth = fitPageWidth
+        stampOverlayView.clear()
+        stampOverlayView.isHidden = !showsStamps
         resetImageLayout()
         self.store = store
         imageView.image = nil
@@ -179,6 +450,9 @@ class UIPageCell: UICollectionViewCell {
         scrollView.setContentOffset(.zero, animated: false)
         setupObserve(store: store)
         renderCurrentState(store: store)
+        if showsStamps {
+            store.send(.loadStamps)
+        }
     }
 
     func setFitPageWidth(_ fitPageWidth: Bool) {
@@ -186,6 +460,14 @@ class UIPageCell: UICollectionViewCell {
         self.fitPageWidth = fitPageWidth
         scrollView.zoomScale = 1.0
         updateImageLayout(for: imageView.image?.size)
+    }
+
+    func setShowsStamps(_ showsStamps: Bool) {
+        stampOverlayView.isHidden = !showsStamps
+        if showsStamps {
+            store?.send(.loadStamps)
+            updateStampOverlay()
+        }
     }
 
     func setupObserve(store: StoreOf<PageFeature>) {
@@ -204,6 +486,8 @@ class UIPageCell: UICollectionViewCell {
                 format: "%.2f%%", progress * 100)
         }
         .store(in: &observationTokens)
+
+        observeStamps(store: store)
 
         SwiftNavigation.observe { [weak self] in
             let status = store.translationStatus
@@ -232,6 +516,21 @@ class UIPageCell: UICollectionViewCell {
                 progressView.isHidden = true
                 progressViewLabel.text = store.errorMessage
             }
+        }
+        .store(in: &observationTokens)
+    }
+
+    private func observeStamps(store: StoreOf<PageFeature>) {
+        SwiftNavigation.observe { [weak self] in
+            let stamps = store.stamps
+            let pageMode = store.pageMode
+            guard let self else { return }
+            guard self.store === store else { return }
+            self.stampOverlayView.configure(
+                stamps: stamps,
+                pageMode: pageMode,
+                imageSize: self.imageView.image?.size
+            )
         }
         .store(in: &observationTokens)
     }
@@ -363,6 +662,7 @@ class UIPageCell: UICollectionViewCell {
               let aspectRatio = Self.fitWidthAspectRatio(for: imageSize) else {
             contentView.layoutIfNeeded()
             scrollView.setContentOffset(.zero, animated: false)
+            updateStampOverlay()
             return
         }
 
@@ -374,6 +674,16 @@ class UIPageCell: UICollectionViewCell {
         fitWidthAspectConstraint?.isActive = true
         contentView.layoutIfNeeded()
         scrollView.setContentOffset(.zero, animated: false)
+        updateStampOverlay()
+    }
+
+    private func updateStampOverlay() {
+        guard let store else { return }
+        stampOverlayView.configure(
+            stamps: store.stamps,
+            pageMode: store.pageMode,
+            imageSize: imageView.image?.size
+        )
     }
 
     static func fitWidthAspectRatio(for imageSize: CGSize) -> CGFloat? {
@@ -396,6 +706,8 @@ class UIPageCell: UICollectionViewCell {
         scrollView.zoomScale = 1.0
         scrollView.setContentOffset(.zero, animated: false)
         fitPageWidth = false
+        stampOverlayView.clear()
+        stampOverlayView.isHidden = true
         resetImageLayout()
     }
 }

--- a/LANreader/Page/UIPageCollection.swift
+++ b/LANreader/Page/UIPageCollection.swift
@@ -25,6 +25,7 @@ enum ReaderCollectionItem: Hashable {
     case page(String)
 }
 
+// swiftlint:disable type_body_length
 class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
     let store: StoreOf<ArchiveReaderFeature>
     var collectionView: UICollectionView!
@@ -176,7 +177,11 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
         let pageCellRegistration = UICollectionView
             .CellRegistration<UIPageCell, String> { [weak self] cell, _, pageId in
                 guard let self, let pageStore = self.pageStore(id: pageId) else { return }
-                cell.configure(with: pageStore, fitPageWidth: self.usesFitPageWidth)
+                cell.configure(
+                    with: pageStore,
+                    fitPageWidth: self.usesFitPageWidth,
+                    showsStamps: self.store.showStamps
+                )
             }
         let placeholderCellRegistration = UICollectionView
             .CellRegistration<UICollectionViewCell, ReaderCollectionItem> { cell, _, _ in
@@ -341,6 +346,13 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
             collectionView.visibleCells
                 .compactMap { $0 as? UIPageCell }
                 .forEach { $0.setFitPageWidth(fitPageWidth) }
+        }
+        observe { [weak self] in
+            guard let self else { return }
+            let showsStamps = store.showStamps
+            collectionView.visibleCells
+                .compactMap { $0 as? UIPageCell }
+                .forEach { $0.setShowsStamps(showsStamps) }
         }
     }
 
@@ -606,6 +618,7 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
         case main
     }
 }
+// swiftlint:enable type_body_length
 
 private extension UIPageCollectionController {
     func consumePendingScrollRequestIfPossible() {

--- a/LANreader/Service/LANraragiService.swift
+++ b/LANreader/Service/LANraragiService.swift
@@ -393,6 +393,12 @@ actor LANraragiService {
         }
     }
 
+    func retrieveStamps(id: String, page: Int) async -> DataTask<ArchiveStampsResponse> {
+        session.request("\(url)/api/archives/\(id)/stamps/\(page)", method: .get)
+            .validate(statusCode: 200...200)
+            .serializingDecodable(ArchiveStampsResponse.self)
+    }
+
     private func resolveArchivePageURL(page: String) -> URL {
         let baseURL = getDomainURL(from: self.url)
         return URL(string: page, relativeTo: baseURL)!.absoluteURL

--- a/LANreaderTests/ArchiveReaderFeatureTests.swift
+++ b/LANreaderTests/ArchiveReaderFeatureTests.swift
@@ -12,6 +12,7 @@ final class ArchiveReaderFeatureTests: XCTestCase {
         UserDefaults.standard.removeObject(forKey: SettingsKey.readDirection)
         UserDefaults.standard.removeObject(forKey: SettingsKey.doublePageLayout)
         UserDefaults.standard.removeObject(forKey: SettingsKey.fitPageWidth)
+        UserDefaults.standard.removeObject(forKey: SettingsKey.showStamps)
         UserDefaults.standard.removeObject(forKey: SettingsKey.autoPageInterval)
         UserDefaults.standard.removeObject(forKey: SettingsKey.splitWideImage)
         UserDefaults.standard.removeObject(forKey: SettingsKey.splitPiorityLeft)
@@ -58,6 +59,96 @@ final class ArchiveReaderFeatureTests: XCTestCase {
             1.5
         )
         XCTAssertNil(UIPageCell.fitWidthAspectRatio(for: CGSize(width: 0, height: 1_500)))
+    }
+
+    func testStampPositionParsesNormalizedCoordinates() {
+        XCTAssertEqual(
+            ArchiveStampPosition(rawValue: " 12.5,100 "),
+            ArchiveStampPosition(rawValue: "12.5,100")
+        )
+        XCTAssertNil(ArchiveStampPosition(rawValue: "-1,50"))
+        XCTAssertNil(ArchiveStampPosition(rawValue: "50,101"))
+        XCTAssertNil(ArchiveStampPosition(rawValue: "not-a-position"))
+    }
+
+    func testStampPositioningMapsStampsOntoSplitPageHalves() {
+        let leftPosition = ArchiveStampPosition(rawValue: "25,30")!
+        let rightPosition = ArchiveStampPosition(rawValue: "75,30")!
+
+        XCTAssertEqual(
+            StampOverlayPositioning.displayedPosition(leftPosition, pageMode: .left),
+            ArchiveStampPosition(rawValue: "50,30")
+        )
+        XCTAssertNil(StampOverlayPositioning.displayedPosition(rightPosition, pageMode: .left))
+        XCTAssertEqual(
+            StampOverlayPositioning.displayedPosition(rightPosition, pageMode: .right),
+            ArchiveStampPosition(rawValue: "50,30")
+        )
+        XCTAssertNil(StampOverlayPositioning.displayedPosition(leftPosition, pageMode: .right))
+    }
+
+    func testStampPositioningUsesRenderedAspectFitImageRect() {
+        XCTAssertEqual(
+            StampOverlayPositioning.aspectFitRect(
+                imageSize: CGSize(width: 1_000, height: 500),
+                in: CGRect(x: 0, y: 0, width: 400, height: 400)
+            ),
+            CGRect(x: 0, y: 100, width: 400, height: 200)
+        )
+    }
+
+    @MainActor
+    func testToggleStampsVisibility() async {
+        let state = makeState()
+        state.$showStamps = Shared(value: false)
+        let store = makeTestStore(initialState: state)
+
+        await store.send(.toggleStampsVisibility) {
+            $0.$showStamps.withLock { $0 = true }
+        }
+    }
+
+    @MainActor
+    func testCachedPageDoesNotLoadStampsFromServer() async {
+        let store = TestStore(
+            initialState: PageFeature.State(
+                archiveId: "archive",
+                pageId: "1",
+                pageNumber: 1,
+                cached: true
+            )
+        ) {
+            PageFeature()
+        }
+
+        await store.send(.loadStamps)
+    }
+
+    @MainActor
+    func testPageLoadsStampsUsingSourceArchiveAndPage() async throws {
+        try await configureVerifiedClient()
+        let stamp = ArchiveStamp(id: "stamp", position: "12,34", content: "Comment")
+        stubArchiveStamps(archiveId: "source", page: 4)
+        let store = TestStore(
+            initialState: PageFeature.State(
+                archiveId: "tank",
+                pageId: "page",
+                pageNumber: 8,
+                sourceArchiveId: "source",
+                sourcePageNumber: 4
+            )
+        ) {
+            PageFeature()
+        }
+
+        await store.send(.loadStamps) {
+            $0.stampsLoading = true
+        }
+        await store.receive(.stampsLoaded([stamp])) {
+            $0.stamps = [stamp]
+            $0.stampsLoading = false
+            $0.stampsLoaded = true
+        }
     }
 
     func testReaderPageLayoutValidatedAspectRatio() {
@@ -3098,6 +3189,25 @@ private func loadedPageState(
     )
     state.imageLoaded = true
     return state
+}
+
+private func stubArchiveStamps(archiveId: String, page: Int) {
+    stub(condition: isHost("localhost")
+            && isPath("/api/archives/\(archiveId)/stamps/\(page)")
+            && isMethodGET()
+            && hasHeaderNamed("Authorization", value: "Bearer YXBpS2V5")) { _ in
+        HTTPStubsResponse(
+            data: Data("""
+            {
+              "result": [
+                { "id": "stamp", "position": "12,34", "content": "Comment" }
+              ]
+            }
+            """.utf8),
+            statusCode: 200,
+            headers: ["Content-Type": "application/json"]
+        )
+    }
 }
 
 private func makePageStates(

--- a/LANreaderTests/Service/LANraragiServiceTest.swift
+++ b/LANreaderTests/Service/LANraragiServiceTest.swift
@@ -118,6 +118,41 @@ class LANraragiServiceTest: XCTestCase {
         XCTAssertEqual(actual[0].title, "title")
     }
 
+    func testRetrieveStampsUsesOneBasedPagePath() async throws {
+        try await configureVerifiedClient()
+
+        let response = Data("""
+        {
+          "result": [
+            {
+              "id": "STAMPS_3_1777224824662",
+              "position": "12.5,34",
+              "content": "Translation note"
+            }
+          ]
+        }
+        """.utf8)
+        stub(condition: isHost("localhost")
+                && isPath("/api/archives/\(archiveId)/stamps/3")
+                && isMethodGET()
+                && hasHeaderNamed("Authorization", value: "Bearer YXBpS2V5")) { _ in
+            HTTPStubsResponse(data: response, statusCode: 200, headers: ["Content-Type": "application/json"])
+        }
+
+        let actual = try await service.retrieveStamps(id: archiveId, page: 3).value
+
+        XCTAssertEqual(
+            actual.result,
+            [
+                ArchiveStamp(
+                    id: "STAMPS_3_1777224824662",
+                    position: "12.5,34",
+                    content: "Translation note"
+                )
+            ]
+        )
+    }
+
     func testRetrieveArchiveThumbnailReturnsImageData() async throws {
         try await configureVerifiedClient()
 

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -1781,6 +1781,76 @@
         }
       }
     },
+    "archive.reader.stamps.hide" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hide stamps"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スタンプを非表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스탬프 숨기기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隐藏图章"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱藏圖章"
+          }
+        }
+      }
+    },
+    "archive.reader.stamps.show" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show stamps"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スタンプを表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스탬프 표시"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示图章"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示圖章"
+          }
+        }
+      }
+    },
     "archive.reader.page.accessibility %lld %lld" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/ci_scripts/macros.json
+++ b/ci_scripts/macros.json
@@ -1,6 +1,6 @@
 [
   {
-    "fingerprint" : "794f4b0a9cf32042592388d014f6a1ea987d323a",
+    "fingerprint" : "1866d1046fd4e54d590af6be5b23de6ca3af2bf9",
     "packageIdentity" : "swift-case-paths",
     "targetName" : "CasePathsMacros"
   },
@@ -10,7 +10,7 @@
     "targetName" : "ComposableArchitectureMacros"
   },
   {
-    "fingerprint" : "8dc1fbf2f6255a73dec53b4648164884898db4c5",
+    "fingerprint" : "5e0815746534ccaa9e20588ea35d3bb2cb27bab8",
     "packageIdentity" : "swift-dependencies",
     "targetName" : "DependenciesMacrosPlugin"
   },


### PR DESCRIPTION
## Change

Display existing LANraragi page stamps in the reader as positioned markers with tappable comments. Add a persisted Show/Hide stamps menu action, keep cached archives offline, support split and Tankoubon source-page mapping, and localize the new menu labels.

This is limited to reading existing stamps; creating, editing, and deleting stamps remain out of scope. The change also includes the approved dependency updates and synchronizes LANreader and Action at version 3.10.0, build 215.

## Risk surface

- [x] Reader, navigation, image rendering, cache, or Tankoubon behavior
- [x] LANraragi request or response contract
- [x] Persistence, migration, or offline behavior
- [x] Localized user interface
- [x] Xcode project, dependency, CI, or release automation
- [ ] None of the above

## Evidence

Commands run and outcomes:

- `./scripts/verify`: repository checks passed, SwiftLint reported 0 violations, and all 204 iOS tests passed.
- `xcodebuild -project LANreader.xcodeproj -scheme LANreader -showBuildSettings -json`: LANreader resolved to 3.10.0 (215).
- `xcodebuild -project LANreader.xcodeproj -scheme Action -showBuildSettings -json`: Action and LANreader resolved to 3.10.0 (215).
- `git diff --check`: passed.
- Official release notes were reviewed for Puppy 0.11.0, Case Paths 1.9.2, Dependencies 1.15.0 through 1.17.0, and XCTest Dynamic Overlay 1.13.0; no application migration is required. Puppy requires swift-log 1.15 or later, which is already resolved.

Behavior evidence (focused test names, screenshots, or manual scenario):

- Manually validated existing stamp display and Show/Hide behavior against a LANraragi server.
- `testRetrieveStampsUsesOneBasedPagePath` verifies the request path, method, authorization header, and response decoding.
- Stamp positioning tests cover normalized coordinates, aspect-fit rendering, and split-page halves.
- Reducer tests cover visibility toggling, source archive/page requests, and the cached offline guard.

Checks not run or known gaps:

- No checks were skipped.
- Stamp creation, editing, deletion, and offline stamp persistence are intentionally outside this PR.

## Durable learning (only when applicable)

Regression tests now protect the LANraragi request contract, normalized and split-page positioning, Tankoubon source mapping, visibility state, and cached offline behavior. No `AGENTS.md` update was needed because these contracts are executable.