### PR TITLE
Edit and delete page stamps

### DIFF
--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		E9A8612D2BF31534003534FA /* AutomaticPageConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A8612C2BF31534003534FA /* AutomaticPageConfig.swift */; };
 		E9AA10022E0000020000AA02 /* TagTokenField.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9AA10012E0000010000AA01 /* TagTokenField.swift */; };
 		E9AAC1352CBC8FC600E5E89A /* UIPageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9AAC1342CBC8FC600E5E89A /* UIPageCell.swift */; };
+		F1A2B3F52FD0000100AAA001 /* StampOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3F42FD0000100AAA001 /* StampOverlayView.swift */; };
 		E9BE57B22942CFEC00A3AEA0 /* LockScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9BE57B12942CFEC00A3AEA0 /* LockScreen.swift */; };
 		E9BFA2052AF51DB500DDE107 /* ArchiveReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9BFA2042AF51DB500DDE107 /* ArchiveReader.swift */; };
 		E9BFA2072AF52C3300DDE107 /* PageImageV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9BFA2062AF52C3300DDE107 /* PageImageV2.swift */; };
@@ -216,6 +217,7 @@
 		E9A8612C2BF31534003534FA /* AutomaticPageConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticPageConfig.swift; sourceTree = "<group>"; };
 		E9AA10012E0000010000AA01 /* TagTokenField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagTokenField.swift; sourceTree = "<group>"; };
 		E9AAC1342CBC8FC600E5E89A /* UIPageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIPageCell.swift; sourceTree = "<group>"; };
+		F1A2B3F42FD0000100AAA001 /* StampOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StampOverlayView.swift; sourceTree = "<group>"; };
 		E9BE57B12942CFEC00A3AEA0 /* LockScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LockScreen.swift; path = LANreader/Common/LockScreen.swift; sourceTree = SOURCE_ROOT; };
 		E9BFA2042AF51DB500DDE107 /* ArchiveReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveReader.swift; sourceTree = "<group>"; };
 		E9BFA2062AF52C3300DDE107 /* PageImageV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageImageV2.swift; sourceTree = "<group>"; };
@@ -317,6 +319,7 @@
 		4BD824C107853A5BC514F2AD /* Page */ = {
 			isa = PBXGroup;
 			children = (
+				F1A2B3F42FD0000100AAA001 /* StampOverlayView.swift */,
 				E9AAC1342CBC8FC600E5E89A /* UIPageCell.swift */,
 				E91EE6842CAB94F60046853C /* UIPageCollection.swift */,
 				E91EE6822CAB78E80046853C /* UIArchiveReader.swift */,
@@ -783,6 +786,7 @@
 				7DF7EA7F2564E5D1003B5A5A /* Persistence.swift in Sources */,
 				E902FC4E2CD870530071106B /* UICategoryList.swift in Sources */,
 				E9810CD72DDC086E002B047A /* TranslationConfigView.swift in Sources */,
+				F1A2B3F52FD0000100AAA001 /* StampOverlayView.swift in Sources */,
 				E9AAC1352CBC8FC600E5E89A /* UIPageCell.swift in Sources */,
 				E9E3631F26F471E400C58D01 /* LogView.swift in Sources */,
 				6DA713301F56AA72BA0B4BE3 /* ServerSettings.swift in Sources */,
@@ -979,7 +983,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreader.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 217;
+				CURRENT_PROJECT_VERSION = 218;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1007,7 +1011,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreaderRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 217;
+				CURRENT_PROJECT_VERSION = 218;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1081,7 +1085,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 217;
+				CURRENT_PROJECT_VERSION = 218;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1111,7 +1115,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 217;
+				CURRENT_PROJECT_VERSION = 218;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;

--- a/LANreader/Page/ArchiveReader.swift
+++ b/LANreader/Page/ArchiveReader.swift
@@ -36,6 +36,13 @@ public struct StampCreationTarget: Equatable, Sendable {
     let position: ArchiveStampPosition
 }
 
+public struct StampEditingTarget: Equatable, Sendable {
+    let pageId: String
+    let stampId: String
+    let sourceArchiveId: String
+    let sourcePageNumber: Int
+}
+
 @Reducer public struct ArchiveReaderFeature: Sendable {
     private let logger = Logger(label: "ArchiveReaderFeature")
 
@@ -90,6 +97,9 @@ public struct StampCreationTarget: Equatable, Sendable {
         var stampCreationTarget: StampCreationTarget?
         var stampComment = ""
         var stampCreationInFlight = false
+        var stampEditingTarget: StampEditingTarget?
+        var stampEditText = ""
+        var stampMutationInFlight = false
 
         var allArchives: IdentifiedArrayOf<Shared<ArchiveItem>> = []
 
@@ -173,6 +183,15 @@ public struct StampCreationTarget: Equatable, Sendable {
             refreshedStamps: [ArchiveStamp]?
         )
         case stampCreationFailed
+        case stampEditingRequested(pageId: String, stamp: ArchiveStamp)
+        case stampEditTextChanged(String)
+        case cancelStampEditing
+        case confirmStampEditing
+        case confirmStampDeletion
+        case stampUpdated(target: StampEditingTarget, content: String)
+        case stampUpdateFailed
+        case stampDeleted(target: StampEditingTarget)
+        case stampDeleteFailed
         case visiblePageChanged(Int)
         case chapterSelected(Int)
         case requestJump(Int, source: ReaderNavigationSource)
@@ -224,6 +243,7 @@ public struct StampCreationTarget: Equatable, Sendable {
         case sliderPreviewLoad
         case primePageAspectRatios
         case stampCreation
+        case stampMutation
     }
 
     public var body: some ReducerOf<Self> {
@@ -438,6 +458,8 @@ public struct StampCreationTarget: Equatable, Sendable {
             case let .stampCreationRequested(pageId, position):
                 guard !state.cached,
                       !state.stampCreationInFlight,
+                      !state.stampMutationInFlight,
+                      state.stampEditingTarget == nil,
                       let page = state.pages[id: pageId],
                       !page.cached,
                       page.imageLoaded else {
@@ -530,6 +552,111 @@ public struct StampCreationTarget: Equatable, Sendable {
             case .stampCreationFailed:
                 state.stampCreationInFlight = false
                 state.errorMessage = String(localized: "archive.reader.stamp.add.failed")
+                return .none
+            case let .stampEditingRequested(pageId, stamp):
+                guard !state.cached,
+                      !state.stampCreationInFlight,
+                      !state.stampMutationInFlight,
+                      state.stampCreationTarget == nil,
+                      let stampId = stamp.id,
+                      !stampId.isEmpty,
+                      let page = state.pages[id: pageId],
+                      !page.cached,
+                      page.stamps.contains(where: { $0.id == stampId }) else {
+                    return .none
+                }
+                state.stampEditingTarget = StampEditingTarget(
+                    pageId: pageId,
+                    stampId: stampId,
+                    sourceArchiveId: page.sourceArchiveId,
+                    sourcePageNumber: page.sourcePageNumber
+                )
+                state.stampEditText = stamp.content
+                return .none
+            case let .stampEditTextChanged(content):
+                state.stampEditText = content
+                return .none
+            case .cancelStampEditing:
+                state.stampEditingTarget = nil
+                state.stampEditText = ""
+                return .none
+            case .confirmStampEditing:
+                guard let target = state.stampEditingTarget else { return .none }
+                let content = state.stampEditText.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !content.isEmpty else { return .none }
+                state.stampEditingTarget = nil
+                state.stampEditText = ""
+                state.stampMutationInFlight = true
+                return .run { send in
+                    do {
+                        let response = try await service.updateStamp(id: target.stampId, content: content).value
+                        guard response.success == 1 else {
+                            logger.warning("server rejected stamp update. stamp=\(target.stampId)")
+                            await send(.stampUpdateFailed)
+                            return
+                        }
+                        await send(.stampUpdated(target: target, content: content))
+                    } catch {
+                        logger.warning("failed to update stamp. stamp=\(target.stampId) \(error.localizedDescription)")
+                        await send(.stampUpdateFailed)
+                    }
+                }
+                .cancellable(id: CancelId.stampMutation, cancelInFlight: true)
+            case .confirmStampDeletion:
+                guard let target = state.stampEditingTarget else { return .none }
+                state.stampEditingTarget = nil
+                state.stampEditText = ""
+                state.stampMutationInFlight = true
+                return .run { send in
+                    do {
+                        let response = try await service.deleteStamp(id: target.stampId).value
+                        guard response.success == 1 else {
+                            logger.warning("server rejected stamp deletion. stamp=\(target.stampId)")
+                            await send(.stampDeleteFailed)
+                            return
+                        }
+                        await send(.stampDeleted(target: target))
+                    } catch {
+                        logger.warning("failed to delete stamp. stamp=\(target.stampId) \(error.localizedDescription)")
+                        await send(.stampDeleteFailed)
+                    }
+                }
+                .cancellable(id: CancelId.stampMutation, cancelInFlight: true)
+            case let .stampUpdated(target, content):
+                state.stampMutationInFlight = false
+                for pageId in state.pages.ids {
+                    guard let page = state.pages[id: pageId],
+                          page.sourceArchiveId == target.sourceArchiveId,
+                          page.sourcePageNumber == target.sourcePageNumber,
+                          let index = page.stamps.firstIndex(where: { $0.id == target.stampId }) else {
+                        continue
+                    }
+                    let stamp = page.stamps[index]
+                    state.pages[id: pageId]?.stamps[index] = ArchiveStamp(
+                        id: stamp.id,
+                        position: stamp.position,
+                        content: content
+                    )
+                }
+                return .none
+            case .stampUpdateFailed:
+                state.stampMutationInFlight = false
+                state.errorMessage = String(localized: "archive.reader.stamp.update.failed")
+                return .none
+            case let .stampDeleted(target):
+                state.stampMutationInFlight = false
+                for pageId in state.pages.ids {
+                    guard let page = state.pages[id: pageId],
+                          page.sourceArchiveId == target.sourceArchiveId,
+                          page.sourcePageNumber == target.sourcePageNumber else {
+                        continue
+                    }
+                    state.pages[id: pageId]?.stamps.removeAll { $0.id == target.stampId }
+                }
+                return .none
+            case .stampDeleteFailed:
+                state.stampMutationInFlight = false
+                state.errorMessage = String(localized: "archive.reader.stamp.delete.failed")
                 return .none
             case let .visiblePageChanged(index):
                 guard !state.pages.isEmpty else { return .none }
@@ -1040,6 +1167,7 @@ public struct StampCreationTarget: Equatable, Sendable {
                     .cancel(id: CancelId.sliderPreviewThumbnailPolling),
                     .cancel(id: CancelId.sliderPreviewLoad),
                     .cancel(id: CancelId.stampCreation),
+                    .cancel(id: CancelId.stampMutation),
                     state.cached ? .send(.loadCached) : .send(.extractArchive)
                 )
             case .loadNextArchive:
@@ -1055,6 +1183,7 @@ public struct StampCreationTarget: Equatable, Sendable {
                     .cancel(id: CancelId.sliderPreviewThumbnailPolling),
                     .cancel(id: CancelId.sliderPreviewLoad),
                     .cancel(id: CancelId.stampCreation),
+                    .cancel(id: CancelId.stampMutation),
                     state.cached ? .send(.loadCached) : .send(.extractArchive)
                 )
             }
@@ -1354,6 +1483,9 @@ public struct StampCreationTarget: Equatable, Sendable {
         state.stampCreationTarget = nil
         state.stampComment = ""
         state.stampCreationInFlight = false
+        state.stampEditingTarget = nil
+        state.stampEditText = ""
+        state.stampMutationInFlight = false
         resetSliderPreviewArchiveState(state: &state)
     }
 }
@@ -1430,6 +1562,35 @@ struct ArchiveReader: View {
                 store.send(.confirmStampCreation)
             }
             .disabled(store.stampComment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+        .alert(
+            "archive.reader.stamp.edit.title",
+            isPresented: Binding(
+                get: { store.stampEditingTarget != nil },
+                set: { isPresented in
+                    if !isPresented, store.stampEditingTarget != nil {
+                        store.send(.cancelStampEditing)
+                    }
+                }
+            )
+        ) {
+            TextField(
+                "archive.reader.stamp.text.placeholder",
+                text: Binding(
+                    get: { store.stampEditText },
+                    set: { store.send(.stampEditTextChanged($0)) }
+                )
+            )
+            Button("delete", role: .destructive) {
+                store.send(.confirmStampDeletion)
+            }
+            Button("cancel", role: .cancel) {
+                store.send(.cancelStampEditing)
+            }
+            Button("save") {
+                store.send(.confirmStampEditing)
+            }
+            .disabled(store.stampEditText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         }
         .overlay(content: {
             store.showAutoPageConfig ? AutomaticPageConfig(

--- a/LANreader/Page/StampOverlayView.swift
+++ b/LANreader/Page/StampOverlayView.swift
@@ -1,0 +1,229 @@
+import UIKit
+
+private final class StampCommentLabel: UILabel {
+    private let contentInsets = UIEdgeInsets(top: 8, left: 10, bottom: 8, right: 10)
+
+    override func drawText(in rect: CGRect) {
+        super.drawText(in: rect.inset(by: contentInsets))
+    }
+
+    override func sizeThatFits(_ size: CGSize) -> CGSize {
+        let contentSize = CGSize(
+            width: max(0, size.width - contentInsets.left - contentInsets.right),
+            height: max(0, size.height - contentInsets.top - contentInsets.bottom)
+        )
+        let labelSize = super.sizeThatFits(contentSize)
+        return CGSize(
+            width: labelSize.width + contentInsets.left + contentInsets.right,
+            height: labelSize.height + contentInsets.top + contentInsets.bottom
+        )
+    }
+}
+
+final class StampOverlayView: UIView {
+    private struct DisplayedStamp {
+        let sourceIndex: Int
+        let stamp: ArchiveStamp
+        let position: ArchiveStampPosition
+    }
+
+    private let markerSize: CGFloat = 30
+    private let calloutSpacing: CGFloat = 6
+    private var stamps: [ArchiveStamp] = []
+    private var displayedStamps: [DisplayedStamp] = []
+    private var markerButtons: [UIButton] = []
+    private var selectedSourceIndex: Int?
+    private var imageSize: CGSize?
+    private var pageMode: PageMode = .normal
+    private var onEditStamp: ((ArchiveStamp) -> Void)?
+
+    private let commentLabel: StampCommentLabel = {
+        let label = StampCommentLabel()
+        label.backgroundColor = UIColor.secondarySystemBackground.withAlphaComponent(0.96)
+        label.textColor = .label
+        label.font = .preferredFont(forTextStyle: .callout)
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
+        label.layer.cornerRadius = 8
+        label.layer.cornerCurve = .continuous
+        label.layer.borderWidth = 1
+        label.layer.borderColor = UIColor.separator.withAlphaComponent(0.35).cgColor
+        label.clipsToBounds = true
+        label.isHidden = true
+        label.isUserInteractionEnabled = false
+        return label
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .clear
+        addSubview(commentLabel)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(
+        stamps: [ArchiveStamp],
+        pageMode: PageMode,
+        imageSize: CGSize?,
+        onEditStamp: @escaping (ArchiveStamp) -> Void
+    ) {
+        let contentsChanged = self.stamps != stamps || self.pageMode != pageMode
+        self.stamps = stamps
+        self.pageMode = pageMode
+        self.imageSize = imageSize
+        self.onEditStamp = onEditStamp
+        if contentsChanged {
+            rebuildMarkers()
+        }
+        setNeedsLayout()
+    }
+
+    func clear() {
+        stamps = []
+        displayedStamps = []
+        imageSize = nil
+        selectedSourceIndex = nil
+        onEditStamp = nil
+        markerButtons.forEach { $0.removeFromSuperview() }
+        markerButtons = []
+        commentLabel.isHidden = true
+        commentLabel.text = nil
+    }
+
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        markerButtons.contains { !$0.isHidden && $0.frame.insetBy(dx: -4, dy: -4).contains(point) }
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        guard let imageSize,
+              let imageRect = StampOverlayPositioning.aspectFitRect(imageSize: imageSize, in: bounds) else {
+            markerButtons.forEach { $0.isHidden = true }
+            commentLabel.isHidden = true
+            return
+        }
+
+        for (index, displayedStamp) in displayedStamps.enumerated() {
+            let button = markerButtons[index]
+            let point = CGPoint(
+                x: imageRect.minX
+                    + imageRect.width * CGFloat(displayedStamp.position.horizontalPercentage / 100),
+                y: imageRect.minY
+                    + imageRect.height * CGFloat(displayedStamp.position.verticalPercentage / 100)
+            )
+            let origin = CGPoint(
+                x: min(max(point.x - markerSize / 2, imageRect.minX), imageRect.maxX - markerSize),
+                y: min(max(point.y - markerSize / 2, imageRect.minY), imageRect.maxY - markerSize)
+            )
+            button.frame = CGRect(origin: origin, size: CGSize(width: markerSize, height: markerSize))
+            button.isHidden = false
+        }
+
+        layoutComment(in: imageRect)
+    }
+
+    private func rebuildMarkers() {
+        markerButtons.forEach { $0.removeFromSuperview() }
+        markerButtons = []
+        displayedStamps = stamps.enumerated().compactMap { index, stamp in
+            guard let position = stamp.normalizedPosition,
+                  let displayedPosition = StampOverlayPositioning.displayedPosition(
+                    position,
+                    pageMode: pageMode
+                  ) else {
+                return nil
+            }
+            return DisplayedStamp(sourceIndex: index, stamp: stamp, position: displayedPosition)
+        }
+
+        if !displayedStamps.contains(where: { $0.sourceIndex == selectedSourceIndex }) {
+            selectedSourceIndex = nil
+        }
+
+        for displayedStamp in displayedStamps {
+            let button = UIButton(type: .system)
+            button.setImage(UIImage(systemName: "seal.fill"), for: .normal)
+            button.tintColor = .white
+            button.backgroundColor = .systemOrange
+            button.layer.cornerRadius = markerSize / 2
+            button.layer.cornerCurve = .continuous
+            button.layer.shadowColor = UIColor.black.cgColor
+            button.layer.shadowOpacity = 0.3
+            button.layer.shadowRadius = 2
+            button.layer.shadowOffset = CGSize(width: 0, height: 1)
+            button.accessibilityLabel = displayedStamp.stamp.content
+            button.addAction(
+                UIAction { [weak self] _ in
+                    self?.toggleComment(for: displayedStamp.sourceIndex)
+                },
+                for: .touchUpInside
+            )
+            button.tag = displayedStamp.sourceIndex
+            button.addGestureRecognizer(
+                UILongPressGestureRecognizer(target: self, action: #selector(handleStampLongPress(_:)))
+            )
+            addSubview(button)
+            markerButtons.append(button)
+        }
+        bringSubviewToFront(commentLabel)
+    }
+
+    @objc private func handleStampLongPress(_ gesture: UILongPressGestureRecognizer) {
+        guard gesture.state == .began,
+              let button = gesture.view as? UIButton,
+              let displayedStamp = displayedStamps.first(where: { $0.sourceIndex == button.tag }) else {
+            return
+        }
+        onEditStamp?(displayedStamp.stamp)
+    }
+
+    private func toggleComment(for sourceIndex: Int) {
+        selectedSourceIndex = selectedSourceIndex == sourceIndex ? nil : sourceIndex
+        setNeedsLayout()
+    }
+
+    private func layoutComment(in imageRect: CGRect) {
+        guard let selectedSourceIndex,
+              let selectedIndex = displayedStamps.firstIndex(where: { $0.sourceIndex == selectedSourceIndex }),
+              displayedStamps.indices.contains(selectedIndex),
+              markerButtons.indices.contains(selectedIndex) else {
+            commentLabel.isHidden = true
+            commentLabel.text = nil
+            return
+        }
+
+        let content = displayedStamps[selectedIndex].stamp.content
+        guard !content.isEmpty else {
+            commentLabel.isHidden = true
+            commentLabel.text = nil
+            return
+        }
+
+        commentLabel.text = content
+        let maxWidth = min(280, imageRect.width)
+        let fittedSize = commentLabel.sizeThatFits(
+            CGSize(width: maxWidth, height: max(imageRect.height, 1))
+        )
+        let calloutSize = CGSize(
+            width: min(fittedSize.width, maxWidth),
+            height: min(fittedSize.height, imageRect.height)
+        )
+        let markerFrame = markerButtons[selectedIndex].frame
+        let proposedY = markerFrame.maxY + calloutSpacing
+        let verticalOrigin = proposedY + calloutSize.height <= imageRect.maxY
+            ? proposedY
+            : max(imageRect.minY, markerFrame.minY - calloutSpacing - calloutSize.height)
+        let horizontalOrigin = min(
+            max(markerFrame.midX - calloutSize.width / 2, imageRect.minX),
+            imageRect.maxX - calloutSize.width
+        )
+        commentLabel.frame = CGRect(
+            origin: CGPoint(x: horizontalOrigin, y: verticalOrigin),
+            size: calloutSize
+        )
+        commentLabel.isHidden = false
+    }
+}

--- a/LANreader/Page/UIPageCell.swift
+++ b/LANreader/Page/UIPageCell.swift
@@ -98,213 +98,6 @@ enum StampOverlayPositioning {
     }
 }
 
-private final class StampCommentLabel: UILabel {
-    private let contentInsets = UIEdgeInsets(top: 8, left: 10, bottom: 8, right: 10)
-
-    override func drawText(in rect: CGRect) {
-        super.drawText(in: rect.inset(by: contentInsets))
-    }
-
-    override func sizeThatFits(_ size: CGSize) -> CGSize {
-        let contentSize = CGSize(
-            width: max(0, size.width - contentInsets.left - contentInsets.right),
-            height: max(0, size.height - contentInsets.top - contentInsets.bottom)
-        )
-        let labelSize = super.sizeThatFits(contentSize)
-        return CGSize(
-            width: labelSize.width + contentInsets.left + contentInsets.right,
-            height: labelSize.height + contentInsets.top + contentInsets.bottom
-        )
-    }
-}
-
-private final class StampOverlayView: UIView {
-    private struct DisplayedStamp {
-        let sourceIndex: Int
-        let stamp: ArchiveStamp
-        let position: ArchiveStampPosition
-    }
-
-    private let markerSize: CGFloat = 30
-    private let calloutSpacing: CGFloat = 6
-    private var stamps: [ArchiveStamp] = []
-    private var displayedStamps: [DisplayedStamp] = []
-    private var markerButtons: [UIButton] = []
-    private var selectedSourceIndex: Int?
-    private var imageSize: CGSize?
-    private var pageMode: PageMode = .normal
-
-    private let commentLabel: StampCommentLabel = {
-        let label = StampCommentLabel()
-        label.backgroundColor = UIColor.secondarySystemBackground.withAlphaComponent(0.96)
-        label.textColor = .label
-        label.font = .preferredFont(forTextStyle: .callout)
-        label.adjustsFontForContentSizeCategory = true
-        label.numberOfLines = 0
-        label.layer.cornerRadius = 8
-        label.layer.cornerCurve = .continuous
-        label.layer.borderWidth = 1
-        label.layer.borderColor = UIColor.separator.withAlphaComponent(0.35).cgColor
-        label.clipsToBounds = true
-        label.isHidden = true
-        label.isUserInteractionEnabled = false
-        return label
-    }()
-
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        backgroundColor = .clear
-        addSubview(commentLabel)
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    func configure(stamps: [ArchiveStamp], pageMode: PageMode, imageSize: CGSize?) {
-        let contentsChanged = self.stamps != stamps || self.pageMode != pageMode
-        self.stamps = stamps
-        self.pageMode = pageMode
-        self.imageSize = imageSize
-        if contentsChanged {
-            rebuildMarkers()
-        }
-        setNeedsLayout()
-    }
-
-    func clear() {
-        stamps = []
-        displayedStamps = []
-        imageSize = nil
-        selectedSourceIndex = nil
-        markerButtons.forEach { $0.removeFromSuperview() }
-        markerButtons = []
-        commentLabel.isHidden = true
-        commentLabel.text = nil
-    }
-
-    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
-        markerButtons.contains { !$0.isHidden && $0.frame.insetBy(dx: -4, dy: -4).contains(point) }
-    }
-
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        guard let imageSize,
-              let imageRect = StampOverlayPositioning.aspectFitRect(imageSize: imageSize, in: bounds) else {
-            markerButtons.forEach { $0.isHidden = true }
-            commentLabel.isHidden = true
-            return
-        }
-
-        for (index, displayedStamp) in displayedStamps.enumerated() {
-            let button = markerButtons[index]
-            let point = CGPoint(
-                x: imageRect.minX
-                    + imageRect.width * CGFloat(displayedStamp.position.horizontalPercentage / 100),
-                y: imageRect.minY
-                    + imageRect.height * CGFloat(displayedStamp.position.verticalPercentage / 100)
-            )
-            let origin = CGPoint(
-                x: min(max(point.x - markerSize / 2, imageRect.minX), imageRect.maxX - markerSize),
-                y: min(max(point.y - markerSize / 2, imageRect.minY), imageRect.maxY - markerSize)
-            )
-            button.frame = CGRect(origin: origin, size: CGSize(width: markerSize, height: markerSize))
-            button.isHidden = false
-        }
-
-        layoutComment(in: imageRect)
-    }
-
-    private func rebuildMarkers() {
-        markerButtons.forEach { $0.removeFromSuperview() }
-        markerButtons = []
-        displayedStamps = stamps.enumerated().compactMap { index, stamp in
-            guard let position = stamp.normalizedPosition,
-                  let displayedPosition = StampOverlayPositioning.displayedPosition(
-                    position,
-                    pageMode: pageMode
-                  ) else {
-                return nil
-            }
-            return DisplayedStamp(sourceIndex: index, stamp: stamp, position: displayedPosition)
-        }
-
-        if !displayedStamps.contains(where: { $0.sourceIndex == selectedSourceIndex }) {
-            selectedSourceIndex = nil
-        }
-
-        for displayedStamp in displayedStamps {
-            let button = UIButton(type: .system)
-            button.setImage(UIImage(systemName: "seal.fill"), for: .normal)
-            button.tintColor = .white
-            button.backgroundColor = .systemOrange
-            button.layer.cornerRadius = markerSize / 2
-            button.layer.cornerCurve = .continuous
-            button.layer.shadowColor = UIColor.black.cgColor
-            button.layer.shadowOpacity = 0.3
-            button.layer.shadowRadius = 2
-            button.layer.shadowOffset = CGSize(width: 0, height: 1)
-            button.accessibilityLabel = displayedStamp.stamp.content
-            button.addAction(
-                UIAction { [weak self] _ in
-                    self?.toggleComment(for: displayedStamp.sourceIndex)
-                },
-                for: .touchUpInside
-            )
-            addSubview(button)
-            markerButtons.append(button)
-        }
-        bringSubviewToFront(commentLabel)
-    }
-
-    private func toggleComment(for sourceIndex: Int) {
-        selectedSourceIndex = selectedSourceIndex == sourceIndex ? nil : sourceIndex
-        setNeedsLayout()
-    }
-
-    private func layoutComment(in imageRect: CGRect) {
-        guard let selectedSourceIndex,
-              let selectedIndex = displayedStamps.firstIndex(where: { $0.sourceIndex == selectedSourceIndex }),
-              displayedStamps.indices.contains(selectedIndex),
-              markerButtons.indices.contains(selectedIndex) else {
-            commentLabel.isHidden = true
-            commentLabel.text = nil
-            return
-        }
-
-        let content = displayedStamps[selectedIndex].stamp.content
-        guard !content.isEmpty else {
-            commentLabel.isHidden = true
-            commentLabel.text = nil
-            return
-        }
-
-        commentLabel.text = content
-        let maxWidth = min(280, imageRect.width)
-        let fittedSize = commentLabel.sizeThatFits(
-            CGSize(width: maxWidth, height: max(imageRect.height, 1))
-        )
-        let calloutSize = CGSize(
-            width: min(fittedSize.width, maxWidth),
-            height: min(fittedSize.height, imageRect.height)
-        )
-        let markerFrame = markerButtons[selectedIndex].frame
-        let proposedY = markerFrame.maxY + calloutSpacing
-        let verticalOrigin = proposedY + calloutSize.height <= imageRect.maxY
-            ? proposedY
-            : max(imageRect.minY, markerFrame.minY - calloutSpacing - calloutSize.height)
-        let horizontalOrigin = min(
-            max(markerFrame.midX - calloutSize.width / 2, imageRect.minX),
-            imageRect.maxX - calloutSize.width
-        )
-        commentLabel.frame = CGRect(
-            origin: CGPoint(x: horizontalOrigin, y: verticalOrigin),
-            size: calloutSize
-        )
-        commentLabel.isHidden = false
-    }
-}
-
 class UIPageCell: UICollectionViewCell {
     static let reuseIdentifier = "UIPageCell"
 
@@ -323,6 +116,7 @@ class UIPageCell: UICollectionViewCell {
 
     private var observationTokens: Set<ObserveToken> = []
     private var onCreateStamp: ((ArchiveStampPosition) -> Void)?
+    private var onEditStamp: ((ArchiveStamp) -> Void)?
     private var fitPageWidth = false
     private var fitScreenHeightConstraint: NSLayoutConstraint!
     private var fitWidthAspectConstraint: NSLayoutConstraint?
@@ -470,12 +264,14 @@ class UIPageCell: UICollectionViewCell {
         with store: StoreOf<PageFeature>,
         fitPageWidth: Bool,
         showsStamps: Bool,
-        onCreateStamp: @escaping (ArchiveStampPosition) -> Void
+        onCreateStamp: @escaping (ArchiveStampPosition) -> Void,
+        onEditStamp: @escaping (ArchiveStamp) -> Void
     ) {
         // Tear down any existing observation from a previous page assignment
         cancelSubscriptions()
         animatedImageView.resetFirstFrameState()
         self.onCreateStamp = onCreateStamp
+        self.onEditStamp = onEditStamp
         self.fitPageWidth = fitPageWidth
         stampOverlayView.clear()
         stampOverlayView.isHidden = !showsStamps
@@ -517,6 +313,15 @@ class UIPageCell: UICollectionViewCell {
             return
         }
         onCreateStamp?(position)
+    }
+
+    func requestStampEditing(for stamp: ArchiveStamp) {
+        guard let store,
+              !store.cached,
+              stamp.id?.isEmpty == false else {
+            return
+        }
+        onEditStamp?(stamp)
     }
 
     func setFitPageWidth(_ fitPageWidth: Bool) {
@@ -593,7 +398,10 @@ class UIPageCell: UICollectionViewCell {
             self.stampOverlayView.configure(
                 stamps: stamps,
                 pageMode: pageMode,
-                imageSize: self.imageView.image?.size
+                imageSize: self.imageView.image?.size,
+                onEditStamp: { [weak self] stamp in
+                    self?.requestStampEditing(for: stamp)
+                }
             )
         }
         .store(in: &observationTokens)
@@ -746,7 +554,10 @@ class UIPageCell: UICollectionViewCell {
         stampOverlayView.configure(
             stamps: store.stamps,
             pageMode: store.pageMode,
-            imageSize: imageView.image?.size
+            imageSize: imageView.image?.size,
+            onEditStamp: { [weak self] stamp in
+                self?.requestStampEditing(for: stamp)
+            }
         )
     }
 
@@ -761,6 +572,7 @@ class UIPageCell: UICollectionViewCell {
         animatedImageView.resetFirstFrameState()
         store = nil
         onCreateStamp = nil
+        onEditStamp = nil
         imageView.image = nil
         imageView.isHidden = true
         animatedImageView.image = nil

--- a/LANreader/Page/UIPageCollection.swift
+++ b/LANreader/Page/UIPageCollection.swift
@@ -183,6 +183,9 @@ class UIPageCollectionController: UIViewController, UICollectionViewDelegate {
                     showsStamps: self.store.showStamps,
                     onCreateStamp: { [weak self] position in
                         self?.store.send(.stampCreationRequested(pageId: pageId, position: position))
+                    },
+                    onEditStamp: { [weak self] stamp in
+                        self?.store.send(.stampEditingRequested(pageId: pageId, stamp: stamp))
                     }
                 )
             }

--- a/LANreader/Service/LANraragiService.swift
+++ b/LANreader/Service/LANraragiService.swift
@@ -418,6 +418,23 @@ actor LANraragiService {
         .serializingDecodable(AddStampResponse.self)
     }
 
+    func updateStamp(id: String, content: String) async -> DataTask<GenericSuccessResponse> {
+        session.request(
+            "\(url)/api/stamps/\(id)",
+            method: .put,
+            parameters: ["content": content],
+            encoding: URLEncoding(destination: .queryString)
+        )
+        .validate(statusCode: 200...200)
+        .serializingDecodable(GenericSuccessResponse.self)
+    }
+
+    func deleteStamp(id: String) async -> DataTask<GenericSuccessResponse> {
+        session.request("\(url)/api/stamps/\(id)", method: .delete)
+            .validate(statusCode: 200...200)
+            .serializingDecodable(GenericSuccessResponse.self)
+    }
+
     private func resolveArchivePageURL(page: String) -> URL {
         let baseURL = getDomainURL(from: self.url)
         return URL(string: page, relativeTo: baseURL)!.absoluteURL

--- a/LANreaderTests/ArchiveReaderFeatureTests.swift
+++ b/LANreaderTests/ArchiveReaderFeatureTests.swift
@@ -251,6 +251,97 @@ final class ArchiveReaderFeatureTests: XCTestCase {
     }
 
     @MainActor
+    func testEditStampUpdatesExistingStampText() async throws {
+        configureReaderDefaults()
+        try await configureVerifiedClient()
+
+        let stamp = ArchiveStamp(id: "stamp", position: "25,30", content: "Original text")
+        stubUpdateArchiveStamp(stampId: "stamp", content: "Updated text")
+        var initialState = makeState()
+        var page = PageFeature.State(
+            archiveId: "archive",
+            pageId: "1",
+            pageNumber: 1,
+            pageMode: .left
+        )
+        page.imageLoaded = true
+        page.stamps = [stamp]
+        page.stampsLoaded = true
+        var siblingPage = PageFeature.State(
+            archiveId: "archive",
+            pageId: "1",
+            pageNumber: 1,
+            pageMode: .right
+        )
+        siblingPage.imageLoaded = true
+        siblingPage.stamps = [stamp]
+        siblingPage.stampsLoaded = true
+        initialState.pages = [page, siblingPage]
+        let target = StampEditingTarget(
+            pageId: page.id, stampId: "stamp", sourceArchiveId: "archive", sourcePageNumber: 1
+        )
+        let store = makeTestStore(initialState: initialState)
+
+        await store.send(.stampEditingRequested(pageId: page.id, stamp: stamp)) {
+            $0.stampEditingTarget = target
+            $0.stampEditText = "Original text"
+        }
+        await store.send(.stampEditTextChanged("  Updated text\n")) {
+            $0.stampEditText = "  Updated text\n"
+        }
+        await store.send(.confirmStampEditing) {
+            $0.stampEditingTarget = nil
+            $0.stampEditText = ""
+            $0.stampMutationInFlight = true
+        }
+        await store.receive(.stampUpdated(target: target, content: "Updated text")) {
+            $0.stampMutationInFlight = false
+            $0.pages[id: page.id]?.stamps = [
+                ArchiveStamp(id: "stamp", position: "25,30", content: "Updated text")
+            ]
+            $0.pages[id: siblingPage.id]?.stamps = [
+                ArchiveStamp(id: "stamp", position: "25,30", content: "Updated text")
+            ]
+        }
+    }
+
+    @MainActor
+    func testDeleteStampRemovesExistingStamp() async throws {
+        configureReaderDefaults()
+        try await configureVerifiedClient()
+
+        let stamp = ArchiveStamp(id: "stamp", position: "25,30", content: "Delete me")
+        stubDeleteArchiveStamp(stampId: "stamp")
+        var initialState = makeState()
+        var page = PageFeature.State(archiveId: "archive", pageId: "1", pageNumber: 1)
+        page.imageLoaded = true
+        page.stamps = [stamp]
+        page.stampsLoaded = true
+        initialState.pages = [page]
+        let target = StampEditingTarget(
+            pageId: page.id,
+            stampId: "stamp",
+            sourceArchiveId: "archive",
+            sourcePageNumber: 1
+        )
+        let store = makeTestStore(initialState: initialState)
+
+        await store.send(.stampEditingRequested(pageId: page.id, stamp: stamp)) {
+            $0.stampEditingTarget = target
+            $0.stampEditText = "Delete me"
+        }
+        await store.send(.confirmStampDeletion) {
+            $0.stampEditingTarget = nil
+            $0.stampEditText = ""
+            $0.stampMutationInFlight = true
+        }
+        await store.receive(.stampDeleted(target: target)) {
+            $0.stampMutationInFlight = false
+            $0.pages[id: page.id]?.stamps = []
+        }
+    }
+
+    @MainActor
     func testCachedReaderDoesNotOfferStampCreation() async {
         var initialState = makeState(cached: true)
         var page = PageFeature.State(
@@ -268,6 +359,24 @@ final class ArchiveReaderFeatureTests: XCTestCase {
             pageId: page.id,
             position: ArchiveStampPosition(rawValue: "50,50")!
         ))
+    }
+
+    @MainActor
+    func testCachedReaderDoesNotOfferStampEditing() async {
+        let stamp = ArchiveStamp(id: "stamp", position: "50,50", content: "Offline")
+        var initialState = makeState(cached: true)
+        var page = PageFeature.State(
+            archiveId: "archive",
+            pageId: "1",
+            pageNumber: 1,
+            cached: true
+        )
+        page.imageLoaded = true
+        page.stamps = [stamp]
+        initialState.pages = [page]
+        let store = makeTestStore(initialState: initialState)
+
+        await store.send(.stampEditingRequested(pageId: page.id, stamp: stamp))
     }
 
     @MainActor
@@ -310,6 +419,51 @@ final class ArchiveReaderFeatureTests: XCTestCase {
                 position: ArchiveStampPosition(rawValue: "50,50")!
             )
         )
+    }
+
+    @MainActor
+    func testUIStampMarkerLongPressIsWiredToEditing() async throws {
+        configureReaderDefaults()
+
+        let stamp = ArchiveStamp(id: "stamp", position: "50,50", content: "Editable")
+        var initialState = makeState(progress: 1)
+        initialState.$showStamps = Shared(value: true)
+        var page = PageFeature.State(archiveId: "archive", pageId: "1", pageNumber: 1)
+        page.imageLoaded = true
+        page.stamps = [stamp]
+        page.stampsLoaded = true
+        initialState.pages = [page]
+
+        let store = Store(initialState: initialState) {
+            ArchiveReaderFeature()
+        } withDependencies: {
+            $0.continuousClock = ImmediateClock()
+        }
+        let controller = UIPageCollectionController(store: store)
+
+        controller.loadViewIfNeeded()
+        controller.view.frame = CGRect(x: 0, y: 0, width: 320, height: 480)
+        controller.view.layoutIfNeeded()
+        await Task.yield()
+        await Task.yield()
+        controller.collectionView.layoutIfNeeded()
+
+        let cell = try XCTUnwrap(controller.collectionView.visibleCells.first as? UIPageCell)
+        let marker = try XCTUnwrap(stampMarker(in: cell, comment: "Editable"))
+        XCTAssertTrue(marker.gestureRecognizers?.contains { $0 is UILongPressGestureRecognizer } == true)
+
+        cell.requestStampEditing(for: stamp)
+
+        XCTAssertEqual(
+            store.stampEditingTarget,
+            StampEditingTarget(
+                pageId: page.id,
+                stampId: "stamp",
+                sourceArchiveId: "archive",
+                sourcePageNumber: 1
+            )
+        )
+        XCTAssertEqual(store.stampEditText, "Editable")
     }
 
     @MainActor
@@ -3510,6 +3664,43 @@ private func stubAddArchiveStamp(
             {
               "operation": "add_stamp",
               "stamp_id": "created-stamp",
+              "success": 1
+            }
+            """.utf8),
+            statusCode: 200,
+            headers: ["Content-Type": "application/json"]
+        )
+    }
+}
+
+private func stubUpdateArchiveStamp(stampId: String, content: String) {
+    stub(condition: isHost("localhost")
+            && isPath("/api/stamps/\(stampId)")
+            && containsQueryParams(["content": content])
+            && isMethodPUT()
+            && hasHeaderNamed("Authorization", value: "Bearer YXBpS2V5")) { _ in
+        HTTPStubsResponse(
+            data: Data("""
+            {
+              "operation": "update_stamp",
+              "success": 1
+            }
+            """.utf8),
+            statusCode: 200,
+            headers: ["Content-Type": "application/json"]
+        )
+    }
+}
+
+private func stubDeleteArchiveStamp(stampId: String) {
+    stub(condition: isHost("localhost")
+            && isPath("/api/stamps/\(stampId)")
+            && isMethodDELETE()
+            && hasHeaderNamed("Authorization", value: "Bearer YXBpS2V5")) { _ in
+        HTTPStubsResponse(
+            data: Data("""
+            {
+              "operation": "delete_stamp",
               "success": 1
             }
             """.utf8),

--- a/LANreaderTests/Service/LANraragiServiceTest.swift
+++ b/LANreaderTests/Service/LANraragiServiceTest.swift
@@ -192,6 +192,59 @@ class LANraragiServiceTest: XCTestCase {
         )
     }
 
+    func testUpdateStampUsesPutQueryContract() async throws {
+        try await configureVerifiedClient()
+
+        let stampId = "STAMPS_3_1777224824662"
+        stub(condition: isHost("localhost")
+                && isPath("/api/stamps/\(stampId)")
+                && containsQueryParams(["content": "Updated note & detail"])
+                && isMethodPUT()
+                && hasHeaderNamed("Authorization", value: "Bearer YXBpS2V5")
+                && { $0.ohhttpStubs_httpBody == nil }) { _ in
+            HTTPStubsResponse(
+                data: Data("""
+                {
+                  "operation": "update_stamp",
+                  "success": 1
+                }
+                """.utf8),
+                statusCode: 200,
+                headers: ["Content-Type": "application/json"]
+            )
+        }
+
+        let actual = try await service.updateStamp(id: stampId, content: "Updated note & detail").value
+
+        XCTAssertEqual(actual.success, 1)
+    }
+
+    func testDeleteStampUsesDeleteContract() async throws {
+        try await configureVerifiedClient()
+
+        let stampId = "STAMPS_3_1777224824662"
+        stub(condition: isHost("localhost")
+                && isPath("/api/stamps/\(stampId)")
+                && isMethodDELETE()
+                && hasHeaderNamed("Authorization", value: "Bearer YXBpS2V5")
+                && { $0.ohhttpStubs_httpBody == nil }) { _ in
+            HTTPStubsResponse(
+                data: Data("""
+                {
+                  "operation": "delete_stamp",
+                  "success": 1
+                }
+                """.utf8),
+                statusCode: 200,
+                headers: ["Content-Type": "application/json"]
+            )
+        }
+
+        let actual = try await service.deleteStamp(id: stampId).value
+
+        XCTAssertEqual(actual.success, 1)
+    }
+
     func testRetrieveArchiveThumbnailReturnsImageData() async throws {
         try await configureVerifiedClient()
 

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -1851,6 +1851,76 @@
         }
       }
     },
+    "archive.reader.stamp.delete.failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Could not delete stamp."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スタンプを削除できませんでした。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스탬프를 삭제할 수 없습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法删除图章。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法刪除圖章。"
+          }
+        }
+      }
+    },
+    "archive.reader.stamp.edit.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit stamp"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スタンプを編集"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스탬프 편집"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "编辑图章"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯圖章"
+          }
+        }
+      }
+    },
     "archive.reader.stamp.text.placeholder" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1882,6 +1952,41 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "圖章文字"
+          }
+        }
+      }
+    },
+    "archive.reader.stamp.update.failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Could not update stamp."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スタンプを更新できませんでした。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스탬프를 수정할 수 없습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法更新图章。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法更新圖章。"
           }
         }
       }


### PR DESCRIPTION
## Change

Long-pressing an existing page stamp now opens an edit dialog with its current Stamp text. Users can save updated text or delete the stamp through the LANraragi stamp update and delete APIs.

Successful mutations update every loaded representation of the source page, including both halves of a split page. Cached pages remain read-only. The existing UIKit stamp overlay was moved into `StampOverlayView.swift` so the gesture behavior stays in the current rendering layer without exceeding the repository file-length guard. The app and Action build number is synchronized at 218 while marketing version remains 3.10.0.

## Risk surface

- [x] Reader, navigation, image rendering, cache, or Tankoubon behavior
- [x] LANraragi request or response contract
- [x] Persistence, migration, or offline behavior
- [x] Localized user interface
- [x] Xcode project, dependency, CI, or release automation
- [ ] None of the above

## Evidence

Commands run and outcomes:

- `./scripts/verify` — passed repository checks, SwiftLint with 0 violations, and 217 iOS tests with 0 failures.
- `git diff --check` — passed.

Behavior evidence (focused test names, screenshots, or manual scenario):

- `testEditStampUpdatesExistingStampText` covers trimmed updates and mirrored split-page state.
- `testDeleteStampRemovesExistingStamp` covers deletion after server success.
- `testCachedReaderDoesNotOfferStampEditing` preserves offline behavior.
- `testUIStampMarkerLongPressIsWiredToEditing` covers the UIKit marker gesture entry path.
- `testUpdateStampUsesPutQueryContract` and `testDeleteStampUsesDeleteContract` verify method, path, query/body encoding, and authorization.

Checks not run or known gaps:

- No manual test against a live LANraragi server; request contracts are covered by stubbed service tests.

## Durable learning (only when applicable)

Regression test, automated guard, or concise `AGENTS.md` update:

- Added reducer, UIKit gesture, cached-reader, split-page, and complete request-contract regressions. No `AGENTS.md` update was needed because the existing reader and API workflow rules cover this behavior.