### PR TITLE
Refresh upload jobs immediately

### DIFF
--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		F1A2B3E52FA0000100AAA001 /* PaginationPositioningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3E62FA0000100AAA001 /* PaginationPositioningTests.swift */; };
 		F1A2B3F02FB0000100AAA001 /* ReaderPageLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3F12FB0000100AAA001 /* ReaderPageLayout.swift */; };
 		F1A2B3F22FC0000100AAA001 /* ReaderPositioningInvariantTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3F32FC0000100AAA001 /* ReaderPositioningInvariantTests.swift */; };
+		F1A2B3F62FD0000100AAA001 /* UploadFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3F72FD0000100AAA001 /* UploadFeatureTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -203,6 +204,7 @@
 		E98B8B7A2A0A7B68004CBBC0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E98B8B8D2A0B12F3004CBBC0 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		E98B8B8F2A0BA9D1004CBBC0 /* UploadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadView.swift; sourceTree = "<group>"; };
+		F1A2B3F72FD0000100AAA001 /* UploadFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadFeatureTests.swift; sourceTree = "<group>"; };
 		E9965AA92D6830D800114E32 /* UICacheView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UICacheView.swift; sourceTree = "<group>"; };
 		E997D7FF2AF20EE2007C91F1 /* ArchiveGridV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveGridV2.swift; sourceTree = "<group>"; };
 		E99D2B3F2B0176400029FDEC /* mul */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; name = mul; path = mul.lproj/LaunchScreen.xcstrings; sourceTree = "<group>"; };
@@ -466,6 +468,7 @@
 				F1A2B3D92F90000200AAA001 /* SearchFeatureTests.swift */,
 				F1A2B3E62FA0000100AAA001 /* PaginationPositioningTests.swift */,
 				F1A2B3F32FC0000100AAA001 /* ReaderPositioningInvariantTests.swift */,
+				F1A2B3F72FD0000100AAA001 /* UploadFeatureTests.swift */,
 				7D354CB824F1316E00617F4A /* Info.plist */,
 				4BD820A697A4726B7B747BFD /* Service */,
 			);
@@ -807,6 +810,7 @@
 				F1A2B3CE2F80000100AAA001 /* LogTextRendererTests.swift in Sources */,
 				F1A2B3E52FA0000100AAA001 /* PaginationPositioningTests.swift in Sources */,
 				F1A2B3F22FC0000100AAA001 /* ReaderPositioningInvariantTests.swift in Sources */,
+				F1A2B3F62FD0000100AAA001 /* UploadFeatureTests.swift in Sources */,
 				F1A2B3D82F90000200AAA001 /* SearchFeatureTests.swift in Sources */,
 				4BD82555CE41A0467CCC6411 /* LANraragiServiceTest.swift in Sources */,
 				7DF6FFAA252DC3BB009280A5 /* FileUtils.swift in Sources */,
@@ -983,7 +987,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreader.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 219;
+				CURRENT_PROJECT_VERSION = 220;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1011,7 +1015,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreaderRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 219;
+				CURRENT_PROJECT_VERSION = 220;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1085,7 +1089,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 219;
+				CURRENT_PROJECT_VERSION = 220;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1115,7 +1119,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 219;
+				CURRENT_PROJECT_VERSION = 220;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;

--- a/LANreader/Setting/UploadView.swift
+++ b/LANreader/Setting/UploadView.swift
@@ -9,6 +9,7 @@ import Logging
     public struct State: Equatable {
         var urls = ""
         var jobDetails: [Int: DownloadJob] = .init()
+        var hasLoadedJobs = false
         var isQueueing = false
         var retryingJobIDs: Set<Int> = []
         var retiredJobIDs: Set<Int> = []
@@ -20,13 +21,19 @@ import Logging
         case queueDownloadFinished([DownloadJob])
         case retryDownload(Int)
         case retryDownloadFinished(originalJobID: Int, jobs: [DownloadJob])
-        case addJobDetails([DownloadJob])
+        case jobsLoaded([DownloadJob], expiredJobIDs: Set<Int>)
+        case jobStatusUpdated(DownloadJob)
         case checkJobStatus
+    }
+
+    private enum CancelID {
+        case jobPolling
     }
 
     @Dependency(\.lanraragiService) var service
     @Dependency(\.appDatabase) var database
     @Dependency(\.continuousClock) var clock
+    @Dependency(\.date.now) var now
 
     public var body: some Reducer<State, Action> {
         BindingReducer()
@@ -44,7 +51,7 @@ import Logging
                     state.retiredJobIDs.remove($0.id)
                     state.jobDetails[$0.id] = $0
                 }
-                return .none
+                return jobs.isEmpty ? .none : .send(.checkJobStatus)
             case let .retryDownload(id):
                 guard let job = state.jobDetails[id],
                       job.isError,
@@ -74,12 +81,22 @@ import Logging
                         state.jobDetails[$0.id] = $0
                     }
                 }
-                return .none
-            case let .addJobDetails(jobs):
+                return jobs.isEmpty ? .none : .send(.checkJobStatus)
+            case let .jobsLoaded(jobs, expiredJobIDs):
+                state.hasLoadedJobs = true
+                expiredJobIDs.forEach {
+                    state.retiredJobIDs.insert($0)
+                    state.jobDetails.removeValue(forKey: $0)
+                }
                 jobs.forEach {
                     if !state.retiredJobIDs.contains($0.id) {
                         state.jobDetails[$0.id] = $0
                     }
+                }
+                return .none
+            case let .jobStatusUpdated(job):
+                if !state.retiredJobIDs.contains(job.id) {
+                    state.jobDetails[job.id] = job
                 }
                 return .none
             case .checkJobStatus:
@@ -90,34 +107,63 @@ import Logging
                             downloadJobs = try database.readAllDownloadJobs()
                         } catch {
                             logger.error("failed to retrieve download jobs from db. \(error)")
-                            downloadJobs = .init()
+                            await send(.jobsLoaded([], expiredJobIDs: []))
+                            try await clock.sleep(for: .seconds(5))
+                            continue
                         }
-                        var updatedJobs: [DownloadJob] = .init()
+
+                        var currentJobs: [DownloadJob] = []
+                        var expiredJobIDs: Set<Int> = []
                         for job in downloadJobs {
-                            if job.lastUpdate.addingTimeInterval(3600) < Date() {
-                                _ = try? database.deleteDownloadJobs(job.id)
-                            }
-                            if !job.isSuccess && !job.isError {
+                            if job.lastUpdate.addingTimeInterval(3600) < now {
+                                expiredJobIDs.insert(job.id)
                                 do {
-                                    let response = try await service.checkJobStatus(id: job.id).value
-                                    var downloadJob = response.toDownloadJob(url: job.url)
-                                    updatedJobs.append(downloadJob)
-                                    do {
-                                        try database.saveDownloadJob(&downloadJob)
-                                    } catch {
-                                        logger.error("failed to save updated job to database. id=\(job.id), \(error)")
-                                    }
+                                    _ = try database.deleteDownloadJobs(job.id)
                                 } catch {
-                                    logger.error("failed to check job status. id=\(job.id) \(error)")
+                                    logger.error("failed to delete expired download job. id=\(job.id), \(error)")
                                 }
-                            } else {
-                                updatedJobs.append(job)
+                                continue
+                            }
+                            currentJobs.append(job)
+                        }
+                        await send(.jobsLoaded(currentJobs, expiredJobIDs: expiredJobIDs))
+
+                        let unfinishedJobs = currentJobs.filter { !$0.isSuccess && !$0.isError }
+                        guard !unfinishedJobs.isEmpty else {
+                            return
+                        }
+
+                        var shouldContinuePolling = false
+                        for job in unfinishedJobs {
+                            do {
+                                let response = try await service.checkJobStatus(id: job.id).value
+                                var downloadJob = response.toDownloadJob(url: job.url)
+                                downloadJob.lastUpdate = now
+                                do {
+                                    try database.saveDownloadJob(&downloadJob)
+                                } catch {
+                                    logger.error("failed to save updated job to database. id=\(job.id), \(error)")
+                                }
+                                await send(.jobStatusUpdated(downloadJob))
+                                if !downloadJob.isSuccess && !downloadJob.isError {
+                                    shouldContinuePolling = true
+                                }
+                            } catch {
+                                if Task.isCancelled {
+                                    return
+                                }
+                                logger.error("failed to check job status. id=\(job.id) \(error)")
+                                shouldContinuePolling = true
                             }
                         }
-                        await send(.addJobDetails(updatedJobs))
+
+                        guard shouldContinuePolling else {
+                            return
+                        }
                         try await clock.sleep(for: .seconds(5))
                     } while true
                 }
+                .cancellable(id: CancelID.jobPolling, cancelInFlight: true)
             case .binding:
                 return .none
             }
@@ -140,7 +186,7 @@ import Logging
                             isSuccess: false,
                             isError: false,
                             message: "",
-                            lastUpdate: Date()
+                            lastUpdate: now
                         )
                         try? database.saveDownloadJob(&downloadJob)
                         jobs.append(downloadJob)
@@ -178,7 +224,7 @@ struct UploadView: View {
             }
         }
         .task {
-            store.send(.checkJobStatus)
+            await store.send(.checkJobStatus).finish()
         }
         .toolbar(.hidden, for: .tabBar)
     }
@@ -251,8 +297,12 @@ struct UploadView: View {
                 jobCard(detail)
             }
 
-            if sortedJobs.isEmpty {
+            if sortedJobs.isEmpty && store.hasLoadedJobs {
                 emptyJobsView
+            } else if sortedJobs.isEmpty {
+                ProgressView()
+                    .frame(maxWidth: .infinity)
+                    .padding(16)
             }
         }
     }

--- a/LANreaderTests/UploadFeatureTests.swift
+++ b/LANreaderTests/UploadFeatureTests.swift
@@ -1,0 +1,202 @@
+import XCTest
+import ComposableArchitecture
+import GRDB
+import OHHTTPStubs
+import OHHTTPStubsSwift
+@testable import LANreader
+
+final class UploadFeatureTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 2_000_000_000)
+
+    override func tearDownWithError() throws {
+        UserDefaults.resetStandardUserDefaults()
+        HTTPStubs.removeAllStubs()
+    }
+
+    @MainActor
+    func testCheckJobStatusShowsCachedJobBeforeRefreshingIt() async throws {
+        let database = try AppDatabase(DatabaseQueue())
+        let cachedJob = Self.makeJob(id: 7, lastUpdate: now.addingTimeInterval(-60))
+        var storedJob = cachedJob
+        try database.saveDownloadJob(&storedJob)
+        let service = try await Self.configuredService()
+        Self.stubJobStatus(id: 7, state: "finished", success: 1)
+
+        let store = TestStore(initialState: UploadFeature.State()) {
+            UploadFeature()
+        } withDependencies: {
+            $0.appDatabase = database
+            $0.lanraragiService = service
+            $0.date.now = now
+        }
+
+        let task = await store.send(.checkJobStatus)
+        await store.receive(\.jobsLoaded) {
+            $0.hasLoadedJobs = true
+            $0.jobDetails[7] = cachedJob
+        }
+
+        let refreshedJob = Self.makeJob(
+            id: 7,
+            title: "Archive Title",
+            isActive: false,
+            isSuccess: true,
+            message: "Done",
+            lastUpdate: now
+        )
+        await store.receive(\.jobStatusUpdated) {
+            $0.jobDetails[7] = refreshedJob
+        }
+        await task.finish()
+
+        XCTAssertEqual(try database.readAllDownloadJobs(), [refreshedJob])
+    }
+
+    @MainActor
+    func testCheckJobStatusRemovesExpiredJobsWithoutRefreshingThem() async throws {
+        let database = try AppDatabase(DatabaseQueue())
+        var expiredJob = Self.makeJob(id: 7, lastUpdate: now.addingTimeInterval(-3601))
+        let completedJob = Self.makeJob(
+            id: 8,
+            isActive: false,
+            isSuccess: true,
+            lastUpdate: now.addingTimeInterval(-60)
+        )
+        var storedCompletedJob = completedJob
+        try database.saveDownloadJob(&expiredJob)
+        try database.saveDownloadJob(&storedCompletedJob)
+
+        let store = TestStore(initialState: UploadFeature.State()) {
+            UploadFeature()
+        } withDependencies: {
+            $0.appDatabase = database
+            $0.date.now = now
+        }
+
+        let task = await store.send(.checkJobStatus)
+        await store.receive(\.jobsLoaded) {
+            $0.hasLoadedJobs = true
+            $0.jobDetails[8] = completedJob
+            $0.retiredJobIDs = [7]
+        }
+        await task.finish()
+
+        XCTAssertEqual(try database.readAllDownloadJobs(), [completedJob])
+    }
+
+    @MainActor
+    func testCheckJobStatusCanBeCancelledWhilePollingAnActiveJob() async throws {
+        let database = try AppDatabase(DatabaseQueue())
+        let cachedJob = Self.makeJob(id: 7, lastUpdate: now.addingTimeInterval(-60))
+        var storedJob = cachedJob
+        try database.saveDownloadJob(&storedJob)
+        let service = try await Self.configuredService()
+        Self.stubJobStatus(id: 7, state: "active", success: nil)
+        let clock = TestClock()
+
+        let store = TestStore(initialState: UploadFeature.State()) {
+            UploadFeature()
+        } withDependencies: {
+            $0.appDatabase = database
+            $0.lanraragiService = service
+            $0.continuousClock = clock
+            $0.date.now = now
+        }
+
+        let task = await store.send(.checkJobStatus)
+        await store.receive(\.jobsLoaded) {
+            $0.hasLoadedJobs = true
+            $0.jobDetails[7] = cachedJob
+        }
+
+        let refreshedJob = Self.makeJob(id: 7, lastUpdate: now)
+        await store.receive(\.jobStatusUpdated) {
+            $0.jobDetails[7] = refreshedJob
+        }
+        await task.cancel()
+    }
+
+    private static func configuredService() async throws -> LANraragiService {
+        let body = Data("""
+        {
+          "archives_per_page": 100,
+          "debug_mode": false,
+          "has_password": true,
+          "motd": "Welcome",
+          "name": "LANraragi",
+          "nofun_mode": false,
+          "server_tracks_progress": true,
+          "version": "0.9.30",
+          "version_name": "Law"
+        }
+        """.utf8)
+        stub(condition: isHost("localhost")
+                && isPath("/api/info")
+                && isMethodGET()) { _ in
+            HTTPStubsResponse(
+                data: body,
+                statusCode: 200,
+                headers: ["Content-Type": "application/json"]
+            )
+        }
+
+        let service = LANraragiService.shared
+        _ = try await service.verifyClient(url: "https://localhost", apiKey: "apiKey")
+        return service
+    }
+
+    private static func stubJobStatus(id: Int, state: String, success: Int?) {
+        let result: String
+        if let success {
+            result = """
+            {
+              "success": \(success),
+              "url": "https://example.com/archive.zip",
+              "title": "Archive Title",
+              "message": "Done"
+            }
+            """
+        } else {
+            result = "null"
+        }
+        let body = Data("""
+        {
+          "id": "\(id)",
+          "state": "\(state)",
+          "task": "download_url",
+          "result": \(result)
+        }
+        """.utf8)
+
+        stub(condition: isHost("localhost")
+                && isPath("/api/minion/\(id)/detail")
+                && isMethodGET()) { _ in
+            HTTPStubsResponse(
+                data: body,
+                statusCode: 200,
+                headers: ["Content-Type": "application/json"]
+            )
+        }
+    }
+
+    private static func makeJob(
+        id: Int,
+        title: String = "",
+        isActive: Bool = true,
+        isSuccess: Bool = false,
+        isError: Bool = false,
+        message: String = "",
+        lastUpdate: Date
+    ) -> DownloadJob {
+        DownloadJob(
+            id: id,
+            url: "https://example.com/archive.zip",
+            title: title,
+            isActive: isActive,
+            isSuccess: isSuccess,
+            isError: isError,
+            message: message,
+            lastUpdate: lastUpdate
+        )
+    }
+}


### PR DESCRIPTION
## Change

Refresh the Upload page from locally stored jobs as soon as it appears, then poll only unfinished jobs every five seconds until they reach a terminal state or the view leaves. Queue and retry flows restart polling, expired jobs are removed without another server request, and the empty state waits for the initial local read. The change stays within the existing Upload feature and lifecycle task.

## Risk surface

- [ ] Reader, navigation, image rendering, cache, or Tankoubon behavior
- [ ] LANraragi request or response contract
- [x] Persistence, migration, or offline behavior
- [ ] Localized user interface
- [x] Xcode project, dependency, CI, or release automation
- [ ] None of the above

## Evidence

Commands run and outcomes:

- `./scripts/verify` passed repository checks, SwiftLint with 0 violations, and 225 tests with 0 failures.
- Resolved build-setting checks for LANreader and Action, Debug and Release, all returned marketing version `3.10.0` and build `220`.
- `git diff --check` and `plutil -lint LANreader.xcodeproj/project.pbxproj` passed.

Behavior evidence (focused test names, screenshots, or manual scenario):

- `testCheckJobStatusShowsCachedJobBeforeRefreshingIt`
- `testCheckJobStatusRemovesExpiredJobsWithoutRefreshingThem`
- `testCheckJobStatusCanBeCancelledWhilePollingAnActiveJob`

Checks not run or known gaps:

- No manual device/server scenario was run; reducer tests cover cached loading, expiration, progressive refresh, and cancellation.

## Durable learning (only when applicable)

Regression test, automated guard, or concise `AGENTS.md` update:

- Added `UploadFeatureTests` coverage for immediate cached display, expired-job cleanup, and lifecycle polling cancellation.