### PR TITLE
Show cache removal in archive details

### DIFF
--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -987,7 +987,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreader.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 223;
+				CURRENT_PROJECT_VERSION = 224;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -998,7 +998,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.0;
+				MARKETING_VERSION = 3.10.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1015,7 +1015,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreaderRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 223;
+				CURRENT_PROJECT_VERSION = 224;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1026,7 +1026,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.0;
+				MARKETING_VERSION = 3.10.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1089,7 +1089,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 223;
+				CURRENT_PROJECT_VERSION = 224;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1101,7 +1101,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.10.0;
+				MARKETING_VERSION = 3.10.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1119,7 +1119,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 223;
+				CURRENT_PROJECT_VERSION = 224;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1131,7 +1131,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.10.0;
+				MARKETING_VERSION = 3.10.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/LANreader/Page/ArchiveDetailsV2.swift
+++ b/LANreader/Page/ArchiveDetailsV2.swift
@@ -24,6 +24,7 @@ import GRDBQuery
         var loading = false
         let cached: Bool
         var showAlert: Bool = false
+        var deleteSucceeded = false
 
         init(
             archive: Shared<ArchiveItem>,
@@ -37,6 +38,19 @@ import GRDBQuery
 
         var isTankoubon: Bool {
             archive.id.isTankoubonArchiveId
+        }
+
+        enum DeleteTarget: Equatable {
+            case cache
+            case archive
+            case tankoubon
+        }
+
+        var deleteTarget: DeleteTarget {
+            if cached {
+                return .cache
+            }
+            return isTankoubon ? .tankoubon : .archive
         }
     }
 
@@ -100,6 +114,29 @@ import GRDBQuery
                 return .none
             case .confirmDelete:
                 state.loading = true
+                state.deleteSucceeded = false
+                if state.cached {
+                    return .run { [id = state.archive.id] send in
+                        let deleted = try database.deleteCache(id)
+                        guard deleted else {
+                            await send(.setErrorMessage(
+                                String(localized: "archive.cache.remove.failed")
+                            ))
+                            return
+                        }
+                        if let cachePath = LANraragiService.cachePath {
+                            let cacheFolder = cachePath.appendingPathComponent(
+                                id,
+                                conformingTo: .folder
+                            )
+                            try? FileManager.default.removeItem(at: cacheFolder)
+                        }
+                        await send(.deleteSuccess)
+                    } catch: { [id = state.archive.id] error, send in
+                        logger.error("failed to remove archive cache, id=\(id) \(error)")
+                        await send(.setErrorMessage(error.localizedDescription))
+                    }
+                }
                 return .run { [id = state.archive.id] send in
                     let response = if id.isTankoubonArchiveId {
                         try await service.deleteTankoubon(id: id).value
@@ -212,8 +249,12 @@ import GRDBQuery
                 state.successMessage = message
                 return .none
             case .deleteSuccess:
-                state.$archiveItems.withLock {
-                    _ = $0.remove(id: state.archive.id)
+                state.loading = false
+                state.deleteSucceeded = true
+                if !state.cached {
+                    state.$archiveItems.withLock {
+                        _ = $0.remove(id: state.archive.id)
+                    }
                 }
                 return .none
             case .binding:
@@ -244,9 +285,14 @@ struct ArchiveDetailsV2: View {
     }
 
     var body: some View {
-        let deleteConfirmationTitle: LocalizedStringKey = store.isTankoubon
-            ? "archive.delete.tankoubon.confirm"
-            : "archive.delete.confirm"
+        let deleteConfirmationTitle: LocalizedStringKey = switch store.deleteTarget {
+        case .cache:
+            "archive.cache.remove.message"
+        case .archive:
+            "archive.delete.confirm"
+        case .tankoubon:
+            "archive.delete.tankoubon.confirm"
+        }
 
         ScrollView {
             VStack(spacing: 22) {
@@ -309,10 +355,9 @@ struct ArchiveDetailsV2: View {
                 Task {
                     await store.send(.confirmDelete).finish()
                 }
-                onDelete()
             }
         } message: {
-            if store.isTankoubon {
+            if store.deleteTarget == .tankoubon {
                 Text("archive.delete.tankoubon.confirm.message")
             }
         }
@@ -341,6 +386,11 @@ struct ArchiveDetailsV2: View {
                 )
                 banner.show()
                 store.send(.setErrorMessage(""))
+            }
+        }
+        .onChange(of: store.deleteSucceeded) {
+            if store.deleteSucceeded {
+                onDelete()
             }
         }
     }
@@ -532,14 +582,19 @@ struct ArchiveDetailsV2: View {
 
     @ViewBuilder
     private func deleteButton(store: StoreOf<ArchiveDetailsFeature>) -> some View {
-        if store.editMode != .active && !store.cached {
+        if store.editMode != .active {
             Button(
                 role: .destructive,
                 action: { store.send(.deleteButtonTapped) },
                 label: {
-                    let titleKey: LocalizedStringKey = store.isTankoubon
-                        ? "archive.delete.tankoubon"
-                        : "archive.delete"
+                    let titleKey: LocalizedStringKey = switch store.deleteTarget {
+                    case .cache:
+                        "archive.cache.remove"
+                    case .archive:
+                        "archive.delete"
+                    case .tankoubon:
+                        "archive.delete.tankoubon"
+                    }
 
                     Label(titleKey, systemImage: "trash")
                         .font(.headline)

--- a/LANreaderTests/ArchiveDetailsTagParserTests.swift
+++ b/LANreaderTests/ArchiveDetailsTagParserTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import ComposableArchitecture
+import GRDB
 @testable import LANreader
 
 final class ArchiveDetailsTagParserTests: XCTestCase {
@@ -112,6 +113,58 @@ final class ArchiveDetailsTagParserTests: XCTestCase {
                 $0.tags = "artist:new,series:one,artist:first"
             }
         }
+    }
+
+    @MainActor
+    func testCachedArchiveDetailsRemovesLocalCache() async throws {
+        let id = "cachedArchiveDetails"
+        let database = try AppDatabase(DatabaseQueue())
+        var cache = ArchiveCache(
+            id: id,
+            title: "Cached archive",
+            tags: "",
+            thumbnail: nil,
+            cached: true,
+            totalPages: 1,
+            toc: nil,
+            lastUpdate: Date(timeIntervalSince1970: 1)
+        )
+        try database.saveCache(&cache)
+
+        let cacheFolder = LANraragiService.cachePath!
+            .appendingPathComponent(id, conformingTo: .folder)
+        try? FileManager.default.removeItem(at: cacheFolder)
+        try FileManager.default.createDirectory(at: cacheFolder, withIntermediateDirectories: true)
+        _ = FileManager.default.createFile(
+            atPath: cacheFolder.appendingPathComponent("1.jpg").path,
+            contents: Data()
+        )
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: cacheFolder)
+        }
+
+        let state = ArchiveDetailsFeature.State(
+            archive: Shared(value: cache.toArchiveItem()),
+            cached: true
+        )
+        XCTAssertEqual(state.deleteTarget, .cache)
+
+        let store = TestStore(initialState: state) {
+            ArchiveDetailsFeature()
+        } withDependencies: {
+            $0.appDatabase = database
+        }
+
+        await store.send(.confirmDelete) {
+            $0.loading = true
+        }
+        await store.receive(.deleteSuccess) {
+            $0.loading = false
+            $0.deleteSucceeded = true
+        }
+
+        XCTAssertNil(try database.readCache(id))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: cacheFolder.path))
     }
 }
 


### PR DESCRIPTION
## Change

Cached archive details now show the existing localized “Remove archive from cache” action. Confirming it removes only the local cache database row and cached files, leaves the server archive untouched, and navigates away only after deletion succeeds. The change reuses the existing details flow and cache copy rather than adding another control path.

LANreader and Action are synchronized at marketing version 3.10.1 and build 224.

## Risk surface

- [x] Reader, navigation, image rendering, cache, or Tankoubon behavior
- [ ] LANraragi request or response contract
- [x] Persistence, migration, or offline behavior
- [x] Localized user interface
- [x] Xcode project, dependency, CI, or release automation
- [ ] None of the above

## Evidence

Commands run and outcomes:

- `./scripts/verify` — passed repository checks, SwiftLint with zero violations, and 232 iOS tests with zero failures.
- `xcodebuild -showBuildSettings -json` for LANreader and Action in Debug and Release — all resolved to marketing version 3.10.1 and build 224.
- `git diff --check` — passed.

Behavior evidence (focused test names, screenshots, or manual scenario):

- `testCachedArchiveDetailsRemovesLocalCache` verifies cached details select local-cache deletion, remove the database row and cached page folder, and complete successfully.

Checks not run or known gaps:

- Manual simulator interaction was not run; pull request CI is pending.

## Durable learning (only when applicable)

Regression test, automated guard, or concise `AGENTS.md` update:

- Added `testCachedArchiveDetailsRemovesLocalCache` to keep the cached-details delete path local-only and verify both persistence and file cleanup.
