### PR TITLE
Add batch cache removal

### DIFF
--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -987,7 +987,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreader.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 232;
+				CURRENT_PROJECT_VERSION = 233;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -998,7 +998,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.1;
+				MARKETING_VERSION = 3.10.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1015,7 +1015,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreaderRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 232;
+				CURRENT_PROJECT_VERSION = 233;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1026,7 +1026,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.1;
+				MARKETING_VERSION = 3.10.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1089,7 +1089,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 232;
+				CURRENT_PROJECT_VERSION = 233;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1101,7 +1101,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.10.1;
+				MARKETING_VERSION = 3.10.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1119,7 +1119,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 232;
+				CURRENT_PROJECT_VERSION = 233;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1131,7 +1131,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.10.1;
+				MARKETING_VERSION = 3.10.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/LANreader/Library/CacheView.swift
+++ b/LANreader/Library/CacheView.swift
@@ -8,6 +8,8 @@ import NotificationBannerSwift
         var archives: IdentifiedArrayOf<GridFeature.State> = []
         var downloading: [String: PageProgress] = [:]
         var errorMessage: String = ""
+        var isSelecting = false
+        var selected: Set<String> = []
     }
 
     public enum Action: Equatable {
@@ -16,6 +18,9 @@ import NotificationBannerSwift
         case removeItemFromDownloading(String)
         case updateProgressInDownloading(String, Int)
         case removeCache(String)
+        case toggleSelectionMode
+        case toggleSelection(String)
+        case removeSelected
         case setErrorMessage(String)
     }
 
@@ -29,6 +34,23 @@ import NotificationBannerSwift
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
+            case .toggleSelectionMode:
+                state.isSelecting.toggle()
+                state.selected.removeAll()
+                return .none
+            case let .toggleSelection(id):
+                guard state.isSelecting, state.archives[id: id] != nil else { return .none }
+                if !state.selected.insert(id).inserted {
+                    state.selected.remove(id)
+                }
+                return .none
+            case .removeSelected:
+                let selected = state.selected.sorted()
+                return .run { send in
+                    for id in selected {
+                        await send(.removeCache(id))
+                    }
+                }
             case .load:
                 guard let allCaches = try? database.readAllCached() else {
                     return .cancel(id: CancelID.progressPolling)
@@ -47,6 +69,7 @@ import NotificationBannerSwift
                     )
                 }
                 state.archives = IdentifiedArray(uniqueElements: gridStates)
+                state.selected.formIntersection(state.archives.ids)
                 state.downloading = downloading
                 return progressPollingEffect(downloading)
             case let .removeItemFromDownloading(id):
@@ -62,6 +85,7 @@ import NotificationBannerSwift
                     return .send(.setErrorMessage(errorMessage))
                 }
                 state.archives.remove(id: id)
+                state.selected.remove(id)
                 state.downloading.removeValue(forKey: id)
                 let cacheFolder = LANraragiService.cachePath!
                     .appendingPathComponent(id, conformingTo: .folder)
@@ -124,6 +148,7 @@ import NotificationBannerSwift
 
 struct CacheView: View {
     @Environment(NavigationHelper.self) private var navigation
+    @State private var confirmingRemoval = false
 
     let store: StoreOf<CacheFeature>
 
@@ -143,6 +168,28 @@ struct CacheView: View {
                 }
             }
             .padding(.horizontal)
+        }
+        .safeAreaInset(edge: .bottom) {
+            if store.isSelecting {
+                HStack {
+                    Text(String(format: String(localized: "archive.selected"), store.selected.count))
+                    Spacer()
+                    Button(role: .destructive) {
+                        confirmingRemoval = true
+                    } label: {
+                        Label("archive.cache.remove", systemImage: "trash")
+                            .labelStyle(.iconOnly)
+                    }
+                    .disabled(store.selected.isEmpty)
+                }
+                .padding()
+                .background(.bar)
+            }
+        }
+        .confirmationDialog("archive.selected.delete", isPresented: $confirmingRemoval, titleVisibility: .visible) {
+            Button("archive.cache.remove", role: .destructive) {
+                store.send(.removeSelected)
+            }
         }
         .task {
             await store.send(.load).finish()
@@ -229,10 +276,24 @@ struct CacheView: View {
                 : nil
             }
             .contextMenu {
-                contextMenu(gridStore: gridStore, inProgress: inProgress)
+                if !store.isSelecting {
+                    contextMenu(gridStore: gridStore, inProgress: inProgress)
+                }
             }
+            .overlay(alignment: .topTrailing) {
+                if store.isSelecting {
+                    Image(systemName: store.selected.contains(gridStore.id) ? "checkmark.circle.fill" : "circle")
+                        .font(.title2)
+                        .foregroundStyle(.white, Color.accentColor)
+                        .padding(8)
+                        .accessibilityHidden(true)
+                }
+            }
+            .accessibilityAddTraits(store.selected.contains(gridStore.id) ? [.isSelected, .isButton] : .isButton)
             .onTapGesture {
-                if !inProgress {
+                if store.isSelecting {
+                    store.send(.toggleSelection(gridStore.id))
+                } else if !inProgress {
                     openReader(gridStore: gridStore)
                 }
             }

--- a/LANreader/Library/CacheView.swift
+++ b/LANreader/Library/CacheView.swift
@@ -181,14 +181,16 @@ struct CacheView: View {
                             .labelStyle(.iconOnly)
                     }
                     .disabled(store.selected.isEmpty)
+                    .confirmationDialog(
+                        "archive.selected.delete", isPresented: $confirmingRemoval, titleVisibility: .visible
+                    ) {
+                        Button("archive.cache.remove", role: .destructive) {
+                            store.send(.removeSelected)
+                        }
+                    }
                 }
                 .padding()
                 .background(.bar)
-            }
-        }
-        .confirmationDialog("archive.selected.delete", isPresented: $confirmingRemoval, titleVisibility: .visible) {
-            Button("archive.cache.remove", role: .destructive) {
-                store.send(.removeSelected)
             }
         }
         .task {
@@ -283,7 +285,7 @@ struct CacheView: View {
             .overlay(alignment: .topTrailing) {
                 if store.isSelecting {
                     Image(systemName: store.selected.contains(gridStore.id) ? "checkmark.circle.fill" : "circle")
-                        .font(.title2)
+                        .font(.largeTitle)
                         .foregroundStyle(.white, Color.accentColor)
                         .padding(8)
                         .accessibilityHidden(true)

--- a/LANreader/Library/UICacheView.swift
+++ b/LANreader/Library/UICacheView.swift
@@ -20,6 +20,15 @@ class UICacheViewController: UIViewController, UICollectionViewDelegate {
         super.viewDidLoad()
 
         navigationItem.title = String(localized: "cached")
+        observe { [weak self] in
+            guard let self else { return }
+            navigationItem.rightBarButtonItem = UIBarButtonItem(
+                title: store.isSelecting ? String(localized: "done") : String(localized: "select"),
+                primaryAction: UIAction { [weak self] _ in
+                    self?.store.send(.toggleSelectionMode)
+                }
+            )
+        }
 
         let hostingController = UIHostingController(
             rootView: CacheView(store: store)

--- a/LANreaderTests/ArchiveReaderFeatureTests.swift
+++ b/LANreaderTests/ArchiveReaderFeatureTests.swift
@@ -2446,6 +2446,45 @@ final class ArchiveReaderFeatureTests: XCTestCase {
     }
 
     @MainActor
+    func testCacheBatchRemovalOnlyDeletesSelectedArchives() async throws {
+        let database = try makeInMemoryDatabase()
+        var initialState = CacheFeature.State()
+        let ids = (0..<3).map { "batch-\(UUID().uuidString)-\($0)" }.sorted()
+        for id in ids {
+            var cache = ArchiveCache(
+                id: id, title: id, tags: "", thumbnail: nil,
+                cached: true, totalPages: 1, lastUpdate: Date()
+            )
+            try database.saveCache(&cache)
+            initialState.archives.append(GridFeature.State(archive: Shared(value: cache.toArchiveItem()), cached: true))
+        }
+        let store = TestStore(initialState: initialState) {
+            CacheFeature()
+        } withDependencies: {
+            $0.appDatabase = database
+        }
+        await store.send(.toggleSelectionMode) { $0.isSelecting = true }
+        await store.send(.toggleSelection(ids[0])) { $0.selected = [ids[0]] }
+        await store.send(.toggleSelection(ids[1])) { $0.selected = [ids[0], ids[1]] }
+        await store.send(.toggleSelection(ids[1])) { $0.selected = [ids[0]] }
+        await store.send(.toggleSelection(ids[2])) { $0.selected = [ids[0], ids[2]] }
+        await store.send(.removeSelected)
+        for id in [ids[0], ids[2]] {
+            await store.receive(.removeCache(id)) {
+                $0.archives.remove(id: id)
+                $0.selected.remove(id)
+            }
+        }
+        await store.finish()
+        XCTAssertEqual(try database.readAllCached().map(\.id), [ids[1]])
+        await store.send(.toggleSelection(ids[1])) { $0.selected = [ids[1]] }
+        await store.send(.toggleSelectionMode) {
+            $0.isSelecting = false
+            $0.selected = []
+        }
+    }
+
+    @MainActor
     func testCacheFeatureLoadRestoresChapters() async throws {
         let chapters = [
             ArchiveChapter(name: "Opening", page: 1),


### PR DESCRIPTION
## Change

Add Select/Done to Cache View so multiple cached archives can be removed together. Selected tiles show checkmarks; a bottom toolbar displays the selection count and an accessible trash icon, with confirmation before removal. Reuses the existing local cache-removal action and localized strings, keeping Cache View offline.

Addresses the batch-removal portion of #383. Batch download and progress synchronization remain separate work.

## Risk surface

- [x] Reader, navigation, image rendering, cache, or Tankoubon behavior
- [ ] LANraragi request or response contract
- [x] Persistence, migration, or offline behavior
- [x] Localized user interface
- [x] Xcode project, dependency, CI, or release automation
- [ ] None of the above

## Evidence

Commands run and outcomes:
- `./scripts/verify`: passed repository checks, lint, and the full iOS test suite.
- `git diff --check`: passed.
- Marketing version increased to 3.10.2 and build number from 232 to 233 across LANreader and Action configurations.

Behavior evidence (focused test names, screenshots, or manual scenario):
- `testCacheBatchRemovalOnlyDeletesSelectedArchives` covers selection, deselection, removal of selected cache records, preservation of unselected records, and clearing selection on Done.
- Selection mode suppresses reader opening and context menus; batch removal dispatches the existing local removal action for each selected archive.

Checks not run or known gaps:
- No automated visual or VoiceOver review; toolbar and selection appearance need device review.
- Existing download cancellation and file-removal error handling are unchanged.

## Durable learning (only when applicable)

Added the focused batch-removal regression test to `ArchiveReaderFeatureTests`.
