### PR TITLE
Add batch downloads from Library

### DIFF
--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		F1A2B3C62F60000200AAA001 /* ArchiveDetailsTagParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C92F60000200AAA001 /* ArchiveDetailsTagParserTests.swift */; };
 		F1A2B3CA2F60000300AAA001 /* ArchiveDetailsTagParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3CB2F60000300AAA001 /* ArchiveDetailsTagParser.swift */; };
 		F1A2B3CC2F70000100AAA001 /* ArchiveListFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3CD2F70000100AAA001 /* ArchiveListFeatureTests.swift */; };
+		AB3870010000000000000001 /* ArchiveListSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3870010000000000000002 /* ArchiveListSelectionTests.swift */; };
 		F1A2B3CE2F80000100AAA001 /* LogTextRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3CF2F80000100AAA001 /* LogTextRendererTests.swift */; };
 		F1A2B3D52F60000400DDD001 /* LANraragiConfigFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3D42F60000400DDD001 /* LANraragiConfigFeatureTests.swift */; };
 		F1A2B3D62F90000100AAA001 /* SearchKeyword.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3D72F90000100AAA001 /* SearchKeyword.swift */; };
@@ -239,6 +240,7 @@
 		F1A2B3C92F60000200AAA001 /* ArchiveDetailsTagParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailsTagParserTests.swift; sourceTree = "<group>"; };
 		F1A2B3CB2F60000300AAA001 /* ArchiveDetailsTagParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailsTagParser.swift; sourceTree = "<group>"; };
 		F1A2B3CD2F70000100AAA001 /* ArchiveListFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveListFeatureTests.swift; sourceTree = "<group>"; };
+		AB3870010000000000000002 /* ArchiveListSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveListSelectionTests.swift; sourceTree = "<group>"; };
 		F1A2B3CF2F80000100AAA001 /* LogTextRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogTextRendererTests.swift; sourceTree = "<group>"; };
 		F1A2B3D42F60000400DDD001 /* LANraragiConfigFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LANraragiConfigFeatureTests.swift; sourceTree = "<group>"; };
 		F1A2B3D72F90000100AAA001 /* SearchKeyword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKeyword.swift; sourceTree = "<group>"; };
@@ -464,6 +466,7 @@
 				F1A2B3D42F60000400DDD001 /* LANraragiConfigFeatureTests.swift */,
 				F1A2B3C92F60000200AAA001 /* ArchiveDetailsTagParserTests.swift */,
 				F1A2B3CD2F70000100AAA001 /* ArchiveListFeatureTests.swift */,
+				AB3870010000000000000002 /* ArchiveListSelectionTests.swift */,
 				F1A2B3CF2F80000100AAA001 /* LogTextRendererTests.swift */,
 				F1A2B3D92F90000200AAA001 /* SearchFeatureTests.swift */,
 				F1A2B3E62FA0000100AAA001 /* PaginationPositioningTests.swift */,
@@ -807,6 +810,7 @@
 				F1A2B3D52F60000400DDD001 /* LANraragiConfigFeatureTests.swift in Sources */,
 				F1A2B3C62F60000200AAA001 /* ArchiveDetailsTagParserTests.swift in Sources */,
 				F1A2B3CC2F70000100AAA001 /* ArchiveListFeatureTests.swift in Sources */,
+				AB3870010000000000000001 /* ArchiveListSelectionTests.swift in Sources */,
 				F1A2B3CE2F80000100AAA001 /* LogTextRendererTests.swift in Sources */,
 				F1A2B3E52FA0000100AAA001 /* PaginationPositioningTests.swift in Sources */,
 				F1A2B3F22FC0000100AAA001 /* ReaderPositioningInvariantTests.swift in Sources */,
@@ -987,7 +991,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreader.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 233;
+				CURRENT_PROJECT_VERSION = 234;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1015,7 +1019,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreaderRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 233;
+				CURRENT_PROJECT_VERSION = 234;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1089,7 +1093,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 233;
+				CURRENT_PROJECT_VERSION = 234;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1119,7 +1123,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 233;
+				CURRENT_PROJECT_VERSION = 234;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;

--- a/LANreader/Common/UIArchiveCell.swift
+++ b/LANreader/Common/UIArchiveCell.swift
@@ -16,9 +16,19 @@ class UIArchiveCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func configure(with store: StoreOf<GridFeature>) {
+    func configure(with store: StoreOf<GridFeature>, selecting: Bool = false, selected: Bool = false) {
         contentConfiguration = UIHostingConfiguration {
             ArchiveGridV2(store: store)
+                .overlay(alignment: .topTrailing) {
+                    if selecting {
+                        Image(systemName: selected ? "checkmark.circle.fill" : "circle")
+                            .font(.largeTitle)
+                            .foregroundStyle(.white, Color.accentColor)
+                            .padding(8)
+                            .accessibilityHidden(true)
+                    }
+                }
+                .accessibilityAddTraits(selected ? [.isSelected, .isButton] : .isButton)
         }
         .margins(.all, 0)
     }

--- a/LANreader/Common/UIArchiveList.swift
+++ b/LANreader/Common/UIArchiveList.swift
@@ -33,6 +33,8 @@ import NotificationBannerSwift
         var errorMessage = ""
         var successMessage = ""
         var cachingArchiveIds: Set<String> = []
+        var batchCachingArchiveIds: Set<String> = []
+        var batchCacheHadSuccess = false
         var currentTab: TabName
 
         var archivesToDisplay: IdentifiedArrayOf<GridFeature.State> = []
@@ -82,6 +84,8 @@ import NotificationBannerSwift
         case appendArchives(String)
         case removeArchive(String)
         case cacheArchive(String)
+        case cacheSelected
+        case toggleSelectionMode
         case cacheArchiveFinished(String)
         case cacheArchiveFailed(String, String)
         case setErrorMessage(String)
@@ -114,6 +118,18 @@ import NotificationBannerSwift
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
+            case .toggleSelectionMode:
+                state.selectMode = state.selectMode == .active ? .inactive : .active
+                state.selected.removeAll()
+                return .none
+            case .cacheSelected:
+                let ids = state.selected.sorted()
+                state.selected.removeAll()
+                state.selectMode = .inactive
+                let previous = state.cachingArchiveIds
+                let effects = ids.map { cacheArchive(state: &state, id: $0) }
+                state.batchCachingArchiveIds.formUnion(state.cachingArchiveIds.subtracting(previous))
+                return .merge(effects)
             case let .setFilter(filter):
                 state.filter = filter
                 return .none
@@ -157,6 +173,7 @@ import NotificationBannerSwift
                     searchFilter: state.filter, sortby: sortby, start: start, order: order, append: true
                 )
             case let .removeArchive(id):
+                state.selected.remove(id)
                 state.archivesToDisplay.remove(id: id)
                 state.archives.remove(id: id)
                 state.$archiveItems.withLock {
@@ -179,6 +196,7 @@ import NotificationBannerSwift
                     state.pendingPage = nil
                 }
                 if !append {
+                    state.selected.removeAll()
                     state.archives = .init()
                     state.archivesToDisplay = .init()
                     state.total = 0
@@ -201,6 +219,7 @@ import NotificationBannerSwift
                     state.archivesToDisplay = state.archives
                 }
 
+                state.selected.formIntersection(state.archivesToDisplay.ids)
                 state.total = total
                 state.loading = false
                 state.showLoading = false
@@ -224,10 +243,11 @@ import NotificationBannerSwift
                 return cacheArchive(state: &state, id: id)
             case let .cacheArchiveFinished(id):
                 state.cachingArchiveIds.remove(id)
-                state.successMessage = String(localized: "archive.cache.added")
+                finishCaching(state: &state, id: id, succeeded: true)
                 return .none
             case let .cacheArchiveFailed(id, message):
                 state.cachingArchiveIds.remove(id)
+                finishCaching(state: &state, id: id, succeeded: false)
                 state.errorMessage = message
                 return .none
             case let .setErrorMessage(message):
@@ -254,6 +274,7 @@ import NotificationBannerSwift
                 }
                 return .none
             case let .addSelect(id):
+                guard state.selectMode == .active, state.archivesToDisplay[id: id] != nil else { return .none }
                 state.selected.insert(id)
                 return .none
             case let .removeSelect(id):
@@ -279,6 +300,7 @@ import NotificationBannerSwift
                     state.archivesToDisplay = state.archives
                 }
 
+                state.selected.formIntersection(state.archivesToDisplay.ids)
                 return .none
             case .alert(.dismiss):
                 return .none
@@ -371,6 +393,7 @@ import NotificationBannerSwift
                 }
                 return .none
             case .toggleHideRead:
+                state.selected.removeAll()
                 state.$hideRead.withLock {
                     $0.toggle()
                 }
@@ -521,6 +544,19 @@ import NotificationBannerSwift
 }
 
 extension ArchiveListFeature {
+    private func finishCaching(state: inout State, id: String, succeeded: Bool) {
+        guard state.batchCachingArchiveIds.remove(id) != nil else {
+            if succeeded { state.successMessage = String(localized: "archive.cache.added") }
+            return
+        }
+        state.batchCacheHadSuccess = state.batchCacheHadSuccess || succeeded
+        guard state.batchCachingArchiveIds.isEmpty else { return }
+        if state.batchCacheHadSuccess {
+            state.successMessage = String(localized: "archive.cache.added")
+        }
+        state.batchCacheHadSuccess = false
+    }
+
     private func cacheArchive(state: inout State, id: String) -> EffectOf<Self> {
         guard !state.cachingArchiveIds.contains(id),
               let archive = state.archives[id: id]?.archive else {
@@ -569,6 +605,7 @@ extension ArchiveListFeature {
     }
 
     private func resetArchives(state: inout State) {
+        state.selected.removeAll()
         state.archivesToDisplay = .init()
         state.archives = .init()
         state.currentPage = 0
@@ -580,6 +617,7 @@ extension ArchiveListFeature {
         page: Int,
         showLoading: Bool
     ) -> EffectOf<Self> {
+        state.selected.removeAll()
         state.loading = true
         if showLoading {
             state.showLoading = true
@@ -597,6 +635,7 @@ extension ArchiveListFeature {
     }
 
     func clearArchives(state: inout State) {
+        state.selected.removeAll()
         state.archivesToDisplay = .init()
         state.archives = .init()
         state.total = 0
@@ -877,8 +916,11 @@ class UIArchiveListViewController: UIViewController {
         let cellRegistration = UICollectionView.CellRegistration<
             UIArchiveCell, StoreOf<GridFeature>
         > { [weak self] cell, _, itemStore in
-            guard self != nil else { return }
-            cell.configure(with: itemStore)
+            guard let self else { return }
+            cell.configure(
+                with: itemStore, selecting: store.selectMode == .active,
+                selected: store.selected.contains(itemStore.id)
+            )
         }
 
         dataSource = UICollectionViewDiffableDataSource<
@@ -964,6 +1006,14 @@ class UIArchiveListViewController: UIViewController {
 
     // swiftlint:disable function_body_length
     func setupToolbar() {
+        if store.selectMode == .active {
+            parent?.navigationItem.rightBarButtonItem = UIBarButtonItem(
+                title: String(localized: "done"), primaryAction: UIAction { [weak self] _ in
+                    self?.store.send(.toggleSelectionMode)
+                }
+            )
+            return
+        }
         let actions = SearchSort.allCases.filter { $0 != SearchSort.random }.map { sort in
             let localizedKey = "settings.archive.list.order.\(sort)"
             let label = NSLocalizedString(localizedKey, comment: "")
@@ -1026,7 +1076,16 @@ class UIArchiveListViewController: UIViewController {
         )
 
         // Create a menu with the actions
-        let menu = UIMenu(title: "", children: [sortGroup, otherGroup])
+        var groups: [UIMenuElement] = [sortGroup, otherGroup]
+        if store.currentTab == .library {
+            groups.append(UIAction(
+                title: String(localized: "select"),
+                image: UIImage(systemName: "checkmark")?.withTintColor(.clear, renderingMode: .alwaysOriginal)
+            ) { [weak self] _ in
+                self?.store.send(.toggleSelectionMode)
+            })
+        }
+        let menu = UIMenu(title: "", children: groups)
         let menuButton = UIBarButtonItem(
             image: UIImage(systemName: "arrow.up.arrow.down.circle"), menu: menu
         )
@@ -1040,6 +1099,37 @@ class UIArchiveListViewController: UIViewController {
         lastObservedSearchSort = store.searchSort
         lastObservedSearchSortOrder = store.searchSortOrder
         lastObservedFilter = store.filter
+
+        observe { [weak self] in
+            guard let self else { return }
+            let selecting = store.selectMode == .active
+            let selected = store.selected
+            setupToolbar()
+            for indexPath in collectionView.indexPathsForVisibleItems {
+                guard let item = dataSource.itemIdentifier(for: indexPath),
+                      let cell = collectionView.cellForItem(at: indexPath) as? UIArchiveCell else { continue }
+                cell.configure(with: item, selecting: selecting, selected: selected.contains(item.id))
+            }
+            guard store.currentTab == .library else { return }
+            let count = UIBarButtonItem.selectionCount(selected.count)
+            let download = UIBarButtonItem(
+                image: UIImage(systemName: "tray.and.arrow.down"),
+                primaryAction: UIAction { [weak self] _ in
+                    self?.store.send(.cacheSelected)
+                }
+            )
+            download.accessibilityLabel = String(localized: "archive.cache.add")
+            download.isEnabled = !selected.isEmpty
+            parent?.toolbarItems = [count, .flexibleSpace(), download]
+            (parent as? UILibraryListViewController)?.updateSelectionToolbarAppearance()
+            guard navigationController?.topViewController === parent else { return }
+            navigationController?.setToolbarHidden(!selecting, animated: false)
+            if #available(iOS 18.0, *) {
+                tabBarController?.setTabBarHidden(selecting, animated: false)
+            } else {
+                tabBarController?.tabBar.isHidden = selecting
+            }
+        }
 
         observe { [weak self] in
             guard let self else { return }
@@ -1231,7 +1321,12 @@ extension UIArchiveListViewController: UICollectionViewDelegate {
     ) {
         guard let selectedItemStore = dataSource.itemIdentifier(for: indexPath)
         else { return }
-        openReader(for: selectedItemStore)
+        if store.selectMode == .active {
+            store.send(store.selected.contains(selectedItemStore.id)
+                ? .removeSelect(selectedItemStore.id) : .addSelect(selectedItemStore.id))
+        } else {
+            openReader(for: selectedItemStore)
+        }
     }
 
     func collectionView(
@@ -1239,7 +1334,8 @@ extension UIArchiveListViewController: UICollectionViewDelegate {
         contextMenuConfigurationForItemAt indexPath: IndexPath,
         point: CGPoint
     ) -> UIContextMenuConfiguration? {
-        guard let itemStore = dataSource.itemIdentifier(for: indexPath) else { return nil }
+        guard store.selectMode != .active,
+              let itemStore = dataSource.itemIdentifier(for: indexPath) else { return nil }
         return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
             guard let self else { return nil }
             let readFromStart = UIAction(

--- a/LANreader/Library/CacheView.swift
+++ b/LANreader/Library/CacheView.swift
@@ -148,7 +148,6 @@ import NotificationBannerSwift
 
 struct CacheView: View {
     @Environment(NavigationHelper.self) private var navigation
-    @State private var confirmingRemoval = false
 
     let store: StoreOf<CacheFeature>
 
@@ -168,30 +167,6 @@ struct CacheView: View {
                 }
             }
             .padding(.horizontal)
-        }
-        .safeAreaInset(edge: .bottom) {
-            if store.isSelecting {
-                HStack {
-                    Text(String(format: String(localized: "archive.selected"), store.selected.count))
-                    Spacer()
-                    Button(role: .destructive) {
-                        confirmingRemoval = true
-                    } label: {
-                        Label("archive.cache.remove", systemImage: "trash")
-                            .labelStyle(.iconOnly)
-                    }
-                    .disabled(store.selected.isEmpty)
-                    .confirmationDialog(
-                        "archive.selected.delete", isPresented: $confirmingRemoval, titleVisibility: .visible
-                    ) {
-                        Button("archive.cache.remove", role: .destructive) {
-                            store.send(.removeSelected)
-                        }
-                    }
-                }
-                .padding()
-                .background(.bar)
-            }
         }
         .task {
             await store.send(.load).finish()

--- a/LANreader/Library/UICacheView.swift
+++ b/LANreader/Library/UICacheView.swift
@@ -28,6 +28,17 @@ class UICacheViewController: UIViewController, UICollectionViewDelegate {
                     self?.store.send(.toggleSelectionMode)
                 }
             )
+            let delete = UIBarButtonItem(
+                image: UIImage(systemName: "trash"), style: .plain,
+                target: self, action: #selector(confirmRemoval(_:))
+            )
+            delete.tintColor = .systemRed
+            delete.accessibilityLabel = String(localized: "archive.cache.remove")
+            delete.isEnabled = !store.selected.isEmpty
+            toolbarItems = [.selectionCount(store.selected.count), .flexibleSpace(), delete]
+            if navigationController?.topViewController === self {
+                navigationController?.setToolbarHidden(!store.isSelecting, animated: false)
+            }
         }
 
         let hostingController = UIHostingController(
@@ -45,10 +56,41 @@ class UICacheViewController: UIViewController, UICollectionViewDelegate {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        navigationController?.setToolbarHidden(!store.isSelecting, animated: false)
         if #available(iOS 18.0, *) {
             tabBarController?.setTabBarHidden(true, animated: false)
         } else {
             tabBarController?.tabBar.isHidden = true
         }
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.setToolbarHidden(true, animated: false)
+    }
+
+    @objc private func confirmRemoval(_ sender: UIBarButtonItem) {
+        let alert = UIAlertController(
+            title: String(localized: "archive.selected.delete"), message: nil, preferredStyle: .actionSheet
+        )
+        alert.addAction(UIAlertAction(
+            title: String(localized: "archive.cache.remove"), style: .destructive
+        ) { [weak self] _ in
+            self?.store.send(.removeSelected)
+        })
+        alert.addAction(UIAlertAction(title: String(localized: "cancel"), style: .cancel))
+        alert.popoverPresentationController?.barButtonItem = sender
+        present(alert, animated: true)
+    }
+}
+
+extension UIBarButtonItem {
+    static func selectionCount(_ count: Int) -> UIBarButtonItem {
+        let item = UIBarButtonItem(
+            title: String(format: String(localized: "archive.selected"), count),
+            style: .plain, target: nil, action: nil
+        )
+        item.accessibilityTraits = .staticText
+        return item
     }
 }

--- a/LANreader/Library/UILibraryList.swift
+++ b/LANreader/Library/UILibraryList.swift
@@ -28,15 +28,10 @@ import UIKit
             ArchiveListFeature()
         }
 
-        Reduce { state, action in
+        Reduce { _, action in
             switch action {
             case .toggleSelectMode:
-                if state.archiveList.selectMode == .inactive {
-                    state.archiveList.selectMode = .active
-                } else {
-                    state.archiveList.selectMode = .inactive
-                }
-                return .none
+                return .send(.archiveList(.toggleSelectionMode))
             case .archiveList:
                 return .none
             case .binding:
@@ -67,14 +62,21 @@ class UILibraryListViewController: UIViewController {
             target: self,
             action: #selector(tapCachedButton)
         )
-        navigationItem.leftBarButtonItems = [cachedButton]
+        navigationItem.leftBarButtonItems = store.archiveList.selectMode == .active ? [] : [cachedButton]
         navigationItem.title = String(localized: "library")
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        setupNavigationBar()
+        observe { [weak self] in
+            self?.setupNavigationBar()
+        }
+        registerForTraitChanges(
+            [UITraitUserInterfaceStyle.self, UITraitAccessibilityContrast.self]
+        ) { (controller: UILibraryListViewController, _) in
+            controller.updateSelectionToolbarAppearance()
+        }
 
         let archiveListView = UIArchiveListViewController(
             store: store.scope(\.archiveList, action: \.archiveList)
@@ -90,11 +92,25 @@ class UILibraryListViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        updateSelectionToolbarAppearance()
+        let selecting = store.archiveList.selectMode == .active
+        navigationController?.setToolbarHidden(!selecting, animated: false)
         if #available(iOS 18.0, *) {
-            tabBarController?.setTabBarHidden(false, animated: false)
+            tabBarController?.setTabBarHidden(selecting, animated: false)
         } else {
-            tabBarController?.tabBar.isHidden = false
+            tabBarController?.tabBar.isHidden = selecting
         }
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.setToolbarHidden(true, animated: false)
+    }
+
+    func updateSelectionToolbarAppearance() {
+        // Resolve against the page, not the toolbar's adaptive glass appearance.
+        let foreground = UIColor.label.resolvedColor(with: traitCollection)
+        toolbarItems?.forEach { $0.tintColor = foreground }
     }
 
     @objc private func tapCachedButton() {

--- a/LANreaderTests/ArchiveListSelectionTests.swift
+++ b/LANreaderTests/ArchiveListSelectionTests.swift
@@ -1,0 +1,178 @@
+import XCTest
+import ComposableArchitecture
+import GRDB
+import UIKit
+@testable import LANreader
+
+final class ArchiveListSelectionTests: XCTestCase {
+    @MainActor
+    func testLibraryToolbarUsesPageColorsInLightAndDarkAppearance() async throws {
+        var state = LibraryFeature.State()
+        state.archiveList = makeSelectionState(count: 1)
+        let store = Store(initialState: state) { LibraryFeature() }
+        let controller = UILibraryListViewController(store: store, navigationHelper: NavigationHelper())
+        let navigation = UINavigationController(rootViewController: controller)
+        navigation.loadViewIfNeeded()
+        controller.loadViewIfNeeded()
+        store.send(.archiveList(.toggleSelectionMode))
+        await Task.yield()
+        for style in [UIUserInterfaceStyle.light, .dark] {
+            controller.overrideUserInterfaceStyle = style
+            await Task.yield()
+            let expected = UIColor.label.resolvedColor(with: UITraitCollection(userInterfaceStyle: style))
+            let count = try XCTUnwrap(controller.toolbarItems?.first)
+            let download = try XCTUnwrap(controller.toolbarItems?.last)
+            XCTAssertEqual(count.tintColor, expected)
+            XCTAssertEqual(download.tintColor, expected)
+        }
+    }
+
+    @MainActor
+    func testLibrarySelectionControlsToolbarAndInterceptsReaderNavigation() async throws {
+        var libraryState = LibraryFeature.State()
+        libraryState.archiveList = makeSelectionState(count: 2)
+        let libraryStore = Store(initialState: libraryState) { LibraryFeature() }
+        let store = libraryStore.scope(\.archiveList, action: \.archiveList)
+        let parent = UILibraryListViewController(store: libraryStore, navigationHelper: NavigationHelper())
+        let navigation = UINavigationController(rootViewController: parent)
+        let tabs = UITabBarController()
+        tabs.viewControllers = [navigation]
+        tabs.loadViewIfNeeded()
+        navigation.loadViewIfNeeded()
+        parent.loadViewIfNeeded()
+        let controller = try XCTUnwrap(parent.children.first as? UIArchiveListViewController)
+        await Task.yield()
+
+        XCTAssertNotNil(parent.navigationItem.rightBarButtonItem?.menu)
+        XCTAssertEqual(parent.navigationItem.leftBarButtonItems?.count, 1)
+        store.send(.toggleSelectionMode)
+        await Task.yield()
+        XCTAssertEqual(parent.navigationItem.rightBarButtonItem?.title, String(localized: "done"))
+        XCTAssertFalse(navigation.isToolbarHidden)
+        XCTAssertTrue(parent.navigationItem.leftBarButtonItems?.isEmpty ?? true)
+        if #available(iOS 18.0, *) {
+            XCTAssertTrue(tabs.isTabBarHidden)
+        } else {
+            XCTAssertTrue(tabs.tabBar.isHidden)
+        }
+        XCTAssertEqual(parent.toolbarItems?.last?.isEnabled, false)
+
+        controller.collectionView(controller.collectionView, didSelectItemAt: IndexPath(item: 0, section: 0))
+        await Task.yield()
+        XCTAssertEqual(store.selected, ["archive-0"])
+        XCTAssertEqual(navigation.viewControllers.count, 1)
+        XCTAssertEqual(parent.toolbarItems?.last?.isEnabled, true)
+        let count = try XCTUnwrap(parent.toolbarItems?.first)
+        XCTAssertEqual(count.title, String(format: String(localized: "archive.selected"), 1))
+        XCTAssertTrue(count.isEnabled)
+        XCTAssertNil(count.customView)
+        XCTAssertNil(controller.collectionView(
+            controller.collectionView, contextMenuConfigurationForItemAt: IndexPath(item: 0, section: 0), point: .zero
+        ))
+
+        store.send(.toggleSelectionMode)
+        await Task.yield()
+        XCTAssertTrue(store.selected.isEmpty)
+        XCTAssertTrue(navigation.isToolbarHidden)
+        if #available(iOS 18.0, *) {
+            XCTAssertFalse(tabs.isTabBarHidden)
+        } else {
+            XCTAssertFalse(tabs.tabBar.isHidden)
+        }
+        XCTAssertNotNil(parent.navigationItem.rightBarButtonItem?.menu)
+        XCTAssertEqual(parent.navigationItem.leftBarButtonItems?.count, 1)
+    }
+
+    @MainActor
+    func testBatchDownloadDispatchesOnlySelectedArchivesAndExitsSelection() async throws {
+        let database = try AppDatabase(DatabaseQueue())
+        let state = makeSelectionState(count: 3)
+        // Existing cache entries exercise the shared duplicate-download guard.
+        for id in ["archive-0", "archive-2"] {
+            var cache = ArchiveCache(
+                id: id, title: id, tags: "", thumbnail: nil,
+                cached: true, totalPages: 1, lastUpdate: Date()
+            )
+            try database.saveCache(&cache)
+        }
+        let store = TestStore(initialState: state) { ArchiveListFeature() } withDependencies: {
+            $0.appDatabase = database
+        }
+        await store.send(.toggleSelectionMode) { $0.selectMode = .active }
+        await store.send(.addSelect("archive-0")) { $0.selected = ["archive-0"] }
+        await store.send(.addSelect("archive-2")) { $0.selected = ["archive-0", "archive-2"] }
+        await store.send(.cacheSelected) {
+            $0.selectMode = .inactive
+            $0.selected = []
+        }
+        await store.finish()
+    }
+
+    @MainActor
+    func testBatchCachingShowsOneSuccessAfterAllResults() async {
+        var state = ArchiveListFeature.State(
+            filter: SearchFilter(category: nil, filter: nil), currentTab: .library
+        )
+        state.cachingArchiveIds = ["a", "b", "c"]
+        state.batchCachingArchiveIds = state.cachingArchiveIds
+        let store = TestStore(initialState: state) { ArchiveListFeature() }
+        await store.send(.cacheArchiveFinished("a")) {
+            $0.cachingArchiveIds.remove("a")
+            $0.batchCachingArchiveIds.remove("a")
+            $0.batchCacheHadSuccess = true
+        }
+        await store.send(.cacheArchiveFinished("b")) {
+            $0.cachingArchiveIds.remove("b")
+            $0.batchCachingArchiveIds.remove("b")
+        }
+        await store.send(.cacheArchiveFailed("c", "Failed")) {
+            $0.cachingArchiveIds = []
+            $0.batchCachingArchiveIds = []
+            $0.batchCacheHadSuccess = false
+            $0.successMessage = String(localized: "archive.cache.added")
+            $0.errorMessage = "Failed"
+        }
+    }
+
+    @MainActor
+    func testCacheSelectionUsesNativeToolbarAndVisibleCount() async throws {
+        let database = try AppDatabase(DatabaseQueue())
+        let store = Store(initialState: CacheFeature.State()) { CacheFeature() } withDependencies: {
+            $0.appDatabase = database
+        }
+        let controller = UICacheViewController(store: store, navigationHelper: NavigationHelper())
+        let navigation = UINavigationController(rootViewController: controller)
+        navigation.loadViewIfNeeded()
+        controller.loadViewIfNeeded()
+        store.send(.toggleSelectionMode)
+        await Task.yield()
+        XCTAssertFalse(navigation.isToolbarHidden)
+        let count = try XCTUnwrap(controller.toolbarItems?.first)
+        XCTAssertEqual(count.title, String(format: String(localized: "archive.selected"), 0))
+        XCTAssertTrue(count.isEnabled)
+        XCTAssertNil(count.customView)
+        XCTAssertEqual(controller.toolbarItems?.last?.accessibilityLabel, String(localized: "archive.cache.remove"))
+        XCTAssertEqual(controller.toolbarItems?.last?.isEnabled, false)
+        store.send(.toggleSelectionMode)
+        await Task.yield()
+        XCTAssertTrue(navigation.isToolbarHidden)
+    }
+
+}
+@MainActor
+private func makeSelectionState(count: Int) -> ArchiveListFeature.State {
+    var state = ArchiveListFeature.State(
+        filter: SearchFilter(category: nil, filter: nil), loadOnAppear: false, currentTab: .library
+    )
+    let archives = (0..<count).map { index in
+        ArchiveItem(
+            id: "archive-\(index)", name: "Archive \(index)", extension: "zip",
+            tags: "", isNew: false, progress: 0, pagecount: 10, dateAdded: nil
+        )
+    }
+    state.archives = IdentifiedArray(uniqueElements: archives.map {
+        GridFeature.State(archive: Shared(value: $0))
+    })
+    state.archivesToDisplay = state.archives
+    return state
+}


### PR DESCRIPTION
## Change

Add Select to the bottom of the Library menu so users can select several archives and download them together. Selection hides the Cache button and tab bar, shows large selection indicators and a split bottom toolbar, and produces one success notification after batch queuing finishes. Reuses the existing download path for normal archives and Tankoubons.

Align Cache View with the same native toolbar, keeping removal local and its confirmation anchored to the trash button. Keep marketing version 3.10.2 and increment build 233 to 234 for both targets.

Addresses the batch-download portion of #383; progress synchronization remains separate work.

## Risk surface

- [x] Reader, navigation, image rendering, cache, or Tankoubon behavior
- [ ] LANraragi request or response contract
- [x] Persistence, migration, or offline behavior
- [x] Localized user interface
- [x] Xcode project, dependency, CI, or release automation
- [ ] None of the above

## Evidence

Commands run and outcomes:
- `./scripts/verify`: passed repository checks, lint, and all 256 iOS tests.
- `git diff --check`: passed.
- `xcodebuild -project LANreader.xcodeproj -alltargets -configuration Debug -showBuildSettings` and the Release equivalent: LANreader and Action resolve to 3.10.2 (234).

Behavior evidence (focused test names, screenshots, or manual scenario):
- `testLibrarySelectionControlsToolbarAndInterceptsReaderNavigation`: Cache button visibility, selection taps, tab-bar restoration, and toolbar count/action state through the Library controller.
- `testBatchDownloadDispatchesOnlySelectedArchivesAndExitsSelection` and `testBatchCachingShowsOneSuccessAfterAllResults`: cached-item skipping and one success notification, including a final failure.
- `testCacheSelectionUsesNativeToolbarAndVisibleCount` and `testLibraryToolbarUsesPageColorsInLightAndDarkAppearance`: native Cache toolbar and Library control colors.
- Existing single-archive download tests continue to pass.

Checks not run or known gaps:
- No automated visual or VoiceOver review; the latest toolbar appearance still needs device review.
- Existing background-download cancellation and terminal-error handling are unchanged. No server API or database schema changes.

## Durable learning (only when applicable)

Regression test, automated guard, or concise `AGENTS.md` update:
- Added `ArchiveListSelectionTests` covering controller integration and batch notifications.
