### PR TITLE
Fix batch selection and failure handling

### DIFF
--- a/LANreader.xcodeproj/project.pbxproj
+++ b/LANreader.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		F1A2B3C62F60000200AAA001 /* ArchiveDetailsTagParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C92F60000200AAA001 /* ArchiveDetailsTagParserTests.swift */; };
 		F1A2B3CA2F60000300AAA001 /* ArchiveDetailsTagParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3CB2F60000300AAA001 /* ArchiveDetailsTagParser.swift */; };
 		F1A2B3CC2F70000100AAA001 /* ArchiveListFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3CD2F70000100AAA001 /* ArchiveListFeatureTests.swift */; };
+		F1A2B3CC2F70000100AAA002 /* ArchiveListBatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3CD2F70000100AAA002 /* ArchiveListBatchTests.swift */; };
 		AB3870010000000000000001 /* ArchiveListSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3870010000000000000002 /* ArchiveListSelectionTests.swift */; };
 		F1A2B3CE2F80000100AAA001 /* LogTextRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3CF2F80000100AAA001 /* LogTextRendererTests.swift */; };
 		F1A2B3D52F60000400DDD001 /* LANraragiConfigFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3D42F60000400DDD001 /* LANraragiConfigFeatureTests.swift */; };
@@ -240,6 +241,7 @@
 		F1A2B3C92F60000200AAA001 /* ArchiveDetailsTagParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailsTagParserTests.swift; sourceTree = "<group>"; };
 		F1A2B3CB2F60000300AAA001 /* ArchiveDetailsTagParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveDetailsTagParser.swift; sourceTree = "<group>"; };
 		F1A2B3CD2F70000100AAA001 /* ArchiveListFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveListFeatureTests.swift; sourceTree = "<group>"; };
+		F1A2B3CD2F70000100AAA002 /* ArchiveListBatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveListBatchTests.swift; sourceTree = "<group>"; };
 		AB3870010000000000000002 /* ArchiveListSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveListSelectionTests.swift; sourceTree = "<group>"; };
 		F1A2B3CF2F80000100AAA001 /* LogTextRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogTextRendererTests.swift; sourceTree = "<group>"; };
 		F1A2B3D42F60000400DDD001 /* LANraragiConfigFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LANraragiConfigFeatureTests.swift; sourceTree = "<group>"; };
@@ -466,6 +468,7 @@
 				F1A2B3D42F60000400DDD001 /* LANraragiConfigFeatureTests.swift */,
 				F1A2B3C92F60000200AAA001 /* ArchiveDetailsTagParserTests.swift */,
 				F1A2B3CD2F70000100AAA001 /* ArchiveListFeatureTests.swift */,
+				F1A2B3CD2F70000100AAA002 /* ArchiveListBatchTests.swift */,
 				AB3870010000000000000002 /* ArchiveListSelectionTests.swift */,
 				F1A2B3CF2F80000100AAA001 /* LogTextRendererTests.swift */,
 				F1A2B3D92F90000200AAA001 /* SearchFeatureTests.swift */,
@@ -810,6 +813,7 @@
 				F1A2B3D52F60000400DDD001 /* LANraragiConfigFeatureTests.swift in Sources */,
 				F1A2B3C62F60000200AAA001 /* ArchiveDetailsTagParserTests.swift in Sources */,
 				F1A2B3CC2F70000100AAA001 /* ArchiveListFeatureTests.swift in Sources */,
+				F1A2B3CC2F70000100AAA002 /* ArchiveListBatchTests.swift in Sources */,
 				AB3870010000000000000001 /* ArchiveListSelectionTests.swift in Sources */,
 				F1A2B3CE2F80000100AAA001 /* LogTextRendererTests.swift in Sources */,
 				F1A2B3E52FA0000100AAA001 /* PaginationPositioningTests.swift in Sources */,
@@ -991,7 +995,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreader.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 238;
+				CURRENT_PROJECT_VERSION = 239;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1002,7 +1006,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.2;
+				MARKETING_VERSION = 3.11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1019,7 +1023,7 @@
 				CODE_SIGN_ENTITLEMENTS = LANreader/LANreaderRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 238;
+				CURRENT_PROJECT_VERSION = 239;
 				DEVELOPMENT_ASSET_PATHS = "\"LANreader/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1030,7 +1034,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.2;
+				MARKETING_VERSION = 3.11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1093,7 +1097,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 238;
+				CURRENT_PROJECT_VERSION = 239;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1105,7 +1109,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.10.2;
+				MARKETING_VERSION = 3.11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1123,7 +1127,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 238;
+				CURRENT_PROJECT_VERSION = 239;
 				DEVELOPMENT_TEAM = UUEBW58SA6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Action/Info.plist;
@@ -1135,7 +1139,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.10.2;
+				MARKETING_VERSION = 3.11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jif.LANreader.3.Action;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/LANreader/Category/UICategoryArchiveGrid.swift
+++ b/LANreader/Category/UICategoryArchiveGrid.swift
@@ -17,7 +17,6 @@ import UIKit
         case binding(BindingAction<State>)
 
         case archiveList(ArchiveListFeature.Action)
-        case toggleSelectMode
     }
 
     public var body: some ReducerOf<Self> {
@@ -27,16 +26,6 @@ import UIKit
             ArchiveListFeature()
         }
 
-        Reduce { _, action in
-            switch action {
-            case .toggleSelectMode:
-                return .send(.archiveList(.toggleSelectionMode))
-            case .binding:
-                return .none
-            case .archiveList:
-                return .none
-            }
-        }
     }
 }
 

--- a/LANreader/Common/UIArchiveCell.swift
+++ b/LANreader/Common/UIArchiveCell.swift
@@ -16,9 +16,13 @@ class UIArchiveCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func configure(with store: StoreOf<GridFeature>, selecting: Bool = false, selected: Bool = false) {
+    func configure(
+        with store: StoreOf<GridFeature>, database: AppDatabase, selecting: Bool = false, selected: Bool = false
+    ) {
         contentConfiguration = UIHostingConfiguration {
-            ArchiveGridV2(store: store)
+            withDependencies { $0.appDatabase = database } operation: {
+                ArchiveGridV2(store: store)
+            }
                 .overlay(alignment: .topTrailing) {
                     if selecting {
                         Image(systemName: selected ? "checkmark.circle.fill" : "circle")

--- a/LANreader/Common/UIArchiveList.swift
+++ b/LANreader/Common/UIArchiveList.swift
@@ -28,6 +28,7 @@ import NotificationBannerSwift
         var loadOnAppear = true
         var archives: IdentifiedArrayOf<GridFeature.State> = []
         var loading: Bool = false
+        var isDeleting = false
         var showLoading: Bool = false
         var total: Int = 0
         var errorMessage = ""
@@ -35,6 +36,7 @@ import NotificationBannerSwift
         var cachingArchiveIds: Set<String> = []
         var batchCachingArchiveIds: Set<String> = []
         var batchCacheHadSuccess = false
+        var batchCacheErrors: Set<String> = []
         var currentTab: TabName
 
         var archivesToDisplay: IdentifiedArrayOf<GridFeature.State> = []
@@ -119,19 +121,20 @@ import NotificationBannerSwift
         Reduce { state, action in
             switch action {
             case .toggleSelectionMode:
-                guard !state.loading else { return .none }
+                guard !state.isDeleting, state.selectMode == .active || !state.loading else { return .none }
                 state.selectMode = state.selectMode == .active ? .inactive : .active
                 state.selected.removeAll()
                 return .none
             case .cacheSelected:
                 guard !state.loading else { return .none }
                 let ids = state.selected.sorted()
-                state.selected.removeAll()
                 let previous = state.cachingArchiveIds
                 let effects = ids.map { cacheArchive(state: &state, id: $0) }
                 state.batchCachingArchiveIds.formUnion(state.cachingArchiveIds.subtracting(previous))
+                state.selected.formIntersection(state.batchCachingArchiveIds)
                 return .merge(effects)
             case let .setFilter(filter):
+                if state.filter != filter { state.selected.removeAll() }
                 state.filter = filter
                 return .none
             case .resetArchives:
@@ -197,7 +200,6 @@ import NotificationBannerSwift
                     state.pendingPage = nil
                 }
                 if !append {
-                    state.selected.removeAll()
                     state.archives = .init()
                     state.archivesToDisplay = .init()
                     state.total = 0
@@ -248,8 +250,7 @@ import NotificationBannerSwift
                 return .none
             case let .cacheArchiveFailed(id, message):
                 state.cachingArchiveIds.remove(id)
-                finishCaching(state: &state, id: id, succeeded: false)
-                state.errorMessage = message
+                finishCaching(state: &state, id: id, succeeded: false, error: message)
                 return .none
             case let .setErrorMessage(message):
                 guard !message.isEmpty else {
@@ -357,6 +358,7 @@ import NotificationBannerSwift
             case .alert(.presented(.confirmDelete)):
                 guard !state.loading, !state.selected.isEmpty else { return .none }
                 state.loading = true
+                state.isDeleting = true
                 return deleteSelected(state)
             case let .setSearchSortOrder(order):
                 state.$searchSortOrder.withLock {
@@ -388,6 +390,7 @@ import NotificationBannerSwift
                 let targetPage = PaginationPositioning.clampedPage(page, pageCount: state.pageCount)
                 guard targetPage != state.currentPage else { return .none }
 
+                state.selected.removeAll()
                 state.loading = true
                 state.showLoading = true
                 state.pendingPage = targetPage
@@ -428,6 +431,7 @@ import NotificationBannerSwift
                 }
                 return .none
             case let .deleteSuccess(archiveIds):
+                state.isDeleting = false
                 archiveIds.forEach { id in
                     state.selected.remove(id)
                     state.archivesToDisplay.remove(id: id)
@@ -561,16 +565,24 @@ extension ArchiveListFeature {
 }
 
 extension ArchiveListFeature {
-    private func finishCaching(state: inout State, id: String, succeeded: Bool) {
+    private func finishCaching(state: inout State, id: String, succeeded: Bool, error: String? = nil) {
         guard state.batchCachingArchiveIds.remove(id) != nil else {
             if succeeded { state.successMessage = String(localized: "archive.cache.added") }
+            if let error { state.errorMessage = error }
             return
         }
+        if let error {
+            state.batchCacheErrors.insert(error)
+        }
+        if succeeded { state.selected.remove(id) }
         state.batchCacheHadSuccess = state.batchCacheHadSuccess || succeeded
         guard state.batchCachingArchiveIds.isEmpty else { return }
-        if state.batchCacheHadSuccess {
+        if !state.batchCacheErrors.isEmpty {
+            state.errorMessage = state.batchCacheErrors.sorted().joined(separator: "\n")
+        } else if state.batchCacheHadSuccess {
             state.successMessage = String(localized: "archive.cache.added")
         }
+        state.batchCacheErrors.removeAll()
         state.batchCacheHadSuccess = false
     }
 
@@ -634,7 +646,6 @@ extension ArchiveListFeature {
         page: Int,
         showLoading: Bool
     ) -> EffectOf<Self> {
-        state.selected.removeAll()
         state.loading = true
         if showLoading {
             state.showLoading = true
@@ -935,7 +946,7 @@ class UIArchiveListViewController: UIViewController {
         > { [weak self] cell, _, itemStore in
             guard let self else { return }
             cell.configure(
-                with: itemStore, selecting: store.selectMode == .active,
+                with: itemStore, database: database, selecting: store.selectMode == .active,
                 selected: store.selected.contains(itemStore.id)
             )
         }
@@ -1029,7 +1040,7 @@ class UIArchiveListViewController: UIViewController {
                     self?.store.send(.toggleSelectionMode)
                 }
             )
-            parent?.navigationItem.rightBarButtonItem?.isEnabled = !store.loading
+            parent?.navigationItem.rightBarButtonItem?.isEnabled = !store.isDeleting
             return
         }
         let actions = SearchSort.allCases.filter { $0 != SearchSort.random }.map { sort in
@@ -1124,7 +1135,9 @@ class UIArchiveListViewController: UIViewController {
             for indexPath in collectionView.indexPathsForVisibleItems {
                 guard let item = dataSource.itemIdentifier(for: indexPath),
                       let cell = collectionView.cellForItem(at: indexPath) as? UIArchiveCell else { continue }
-                cell.configure(with: item, selecting: selecting, selected: selected.contains(item.id))
+                cell.configure(
+                    with: item, database: database, selecting: selecting, selected: selected.contains(item.id)
+                )
             }
             let count = UIBarButtonItem.selectionCount(selected.count)
             let download = UIBarButtonItem(
@@ -1170,12 +1183,6 @@ class UIArchiveListViewController: UIViewController {
             if !store.loading {
                 refreshControl.endRefreshing()
             }
-        }
-
-        observe { [weak self] in
-            guard let self else { return }
-            guard !store.archives.isEmpty else { return }
-            setupToolbar()
         }
 
         observe { [weak self] in

--- a/LANreader/Library/UILibraryList.swift
+++ b/LANreader/Library/UILibraryList.swift
@@ -15,7 +15,6 @@ import UIKit
         case binding(BindingAction<State>)
 
         case archiveList(ArchiveListFeature.Action)
-        case toggleSelectMode
     }
 
     @Dependency(\.lanraragiService) var service
@@ -28,16 +27,6 @@ import UIKit
             ArchiveListFeature()
         }
 
-        Reduce { _, action in
-            switch action {
-            case .toggleSelectMode:
-                return .send(.archiveList(.toggleSelectionMode))
-            case .archiveList:
-                return .none
-            case .binding:
-                return .none
-            }
-        }
     }
 }
 

--- a/LANreaderTests/ArchiveListBatchTests.swift
+++ b/LANreaderTests/ArchiveListBatchTests.swift
@@ -1,0 +1,163 @@
+import XCTest
+import ComposableArchitecture
+import GRDB
+import OHHTTPStubs
+import OHHTTPStubsSwift
+@testable import LANreader
+
+final class ArchiveListBatchTests: XCTestCase {
+    @MainActor
+    func testBatchDownloadExtractsOnlySelectedUncachedArchives() async throws {
+        try await configureArchiveListTestClient()
+        for id in ["archive-0", "archive-2"] {
+            try stubArchiveListExtraction(id: id, pages: ["./api/archives/\(id)/page?path=001.jpg"])
+        }
+        stubUnexpectedBatchExtraction()
+        let database = try makeArchiveListTestDatabase()
+        var state = makePaginatedArchiveListState()
+        state.archives = expectedArchiveListGridStates(in: &state, count: 3)
+        state.archivesToDisplay = state.archives
+        state.selectMode = .active
+        state.selected = ["archive-0", "archive-2"]
+        let store = TestStore(initialState: state) { ArchiveListFeature() } withDependencies: {
+            $0.appDatabase = database
+        }
+        store.exhaustivity = .off
+        await store.send(.cacheSelected)
+        await store.receive(\.cacheArchiveFinished)
+        await store.receive(\.cacheArchiveFinished)
+        await store.finish()
+        XCTAssertEqual(Set(try database.readAllCached().map(\.id)), ["archive-0", "archive-2"])
+        XCTAssertEqual(store.state.selectMode, .active)
+        XCTAssertEqual(store.state.successMessage, String(localized: "archive.cache.added"))
+    }
+
+    @MainActor
+    func testDoneCanExitSelectionWhileLoading() async {
+        var state = makePaginatedArchiveListState()
+        state.selectMode = .active
+        state.selected = ["archive-0"]
+        state.loading = true
+        let store = TestStore(initialState: state) { ArchiveListFeature() }
+        await store.send(.toggleSelectionMode) {
+            $0.selectMode = .inactive
+            $0.selected = []
+        }
+    }
+
+    @MainActor
+    func testPartialBatchDeletionPreservesFailedSelectionAfterPageReload() async throws {
+        try await configureArchiveListTestClient()
+        stubArchiveListBatchDelete(path: "/api/archives/archive-0", success: 1)
+        stubArchiveListBatchDelete(path: "/api/archives/archive-1", success: 0)
+        stubRemainingBatchArchive()
+        var state = makePaginatedArchiveListState()
+        state.archives = expectedArchiveListGridStates(in: &state, count: 2)
+        state.archivesToDisplay = state.archives
+        state.total = 2
+        state.serverPageSize = 2
+        state.selectMode = .active
+        state.selected = ["archive-0", "archive-1"]
+        let store = TestStore(initialState: state) { ArchiveListFeature() }
+        store.exhaustivity = .off
+        await store.send(.deleteButtonTapped)
+        await store.send(.alert(.presented(.confirmDelete)))
+        await store.receive(.deleteSuccess(["archive-0"]))
+        await store.receive(.load(false))
+        XCTAssertEqual(store.state.selected, ["archive-1"])
+        await store.receive(\.populateArchives)
+        await store.finish()
+        XCTAssertEqual(store.state.selected, ["archive-1"])
+        XCTAssertEqual(store.state.selectMode, .active)
+    }
+
+    @MainActor
+    func testDoneCannotExitDuringDestructiveBatch() async {
+        var state = makePaginatedArchiveListState()
+        state.selectMode = .active
+        state.loading = true
+        state.isDeleting = true
+        let store = TestStore(initialState: state) { ArchiveListFeature() }
+        await store.send(.toggleSelectionMode)
+    }
+
+    @MainActor
+    func testChangingFilterClearsSelection() async {
+        var state = makePaginatedArchiveListState()
+        state.selected = ["archive-0"]
+        let store = TestStore(initialState: state) { ArchiveListFeature() }
+        let filter = SearchFilter(category: nil, filter: "new query")
+        await store.send(.setFilter(filter)) {
+            $0.filter = filter
+            $0.selected = []
+        }
+    }
+
+    @MainActor
+    func testBatchDownloadReportsFailuresOnceAndKeepsFailedSelection() async {
+        var state = makePaginatedArchiveListState()
+        state.archives = expectedArchiveListGridStates(in: &state, count: 3)
+        state.archivesToDisplay = state.archives
+        state.selectMode = .active
+        state.cachingArchiveIds = ["archive-0", "archive-1", "archive-2"]
+        state.batchCachingArchiveIds = state.cachingArchiveIds
+        state.selected = state.cachingArchiveIds
+        let store = TestStore(initialState: state) { ArchiveListFeature() }
+        for id in ["archive-0", "archive-1"] {
+            await store.send(.cacheArchiveFailed(id, "Failed")) {
+                $0.cachingArchiveIds.remove(id)
+                $0.batchCachingArchiveIds.remove(id)
+                $0.batchCacheErrors = ["Failed"]
+            }
+            XCTAssertTrue(store.state.errorMessage.isEmpty)
+        }
+        await store.send(.cacheArchiveFinished("archive-2")) {
+            $0.cachingArchiveIds = []
+            $0.batchCachingArchiveIds = []
+            $0.batchCacheErrors = []
+            $0.errorMessage = "Failed"
+            $0.selected.remove("archive-2")
+        }
+        XCTAssertTrue(store.state.successMessage.isEmpty)
+    }
+    override func tearDownWithError() throws {
+        UserDefaults.resetStandardUserDefaults()
+        HTTPStubs.removeAllStubs()
+    }
+
+    @MainActor
+    func testBatchDownloadReportsSuccessOnlyAfterLastArchive() async {
+        var state = makePaginatedArchiveListState()
+        state.cachingArchiveIds = ["a", "b"]
+        state.batchCachingArchiveIds = state.cachingArchiveIds
+        let store = TestStore(initialState: state) { ArchiveListFeature() }
+        await store.send(.cacheArchiveFinished("a")) {
+            $0.cachingArchiveIds = ["b"]
+            $0.batchCachingArchiveIds = ["b"]
+            $0.batchCacheHadSuccess = true
+        }
+        XCTAssertTrue(store.state.successMessage.isEmpty)
+        await store.send(.cacheArchiveFinished("b")) {
+            $0.cachingArchiveIds = []
+            $0.batchCachingArchiveIds = []
+            $0.batchCacheHadSuccess = false
+            $0.successMessage = String(localized: "archive.cache.added")
+        }
+    }
+}
+
+private func stubUnexpectedBatchExtraction() {
+    stub(condition: isPath("/api/archives/archive-1/extract")) { _ in
+        XCTFail("Unselected archive must not be extracted")
+        return HTTPStubsResponse(data: Data(), statusCode: 500, headers: nil)
+    }
+}
+
+private func stubRemainingBatchArchive() {
+    stub(condition: isPath("/api/search") && isMethodGET() && containsQueryParams(["start": "0"])) { _ in
+        HTTPStubsResponse(data: Data("""
+        {"data":[{"arcid":"archive-1","extension":"zip","isnew":"false","tags":"",
+        "title":"Archive 1","pagecount":10,"progress":0}],"recordsFiltered":1,"recordsTotal":1}
+        """.utf8), statusCode: 200, headers: ["Content-Type": "application/json"])
+    }
+}

--- a/LANreaderTests/ArchiveListFeatureTests.swift
+++ b/LANreaderTests/ArchiveListFeatureTests.swift
@@ -6,6 +6,7 @@ import OHHTTPStubsSwift
 @testable import LANreader
 
 final class ArchiveListFeatureTests: XCTestCase {
+
     @MainActor
     func testSuccessfulBatchDeletionKeepsSelectionMode() async {
         var state = ArchiveListFeature.State(
@@ -24,9 +25,9 @@ final class ArchiveListFeatureTests: XCTestCase {
 
     @MainActor
     func testBatchDeleteRoutesTankoubonAndKeepsFailedSelection() async throws {
-        try await configureVerifiedClient()
+        try await configureArchiveListTestClient()
         for (path, success) in [("/api/archives/archive-0", 1), ("/api/tankoubons/TANK_1", 0)] {
-            stubBatchDelete(path: path, success: success)
+            stubArchiveListBatchDelete(path: path, success: success)
         }
         var state = ArchiveListFeature.State(
             filter: SearchFilter(category: nil, filter: nil), loadOnAppear: false, currentTab: .library
@@ -50,12 +51,14 @@ final class ArchiveListFeatureTests: XCTestCase {
         await store.send(.alert(.presented(.confirmDelete))) {
             $0.alert = nil
             $0.loading = true
+            $0.isDeleting = true
         }
         await store.receive(.setErrorMessage(String(localized: "archive.selected.delete.error"))) {
             $0.loading = false
             $0.errorMessage = String(localized: "archive.selected.delete.error")
         }
         await store.receive(.deleteSuccess(["archive-0"])) {
+            $0.isDeleting = false
             $0.selected = ["TANK_1"]
             $0.archives.remove(id: "archive-0")
             $0.archivesToDisplay.remove(id: "archive-0")
@@ -113,12 +116,12 @@ final class ArchiveListFeatureTests: XCTestCase {
 
     @MainActor
     func testPageZeroResponseDefinesServerPageSize() async {
-        let store = TestStore(initialState: makePaginatedState()) {
+        let store = TestStore(initialState: makePaginatedArchiveListState()) {
             ArchiveListFeature()
         }
 
         await store.send(.populateArchives(makeArchives(count: 100), 250, false)) {
-            $0.archives = expectedGridStates(in: &$0, count: 100)
+            $0.archives = expectedArchiveListGridStates(in: &$0, count: 100)
             $0.archivesToDisplay = $0.archives
             $0.serverPageSize = 100
             $0.total = 250
@@ -131,7 +134,7 @@ final class ArchiveListFeatureTests: XCTestCase {
 
     @MainActor
     func testShortFinalPageDoesNotShrinkServerPageSize() async {
-        var initialState = makePaginatedState()
+        var initialState = makePaginatedArchiveListState()
         initialState.serverPageSize = 100
         initialState.total = 250
         initialState.currentPage = 2
@@ -142,7 +145,7 @@ final class ArchiveListFeatureTests: XCTestCase {
 
         // The last page returns fewer records; the discovered size must survive it.
         await store.send(.populateArchives(makeArchives(count: 50), 250, false)) {
-            $0.archives = expectedGridStates(in: &$0, count: 50)
+            $0.archives = expectedArchiveListGridStates(in: &$0, count: 50)
             $0.archivesToDisplay = $0.archives
             $0.loading = false
             $0.showLoading = false
@@ -172,7 +175,7 @@ final class ArchiveListFeatureTests: XCTestCase {
 
     @MainActor
     func testGoToPageIsIgnoredForRandomSort() async {
-        var initialState = makePaginatedState()
+        var initialState = makePaginatedArchiveListState()
         initialState.$searchSort = Shared(value: SearchSort.random.rawValue)
         initialState.serverPageSize = 100
         initialState.total = 250
@@ -187,10 +190,10 @@ final class ArchiveListFeatureTests: XCTestCase {
 
     @MainActor
     func testGoToPageRequestsMatchingServerOffset() async throws {
-        try await configureVerifiedClient()
+        try await configureArchiveListTestClient()
         stubSearchExpectingStart("200", recordsFiltered: 250)
 
-        var initialState = makePaginatedState()
+        var initialState = makePaginatedArchiveListState()
         initialState.serverPageSize = 100
         initialState.total = 250
 
@@ -216,10 +219,10 @@ final class ArchiveListFeatureTests: XCTestCase {
 
     @MainActor
     func testGoToPageClampsBeyondLastPage() async throws {
-        try await configureVerifiedClient()
+        try await configureArchiveListTestClient()
         stubSearchExpectingStart("200", recordsFiltered: 250)
 
-        var initialState = makePaginatedState()
+        var initialState = makePaginatedArchiveListState()
         initialState.serverPageSize = 100
         initialState.total = 250
 
@@ -244,13 +247,13 @@ final class ArchiveListFeatureTests: XCTestCase {
 
     @MainActor
     func testFailedPageRequestKeepsCurrentPageAndArchives() async throws {
-        try await configureVerifiedClient()
+        try await configureArchiveListTestClient()
         stubFailedSearchExpectingStart("200")
 
-        var initialState = makePaginatedState()
+        var initialState = makePaginatedArchiveListState()
         initialState.serverPageSize = 100
         initialState.total = 250
-        initialState.archives = expectedGridStates(in: &initialState, count: 1)
+        initialState.archives = expectedArchiveListGridStates(in: &initialState, count: 1)
         initialState.archivesToDisplay = initialState.archives
 
         let store = TestStore(initialState: initialState) {
@@ -294,10 +297,10 @@ final class ArchiveListFeatureTests: XCTestCase {
 
     @MainActor
     func testLoadKeepsCurrentPageInPaginationMode() async throws {
-        try await configureVerifiedClient()
+        try await configureArchiveListTestClient()
         stubSearchExpectingStart("200", recordsFiltered: 250)
 
-        var initialState = makePaginatedState()
+        var initialState = makePaginatedArchiveListState()
         initialState.serverPageSize = 100
         initialState.total = 250
         initialState.currentPage = 2
@@ -323,17 +326,17 @@ final class ArchiveListFeatureTests: XCTestCase {
 
     @MainActor
     func testReloadFromFirstPageRestartsWhileAnotherRequestIsLoading() async throws {
-        try await configureVerifiedClient()
+        try await configureArchiveListTestClient()
         stubSearchExpectingStart("0", recordsFiltered: 250)
 
-        var initialState = makePaginatedState()
+        var initialState = makePaginatedArchiveListState()
         initialState.serverPageSize = 100
         initialState.total = 250
         initialState.currentPage = 2
         initialState.pendingPage = 2
         initialState.loading = true
         initialState.showLoading = true
-        initialState.archives = expectedGridStates(in: &initialState, count: 1)
+        initialState.archives = expectedArchiveListGridStates(in: &initialState, count: 1)
         initialState.archivesToDisplay = initialState.archives
 
         let store = TestStore(initialState: initialState) {
@@ -356,10 +359,10 @@ final class ArchiveListFeatureTests: XCTestCase {
 
     @MainActor
     func testResetArchivesSendsLoadBackToFirstPage() async throws {
-        try await configureVerifiedClient()
+        try await configureArchiveListTestClient()
         stubSearchExpectingStart("0", recordsFiltered: 250)
 
-        var initialState = makePaginatedState()
+        var initialState = makePaginatedArchiveListState()
         initialState.serverPageSize = 100
         initialState.total = 250
         initialState.currentPage = 2
@@ -387,11 +390,11 @@ final class ArchiveListFeatureTests: XCTestCase {
 
     @MainActor
     func testLoadFallsBackWhenCurrentPageNoLongerExists() async throws {
-        try await configureVerifiedClient()
+        try await configureArchiveListTestClient()
         stubSearchExpectingStart("200", recordsFiltered: 150)
         stubSearchExpectingStart("100", recordsFiltered: 150)
 
-        var initialState = makePaginatedState()
+        var initialState = makePaginatedArchiveListState()
         initialState.serverPageSize = 100
         initialState.total = 250
         initialState.currentPage = 2
@@ -414,14 +417,14 @@ final class ArchiveListFeatureTests: XCTestCase {
 
     @MainActor
     func testDeletingLastPageReloadsPreviousPage() async throws {
-        try await configureVerifiedClient()
+        try await configureArchiveListTestClient()
         stubSearchExpectingStart("0", recordsFiltered: 100)
 
-        var initialState = makePaginatedState()
+        var initialState = makePaginatedArchiveListState()
         initialState.serverPageSize = 100
         initialState.total = 101
         initialState.currentPage = 1
-        initialState.archives = expectedGridStates(in: &initialState, count: 1)
+        initialState.archives = expectedArchiveListGridStates(in: &initialState, count: 1)
         initialState.archivesToDisplay = initialState.archives
 
         let store = TestStore(initialState: initialState) {
@@ -444,7 +447,7 @@ final class ArchiveListFeatureTests: XCTestCase {
 
     @MainActor
     func testPagerHiddenUntilThereIsMoreThanOnePage() {
-        var state = makePaginatedState()
+        var state = makePaginatedArchiveListState()
         state.serverPageSize = 100
 
         state.total = 80
@@ -488,10 +491,10 @@ final class ArchiveListFeatureTests: XCTestCase {
 
     @MainActor
     func testCacheArchiveFromListSavesDownloadMetadata() async throws {
-        try await configureVerifiedClient()
+        try await configureArchiveListTestClient()
 
         let archiveId = "archive-to-cache"
-        try stubArchiveExtraction(
+        try stubArchiveListExtraction(
             id: archiveId,
             pages: [
                 "./api/archives/\(archiveId)/page?path=001.jpg",
@@ -516,7 +519,7 @@ final class ArchiveListFeatureTests: XCTestCase {
         )
         initialState.archives = [GridFeature.State(archive: Shared(value: archive))]
 
-        let database = try makeInMemoryDatabase()
+        let database = try makeArchiveListTestDatabase()
         let store = TestStore(initialState: initialState) {
             ArchiveListFeature()
         } withDependencies: {
@@ -543,13 +546,13 @@ final class ArchiveListFeatureTests: XCTestCase {
 
     @MainActor
     func testGridLoadUsesArchiveThumbnailEndpointForNormalArchive() async throws {
-        try await configureVerifiedClient()
+        try await configureArchiveListTestClient()
 
         let archiveId = "0123456789012345678901234567890123456789"
         let expectedThumbnail = Data([0xFF, 0xD8, 0xFF, 0xDB])
         stubArchiveThumbnail(id: archiveId, data: expectedThumbnail)
 
-        let database = try makeInMemoryDatabase()
+        let database = try makeArchiveListTestDatabase()
         let store = makeGridTestStore(
             archive: makeArchive(id: archiveId, fileExtension: "zip"),
             database: database
@@ -566,13 +569,13 @@ final class ArchiveListFeatureTests: XCTestCase {
 
     @MainActor
     func testGridLoadUsesTankoubonThumbnailEndpointForTankArchive() async throws {
-        try await configureVerifiedClient()
+        try await configureArchiveListTestClient()
 
         let tankId = "TANK_1783084742"
         let expectedThumbnail = Data([0x89, 0x50, 0x4E, 0x47])
         stubTankoubonThumbnail(id: tankId, data: expectedThumbnail)
 
-        let database = try makeInMemoryDatabase()
+        let database = try makeArchiveListTestDatabase()
         let store = makeGridTestStore(
             archive: makeArchive(id: tankId, fileExtension: ".tank"),
             database: database
@@ -589,7 +592,7 @@ final class ArchiveListFeatureTests: XCTestCase {
 
 }
 
-private func stubBatchDelete(path: String, success: Int) {
+func stubArchiveListBatchDelete(path: String, success: Int) {
     stub(condition: isHost("localhost") && isPath(path) && isMethodDELETE()
             && hasHeaderNamed("Authorization", value: "Bearer YXBpS2V5")) { request in
         XCTAssertNil(request.url?.query)
@@ -602,7 +605,7 @@ private func stubBatchDelete(path: String, success: Int) {
     }
 }
 
-private func configureVerifiedClient() async throws {
+func configureArchiveListTestClient() async throws {
     let url = "https://localhost"
     let apiKey = "apiKey"
     UserDefaults.standard.set(url, forKey: SettingsKey.lanraragiUrl)
@@ -673,7 +676,7 @@ private func stubArchiveThumbnail(id: String, data: Data) {    stub(condition: i
     }
 }
 
-private func stubArchiveExtraction(id: String, pages: [String]) throws {
+func stubArchiveListExtraction(id: String, pages: [String]) throws {
     let data = try JSONSerialization.data(withJSONObject: ["pages": pages])
     stub(condition: isHost("localhost")
             && isPath("/api/archives/\(id)/extract")
@@ -706,7 +709,7 @@ private func makeGridTestStore(
 }
 
 @MainActor
-private func makePaginatedState() -> ArchiveListFeature.State {
+func makePaginatedArchiveListState() -> ArchiveListFeature.State {
     let state = ArchiveListFeature.State(
         filter: SearchFilter(category: nil, filter: nil),
         loadOnAppear: false,
@@ -739,7 +742,7 @@ private func makeArchives(count: Int) -> [ArchiveItem] {
 /// Rebuilds the grid states the reducer derives from the shared archive store, so tests
 /// assert against the same `Shared` references rather than detached copies.
 @MainActor
-private func expectedGridStates(
+func expectedArchiveListGridStates(
     in state: inout ArchiveListFeature.State,
     count: Int
 ) -> IdentifiedArrayOf<GridFeature.State> {
@@ -766,6 +769,6 @@ private func makeArchive(id: String, fileExtension: String) -> ArchiveItem {    
     )
 }
 
-private func makeInMemoryDatabase() throws -> AppDatabase {
+func makeArchiveListTestDatabase() throws -> AppDatabase {
     try AppDatabase(DatabaseQueue())
 }

--- a/LANreaderTests/ArchiveListSelectionTests.swift
+++ b/LANreaderTests/ArchiveListSelectionTests.swift
@@ -7,7 +7,7 @@ import UIKit
 final class ArchiveListSelectionTests: XCTestCase {
     @MainActor
     func testCategorySelectionPreservesHiddenTabBar() async throws {
-        var list = makeSelectionState(count: 0)
+        var list = makeSelectionState(count: 1)
         list.currentTab = .category
         let state = CategoryArchiveListFeature.State(id: "category", name: "Category", archiveList: list)
         let store = Store(initialState: state) {
@@ -26,7 +26,7 @@ final class ArchiveListSelectionTests: XCTestCase {
             $0.appDatabase = database
         } operation: {
             var state = SearchFeature.State()
-            state.archiveList = makeSelectionState(count: 0)
+            state.archiveList = makeSelectionState(count: 1)
             state.archiveList.currentTab = .search
             let store = Store(initialState: state) {
                 SearchFeature().dependency(\.appDatabase, database)
@@ -141,7 +141,7 @@ final class ArchiveListSelectionTests: XCTestCase {
     }
 
     @MainActor
-    func testBatchDownloadDispatchesOnlySelectedArchivesAndKeepsSelectionMode() async throws {
+    func testBatchDownloadSkipsAlreadyCachedArchivesAndKeepsSelectionMode() async throws {
         let database = try AppDatabase(DatabaseQueue())
         let state = makeSelectionState(count: 3)
         // Existing cache entries exercise the shared duplicate-download guard.
@@ -165,7 +165,7 @@ final class ArchiveListSelectionTests: XCTestCase {
     }
 
     @MainActor
-    func testBatchCachingShowsOneSuccessAfterAllResults() async {
+    func testBatchCachingReportsMixedResultsAfterAllResults() async {
         var state = ArchiveListFeature.State(
             filter: SearchFilter(category: nil, filter: nil), currentTab: .library
         )
@@ -185,7 +185,6 @@ final class ArchiveListSelectionTests: XCTestCase {
             $0.cachingArchiveIds = []
             $0.batchCachingArchiveIds = []
             $0.batchCacheHadSuccess = false
-            $0.successMessage = String(localized: "archive.cache.added")
             $0.errorMessage = "Failed"
         }
     }
@@ -238,6 +237,9 @@ private func checkSharedSelection(
     controller: UIViewController, store: StoreOf<ArchiveListFeature>, pushed: Bool
 ) async throws {
     let database = try AppDatabase(DatabaseQueue())
+    let thumbnailData = UIGraphicsImageRenderer(size: CGSize(width: 1, height: 1)).pngData { _ in }
+    var thumbnail = ArchiveThumbnail(id: "archive-0", thumbnail: thumbnailData, lastUpdate: Date())
+    try database.saveArchiveThumbnail(&thumbnail)
     try await withDependencies {
         $0.appDatabase = database
     } operation: {
@@ -263,12 +265,14 @@ private func checkSharedSelection(
             list.view.layoutIfNeeded()
             XCTAssertTrue(tabs.isTabBarHidden)
         }
-        XCTAssertTrue(store.selected.isEmpty)
+        list.collectionView(list.collectionView, didSelectItemAt: IndexPath(item: 0, section: 0))
+        await Task.yield()
+        XCTAssertEqual(store.selected, ["archive-0"])
         XCTAssertEqual(controller.toolbarItems?.count, 4)
         XCTAssertEqual(controller.toolbarItems?.last?.accessibilityLabel, String(localized: "archive.delete"))
         XCTAssertEqual(controller.toolbarItems?[2].accessibilityLabel, String(localized: "archive.cache.add"))
-        XCTAssertEqual(controller.toolbarItems?.last?.isEnabled, false)
-        XCTAssertEqual(controller.toolbarItems?[2].isEnabled, false)
+        XCTAssertEqual(controller.toolbarItems?.last?.isEnabled, true)
+        XCTAssertEqual(controller.toolbarItems?[2].isEnabled, true)
         store.send(.toggleSelectionMode)
         await Task.yield()
         XCTAssertTrue(navigation.isToolbarHidden)


### PR DESCRIPTION
## Change

Fix shared batch selection and failure handling: retain failed items through pagination refresh, allow Done during ordinary loading but not deletion, and report batch cache-start failures once. Remove duplicate toolbar updates and unused selection forwarding actions. Keep the existing shared reducer and UIKit grid.

Set LANreader and Action to marketing version 3.11.0 and build 239 (from 238).

## Risk surface

- [x] Reader, navigation, image rendering, cache, or Tankoubon behavior
- [ ] LANraragi request or response contract
- [ ] Persistence, migration, or offline behavior
- [ ] Localized user interface
- [x] Xcode project, dependency, CI, or release automation
- [ ] None of the above

## Evidence

Commands run and outcomes:
- `./scripts/verify`: passed, 268 tests with zero failures, including repository checks and lint.
- `git diff --check`: passed.
- `xcodebuild -project LANreader.xcodeproj -alltargets -configuration Debug -showBuildSettings -json` and the equivalent Release command: LANreader and Action both resolve to 3.11.0 (239).

Behavior evidence (focused test names, screenshots, or manual scenario):
- `testPartialBatchDeletionPreservesFailedSelectionAfterPageReload` exercises deletion and the following search reload through HTTP stubs.
- `testBatchDownloadExtractsOnlySelectedUncachedArchives` exercises cache initiation and verifies saved metadata for only the selected archives.
- `testDoneCanExitSelectionWhileLoading`, `testDoneCannotExitDuringDestructiveBatch`, and batch feedback tests cover the loading and completion states.
- Category and Search selection tests now use populated UIKit grids. Pass the injected database into hosted cells so those tests use their in-memory database.

Checks not run or known gaps:
- Physical-device swipe-back has not been manually verified. Cache tests verify initiation and metadata, not completion of background image downloads. Remote CI is pending publication.

## Durable learning (only when applicable)

Regression test, automated guard, or concise `AGENTS.md` update:
- Added focused batch regression tests and strengthened existing UIKit integration tests; no additional agent rules needed.
